### PR TITLE
simply example with vfmul.vv instead of vfmacc.vv

### DIFF
--- a/examples/rvv_matmul.c
+++ b/examples/rvv_matmul.c
@@ -27,7 +27,7 @@ void matmul(double **a, double **b, double **c, int n, int m, int o) {
         vfloat64m1_t vec_a = vle64_v_f64m1(ptr_a, vl);
         vfloat64m1_t vec_b = vle64_v_f64m1(ptr_b, vl);
 
-        vec_s = vfmacc_vv_f64m1(vec_s, vec_a, vec_b, vl);
+        vec_s = vfmul_vv_f64m1(vec_s, vec_a, vec_b, vl);
       }
 
       vfloat64m1_t vec_sum;


### PR DESCRIPTION
From the mean of the example, I think the no need to use `vfmacc`(https://github.com/riscv-non-isa/rvv-intrinsic-doc/blob/master/examples/rvv_matmul.c#L30). Because the below call `vfredsum_vs_f64m1_f64m1` will sum the multiple results.