### PR TITLE
fix the order of mask and maskedoff from the tail-policy table

### DIFF
--- a/rvv-intrinsic-rfc.md
+++ b/rvv-intrinsic-rfc.md
@@ -376,9 +376,9 @@ For intrinsics with `maskedoff` and `ta` argument:
 | ------- | -------------------- | ------------------------- | ------------------------------------------------------------------------
 | No      | No                   | N/A                       | `vadd_vv_<ty>(vs2, vs1, vl)`
 | No      | Yes                  | N/A                       | `vadd_vv_<ty>_tu(dest, vs2, vs1, vl)`
-| Yes     | No                   | No                        | `vadd_vv_<ty>_mt(vundefined(), mask, vs2, vs1, vl, VE_TAIL_AGNOSTIC)`
-| Yes     | No                   | Yes                       | `vadd_vv_<ty>_mt(maskedoff, mask, vs2, vs1, vl, VE_TAIL_AGNOSTIC)`
-| Yes     | Yes                  | Yes                       | `vadd_vv_<ty>_mt(maskedoff, mask, vs2, vs1, vl, VE_TAIL_UNDISTURBED)`
+| Yes     | No                   | No                        | `vadd_vv_<ty>_mt(mask, vundefined(), vs2, vs1, vl, VE_TAIL_AGNOSTIC)`
+| Yes     | No                   | Yes                       | `vadd_vv_<ty>_mt(mask, maskedoff, vs2, vs1, vl, VE_TAIL_AGNOSTIC)`
+| Yes     | Yes                  | Yes                       | `vadd_vv_<ty>_mt(mask, maskedoff, vs2, vs1, vl, VE_TAIL_UNDISTURBED)`
 | Yes     | Yes                  | No                        | No support. Tail undisturbed and maskedoff agnostic is likely rare.
 
 For intrinsics without mask and with an additional `dest` argument:


### PR DESCRIPTION
The order of mask and maskedoff args in [the tail-policy table](https://github.com/riscv-non-isa/rvv-intrinsic-doc/blob/master/rvv-intrinsic-rfc.md#tail-policy-in-the-intrinsics) is different from the prototype of the intrinsic function. So need be consistent.

old:
```
vadd_vv_<ty>_mt(maskedoff, mask, vs2, vs1, vl, VE_TAIL_AGNOSTIC)
```

change to:
```
vadd_vv_<ty>_mt(mask, maskedoff, vs2, vs1, vl, VE_TAIL_AGNOSTIC)
```


