### PR TITLE
Add --skip-default-inst option to skip rendering of the RVV instructions

### DIFF
--- a/rvv-intrinsic-generator/Makefile
+++ b/rvv-intrinsic-generator/Makefile
@@ -66,6 +66,12 @@ TRIGGER_VENDOR_INST := --vendor-inst $(VENDOR_INST)
 else
 TRIGGER_VENDOR_INST :=
 endif
+# Derived variable to trigger option --skip-default-inst
+ifeq ($(SKIP_DEFAULT_INST), ON)
+TRIGGER_SKIP_DEFAULT_INST := --skip-default-inst
+else
+TRIGGER_SKIP_DEFAULT_INST :=
+endif
 
 ###############################################################################
 # Functions
@@ -79,7 +85,9 @@ endif
 define gen_doc
 	mkdir -p $(1)
 	rm -rf $(1)/$(2)
-	$(PY3) -m $(MAIN) --gen $(3) --out $(1)/$(2) $(4) $(TRIGGER_VENDOR_INST)
+	$(PY3) -m $(MAIN) --gen $(3) \
+		--out $(1)/$(2) $(4) \
+		$(TRIGGER_VENDOR_INST) $(TRIGGER_SKIP_DEFAULT_INST)
 endef
 
 # Generate grouped files under $(1). Each file contains a group of RVV
@@ -92,12 +100,16 @@ define gen_docs
 	mkdir -p $(1)
 	rm $(1)/$(2) -rf
 	mkdir -p $(1)/$(2)
-	$(PY3) -m $(MAIN) --gen $(3) --out $(1)/$(2) $(4) $(TRIGGER_VENDOR_INST)
+	$(PY3) -m $(MAIN) --gen $(3) \
+		--out $(1)/$(2) $(4) \
+		$(TRIGGER_VENDOR_INST) $(TRIGGER_SKIP_DEFAULT_INST)
 endef
 
 define gen_tests
 	rm $(1)/*.c -f
-	$(PY3) -m $(MAIN) --gen $(2) --out $(1) $(3) $(TRIGGER_VENDOR_INST)
+	$(PY3) -m $(MAIN) --gen $(2) \
+		--out $(1) $(3) \
+		$(TRIGGER_VENDOR_INST) $(TRIGGER_SKIP_DEFAULT_INST)
 endef
 
 # Compile all *.c under $(1) with $(2), then pretty-print with testing-report
@@ -282,7 +294,7 @@ run-test:
 VENDOR_GENERATOR_OUTPUT ?=
 vendor-generator:
 	$(PY3) -m $(MAIN) --out $(DIR)/$(VENDOR_GENERATOR_OUTPUT) \
-	$(TRIGGER_VENDOR_INST) \
+	$(TRIGGER_VENDOR_INST) $(TRIGGER_SKIP_DEFAULT_INST) \
 	--vendor-generator-script $(VENDOR_GENERATOR_SCRIPT) \
 	--vendor-generator-name $(VENDOR_GENERATOR_NAME)
 

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/main.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/main.py
@@ -98,6 +98,7 @@ def main():
   parser.add_argument("--llvm", default=False, action="store_true")
   parser.add_argument("--has-policy", default=False, action="store_true")
   parser.add_argument("--vendor-inst")
+  parser.add_argument("--skip-default-inst", default=False, action="store_true")
   parser.add_argument("--vendor-generator-script")
   parser.add_argument("--vendor-generator-name")
   parser.add_argument("--out")
@@ -117,7 +118,10 @@ def main():
     print(f"Triggering the generator {args.vendor_generator_name}")
     with open(args.out, "w", encoding="utf-8") as f:
       g = vendor_generator(f, args.has_policy)
-      inst.gen(g)
+      if not args.skip_default_inst:
+        inst.gen(g)
+      else:
+        print("Skipping default RVV instructions (--skip-default-inst)")
       if vendor_gen is not None:
         vendor_gen(g)
       g.report_summary()
@@ -139,7 +143,10 @@ def main():
       else:
         assert False
 
-      inst.gen(g)
+      if not args.skip_default_inst:
+        inst.gen(g)
+      else:
+        print("Skipping default RVV instructions (--skip-default-inst)")
       if vendor_gen is not None:
         vendor_gen(g)
       g.report_summary()
@@ -155,8 +162,10 @@ def main():
     g = generator.APITestGenerator(args.out, True, args.llvm, args.has_policy)
   else:
     assert False
-
-  inst.gen(g)
+  if not args.skip_default_inst:
+    inst.gen(g)
+  else:
+    print("Skipping default RVV instructions (--skip-default-inst)")
   if vendor_gen is not None:
     vendor_gen(g)
   g.report_summary()


### PR DESCRIPTION
This is a part of the feature to allow other vendors to hook their own instructions (or generator) to this framework. A full example of the usage will be added in the future.