### PR TITLE
Remove the `vread_csr` / `vwrite_csr` intrinsics

### DIFF
--- a/rvv-intrinsic-api.md
+++ b/rvv-intrinsic-api.md
@@ -61,16 +61,6 @@ These utility functions help users extract a smaller LMUL value from a larger LM
 ### Read/Write URW vector CSRs
 
 ```
-enum RVV_CSR {
-  RVV_VSTART = 0,
-  RVV_VXSAT,
-  RVV_VXRM,
-  RVV_VCSR,
-};
-
-unsigned long __riscv_vread_csr(enum RVV_CSR csr);
-void __riscv_vwrite_csr(enum RVV_CSR csr, unsigned long value);
-
 unsigned long __riscv_vlenb();
 ```
 

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -111,7 +111,7 @@ class Generator():
         return False
     unsupported_op = [
         "setvl", "vundefined", "viota", "vmclr", "vmset_", "vid", "vmv_v_x",
-        "vfmv_v_f", "vread_csr", "vwrite_csr", "vcreate", "vlm_v"
+        "vfmv_v_f", "vcreate", "vlm_v"
     ]
     if any(i in name for i in unsupported_op):
       if ("vid" in name) or ("viota" in name):
@@ -138,7 +138,7 @@ class Generator():
         overloaded_name = "_".join(sn[0:3])
       else:
         overloaded_name = "_".join(sn[0:-1])
-    elif name in ["vread_csr", "vwrite_csr", "vlmul_trunc", "vlmul_ext"]:
+    elif name in ["vlmul_trunc", "vlmul_ext"]:
       overloaded_name = name
     elif name.find("cvt") != -1:
       if name.find("cvt_rod") != -1 or name.find("cvt_rtz") != -1:


### PR DESCRIPTION
These interfaces expose control to VSTART, VXSAT, VXRM, and VCSR. 

- The intrinsics should not expose control to VSTART as the intrinsic executions assume it to be set to 0.
- Rounding mode (`vxrm`) control is now modeled in the floating-point intrinsics.
- We are planning to add exception handling intrinsics variants in the future, that allows users to accss VXSAT for their fixed-point instruction executions.

Concluding these facts above, `vread_csr` and `vwrite_csr` is no longer needed.

---

Although we don't have the exception handling intrinsics for now, but for us to stay consistent that there won't be any backward incompatibility after v1.0, we should remove the interfaces now.

This resolves #246.

LLVM implementation is at https://reviews.llvm.org/D156321.