### PR TITLE
Expose vlenb to user

### DIFF
--- a/rvv-intrinsic-api.md
+++ b/rvv-intrinsic-api.md
@@ -70,6 +70,8 @@ enum RVV_CSR {
 
 unsigned long vread_csr(enum RVV_CSR csr);
 void vwrite_csr(enum RVV_CSR csr, unsigned long value);
+
+unsigned long vlenb();
 ```
 
 ## 7. Vector Loads and Stores


### PR DESCRIPTION
This resolves riscv-non-isa/rvv-intrinsic-doc#180.

Corresponding LLVM change is [D141032 [Clang][RISCV] Expose vlenb to user](https://reviews.llvm.org/D141032).