### PR TITLE
Add macro to imply compiler availability on intrinsic versions

### DIFF
--- a/version_macro.adoc
+++ b/version_macro.adoc
@@ -1,0 +1,17 @@
+= Version Macro
+
+The `__riscv_v_intrinsic` macro is the test macro to checking the availability and version the compiler supports for the RISC-V V C intrinsic API.
+
+The value of architecture extension test macro are defined as its version, which is compute by the following formula:
+
+```
+<MAJOR_VERSION> * 1,000,000 + <MINOR_VERSION> * 1,000 + <REVISION_VERSION>
+```
+
+For example, the v0.10 version should define the macro with value `10000`.
+
+[cols="1,1,1"]
+|===
+|Name |Value | When defined 
+|`__riscv_v_intrinsic` | Intrinsic Version | Defined when the version is available in the compiler
+|=== 


### PR DESCRIPTION
The approach to API change will involve multiple releases, so we need a macro to imply the version supported in the compiler.

The value calculation of version number is the same as [riscv-non-isa/riscv-c-api-doc](https://github.com/riscv-non-isa/riscv-c-api-doc).

Adding the document as ASCIIDoc format since we will soon re-format other markdowns to ASCIIDoc as well. The document will be restructured and not be a single document like this PR is proposing right now.