### PR TITLE
rvv examples improvement

### DIFF
--- a/examples/rvv_reduce.c
+++ b/examples/rvv_reduce.c
@@ -24,7 +24,6 @@ void reduce(double *a, double *b, double *result_sum, int *result_count,
   size_t vlmax = vsetvlmax_e64m1();
   vfloat64m1_t vec_zero = vfmv_v_f_f64m1(0, vlmax);
   vfloat64m1_t vec_s = vfmv_v_f_f64m1(0, vlmax);
-  vfloat64m1_t vec_one = vfmv_v_f_f64m1(1, vlmax);
   for (size_t vl; n > 0; n -= vl, a += vl, b += vl) {
     vl = vsetvl_e64m1(n);
 

--- a/examples/rvv_strcpy.c
+++ b/examples/rvv_strcpy.c
@@ -26,7 +26,7 @@ char *strcpy_vec(char *dst, const char *src) {
 }
 
 int main() {
-  const int N = 100;
+  const int N = 2000;
   const uint32_t seed = 0xdeadbeef;
   srand(seed);
 


### PR DESCRIPTION
- examples/rvv_strcpy: increase copy length
    According to sections 15.4 and 15.5 of the riscv-v-spec-1.0, vmsbf and
    vmsif will set 1 to all the active mask elements whose indexes are smaller
    (or <= for vmsif) than the first active source element that is a 1, a
    special case of these instructions is when the source operand is all-0s,
    then the destination register would be set to all-1s.

    This special case is important for long string copy where the terminator 0
    won't be detected in the first iteration, so this patch increases the
    string length from 100B to 2000B to cover the case. 2000B should be big
    enough to cover the mainstream VLEN implementations with LMUL set to 8.

- examples/rvv_reduce: remove unused variable