### PR TITLE
add `_m` intrinsic to the tail policy table for completeness

### DIFF
--- a/rvv-intrinsic-rfc.md
+++ b/rvv-intrinsic-rfc.md
@@ -377,7 +377,7 @@ For intrinsics with `maskedoff` and `ta` argument:
 | No      | No                   | N/A                       | `vadd_vv_<ty>(vs2, vs1, vl)`
 | No      | Yes                  | N/A                       | `vadd_vv_<ty>_tu(dest, vs2, vs1, vl)`
 | Yes     | No                   | No                        | `vadd_vv_<ty>_mt(mask, vundefined(), vs2, vs1, vl, VE_TAIL_AGNOSTIC)`
-| Yes     | No                   | Yes                       | `vadd_vv_<ty>_mt(mask, maskedoff, vs2, vs1, vl, VE_TAIL_AGNOSTIC)`
+| Yes     | No                   | Yes                       | `vadd_vv_<ty>_mt(mask, maskedoff, vs2, vs1, vl, VE_TAIL_AGNOSTIC)`<br>`vadd_vv_<ty>_m(mask, maskedoff, vs2, vs1, vl)`
 | Yes     | Yes                  | Yes                       | `vadd_vv_<ty>_mt(mask, maskedoff, vs2, vs1, vl, VE_TAIL_UNDISTURBED)`
 | Yes     | Yes                  | No                        | No support. Tail undisturbed and maskedoff agnostic is likely rare.
 
@@ -393,7 +393,7 @@ For multiply-add intrinsics:
 | No      | No                   | N/A                       | `vmacc_vv_<ty>(vd, vs1, vs2, vl)`
 | No      | Yes                  | N/A                       | `vmacc_vv_<ty>_tu(vd, vs1, vs2, vl)`
 | Yes     | No                   | No                        | No support.
-| Yes     | No                   | Yes                       | `vmacc_vv_<ty>_mt(mask, vd, vs1, vs2, vl, VE_TAIL_AGNOSTIC)`
+| Yes     | No                   | Yes                       | `vmacc_vv_<ty>_mt(mask, vd, vs1, vs2, vl, VE_TAIL_AGNOSTIC)`<br>`vmacc_vv_<ty>_m(mask, vd, vs1, vs2, vl)`
 | Yes     | Yes                  | Yes                       | `vmacc_vv_<ty>_mt(mask, vd, vs1, vs2, vl, VE_TAIL_UNDISTURBED)`
 | Yes     | Yes                  | No                        | No support. Tail undisturbed and maskedoff agnostic is likely rare.
 


### PR DESCRIPTION
Hi all,

I think the tail policy table misses the `_m` intrinsic, and from the [Mask in Intrinsics](https://github.com/riscv-non-isa/rvv-intrinsic-doc/blob/master/rvv-intrinsic-rfc.md#mask-in-intrinsics) before, the tail policy should be `ta`. So it equal to the `vadd_vv_<ty>_mt(mask, maskedoff, vs2, vs1, vl, VE_TAIL_AGNOSTIC)` and `vmacc_vv_<ty>_mt(mask, vd, vs1, vs2, vl, VE_TAIL_AGNOSTIC)`. Is my thinking correct?

Best regards,
Tin