### PR TITLE
Fix and cleanup examples

### DIFF
--- a/examples/rvv_branch.c
+++ b/examples/rvv_branch.c
@@ -8,10 +8,9 @@ void branch_golden(double *a, double *b, double *c, int n, double constant) {
   }
 }
 
-void branch(double *a, double *b, double *c, int n, double constant) {
+void branch_vec(double *a, double *b, double *c, int n, double constant) {
   // set vlmax and initialize variables
   size_t vlmax = __riscv_vsetvlmax_e64m1();
-  vfloat64m1_t vec_zero = __riscv_vfmv_v_f_f64m1(0, vlmax);
   vfloat64m1_t vec_constant = __riscv_vfmv_v_f_f64m1(constant, vlmax);
   for (size_t vl; n > 0; n -= vl, a += vl, b += vl, c += vl) {
     vl = __riscv_vsetvl_e64m1(n);
@@ -19,7 +18,7 @@ void branch(double *a, double *b, double *c, int n, double constant) {
     vfloat64m1_t vec_a = __riscv_vle64_v_f64m1(a, vl);
     vfloat64m1_t vec_b = __riscv_vle64_v_f64m1(b, vl);
 
-    vbool64_t mask = __riscv_vmfne_vv_f64m1_b64(vec_b, vec_zero, vl);
+    vbool64_t mask = __riscv_vmfne_vf_f64m1_b64(vec_b, 0, vl);
 
     vfloat64m1_t vec_c = __riscv_vfdiv_vv_f64m1_mu(mask, /*maskedoff*/ vec_constant, vec_a, vec_b, vl);
     __riscv_vse64_v_f64m1(c, vec_c, vl);
@@ -44,7 +43,7 @@ int main() {
   // compute
   double golden[N], actual[N];
   branch_golden(A, B, golden, N, constant);
-  branch(A, B, actual, N, constant);
+  branch_vec(A, B, actual, N, constant);
 
   // compare
   puts(compare_1d(golden, actual, N) ? "pass" : "fail");

--- a/examples/rvv_index.c
+++ b/examples/rvv_index.c
@@ -8,7 +8,7 @@ void index_golden(double *a, double *b, double *c, int n) {
   }
 }
 
-void index_(double *a, double *b, double *c, int n) {
+void index_vec(double *a, double *b, double *c, int n) {
   size_t vlmax = __riscv_vsetvlmax_e32m1();
   vuint32m1_t vec_i = __riscv_vid_v_u32m1(vlmax);
   for (size_t vl; n > 0; n -= vl, a += vl, b += vl, c += vl) {
@@ -19,8 +19,7 @@ void index_(double *a, double *b, double *c, int n) {
     vfloat64m2_t vec_b = __riscv_vle64_v_f64m2(b, vl);
     vfloat64m2_t vec_c = __riscv_vle64_v_f64m2(c, vl);
 
-    vfloat64m2_t vec_a =
-        __riscv_vfadd_vv_f64m2(vec_b, __riscv_vfmul_vv_f64m2(vec_c, vec_i_double, vl), vl);
+    vfloat64m2_t vec_a = __riscv_vfmadd_vv_f64m2(vec_c, vec_i_double, vec_b, vl);
     __riscv_vse64_v_f64m2(a, vec_a, vl);
 
     vec_i = __riscv_vadd_vx_u32m1(vec_i, vl, vl);
@@ -40,7 +39,7 @@ int main() {
   // compute
   double golden[N], actual[N];
   index_golden(golden, B, C, N);
-  index_(actual, B, C, N);
+  index_vec(actual, B, C, N);
 
   // compare
   puts(compare_1d(golden, actual, N) ? "pass" : "fail");

--- a/examples/rvv_memcpy.c
+++ b/examples/rvv_memcpy.c
@@ -2,15 +2,17 @@
 #include <riscv_vector.h>
 #include <string.h>
 
-void *memcpy_vec(void *dst, void *src, size_t n) {
-  void *save = dst;
+void *memcpy_vec(void *restrict destination, const void *restrict source,
+                 size_t n) {
+  unsigned char *dst = destination;
+  const unsigned char *src = source;
   // copy data byte by byte
   for (size_t vl; n > 0; n -= vl, src += vl, dst += vl) {
     vl = __riscv_vsetvl_e8m8(n);
     vuint8m8_t vec_src = __riscv_vle8_v_u8m8(src, vl);
     __riscv_vse8_v_u8m8(dst, vec_src, vl);
   }
-  return save;
+  return destination;
 }
 
 int main() {

--- a/examples/rvv_saxpy.c
+++ b/examples/rvv_saxpy.c
@@ -51,18 +51,11 @@ void saxpy_golden(size_t n, const float a, const float *x, float *y) {
 
 // reference https://github.com/riscv/riscv-v-spec/blob/master/example/saxpy.s
 void saxpy_vec(size_t n, const float a, const float *x, float *y) {
-  size_t l;
-
-  vfloat32m8_t vx, vy;
-
-  for (; n > 0; n -= l) {
-    l = __riscv_vsetvl_e32m8(n);
-    vx = __riscv_vle32_v_f32m8(x, l);
-    x += l;
-    vy = __riscv_vle32_v_f32m8(y, l);
-    vy = __riscv_vfmacc_vf_f32m8(vy, a, vx, l);
-    __riscv_vse32_v_f32m8 (y, vy, l);
-    y += l;
+  for (size_t vl; n > 0; n -= vl, x += vl, y += vl) {
+    vl = __riscv_vsetvl_e32m8(n);
+    vfloat32m8_t vx = __riscv_vle32_v_f32m8(x, vl);
+    vfloat32m8_t vy = __riscv_vle32_v_f32m8(y, vl);
+    __riscv_vse32_v_f32m8(y, __riscv_vfmacc_vf_f32m8(vy, a, vx, vl), vl);
   }
 }
 

--- a/examples/rvv_saxpy.c
+++ b/examples/rvv_saxpy.c
@@ -73,11 +73,11 @@ int main() {
   int pass = 1;
   for (int i = 0; i < N; i++) {
     if (!fp_eq(output_golden[i], output[i], 1e-6)) {
-      printf("failed, %f=!%f\n", output_golden[i], output[i]);
+      printf("fail, %f=!%f\n", output_golden[i], output[i]);
       pass = 0;
     }
   }
   if (pass)
-    printf("passed\n");
+    printf("pass\n");
   return (pass == 0);
 }

--- a/examples/rvv_sgemm.c
+++ b/examples/rvv_sgemm.c
@@ -109,11 +109,11 @@ int main() {
   int pass = 1;
   for (int i = 0; i < OUTPUT_LEN; i++) {
     if (!fp_eq(golden_array[i], c_array[i], 1e-5)) {
-      printf("index %d failed, %f=!%f\n", i, golden_array[i], c_array[i]);
+      printf("index %d fail, %f=!%f\n", i, golden_array[i], c_array[i]);
       pass = 0;
     }
   }
   if (pass)
-    printf("passed\n");
+    printf("pass\n");
   return (pass == 0);
 }

--- a/examples/rvv_strcmp.c
+++ b/examples/rvv_strcmp.c
@@ -3,21 +3,20 @@
 #include <string.h>
 
 // reference https://github.com/riscv/riscv-v-spec/blob/master/example/strcmp.s
-int strcmp_vec(const char *src1, const char *src2) {
+int strcmp_vec(const char *source1, const char *source2) {
+  const unsigned char *src1 = (const void*)source1, *src2 = (const void*)source2;
   size_t vlmax = __riscv_vsetvlmax_e8m2();
   long first_set_bit = -1;
-  size_t vl, vl1;
-  while (first_set_bit < 0) {
-    vint8m2_t vec_src1 = __riscv_vle8ff_v_i8m2(src1, &vl, vlmax);
-    vint8m2_t vec_src2 = __riscv_vle8ff_v_i8m2(src2, &vl1, vlmax);
+  size_t vl;
+  for (; first_set_bit < 0; src1 += vl, src2 += vl) {
+    vuint8m2_t vec_src1 = __riscv_vle8ff_v_u8m2(src1, &vl, vlmax);
+    vuint8m2_t vec_src2 = __riscv_vle8ff_v_u8m2(src2, &vl, vl);
 
-    vbool4_t string_terminate = __riscv_vmseq_vx_i8m2_b4(vec_src1, 0, vl);
-    vbool4_t no_equal = __riscv_vmsne_vv_i8m2_b4(vec_src1, vec_src2, vl);
+    vbool4_t string_terminate = __riscv_vmseq_vx_u8m2_b4(vec_src1, 0, vl);
+    vbool4_t no_equal = __riscv_vmsne_vv_u8m2_b4(vec_src1, vec_src2, vl);
     vbool4_t vec_terminate = __riscv_vmor_mm_b4(string_terminate, no_equal, vl);
 
     first_set_bit = __riscv_vfirst_m_b4(vec_terminate, vl);
-    src1 += vl;
-    src2 += vl;
   }
   src1 -= vl - first_set_bit;
   src2 -= vl - first_set_bit;

--- a/examples/rvv_strcpy.c
+++ b/examples/rvv_strcpy.c
@@ -4,25 +4,21 @@
 #include <string.h>
 
 // reference https://github.com/riscv/riscv-v-spec/blob/master/example/strcpy.s
-char *strcpy_vec(char *dst, const char *src) {
-  char *save = dst;
+char *strcpy_vec(char *destination, const char *source) {
+  unsigned char *dst = (unsigned char*)destination;
+  unsigned char *src = (unsigned char*)source;
   size_t vlmax = __riscv_vsetvlmax_e8m8();
   long first_set_bit = -1;
-  size_t vl;
-  while (first_set_bit < 0) {
-    vint8m8_t vec_src = __riscv_vle8ff_v_i8m8(src, &vl, vlmax);
+  for (size_t vl; first_set_bit < 0; src += vl, dst += vl) {
+    vuint8m8_t vec_src = __riscv_vle8ff_v_u8m8(src, &vl, vlmax);
 
-    vbool1_t string_terminate = __riscv_vmseq_vx_i8m8_b1(vec_src, 0, vl);
+    vbool1_t string_terminate = __riscv_vmseq_vx_u8m8_b1(vec_src, 0, vl);
     vbool1_t mask = __riscv_vmsif_m_b1(string_terminate, vl);
 
-    __riscv_vse8_v_i8m8_m(mask, dst, vec_src, vl);
-
-    src += vl;
-    dst += vl;
-
+    __riscv_vse8_v_u8m8_m(mask, dst, vec_src, vl);
     first_set_bit = __riscv_vfirst_m_b1(string_terminate, vl);
   }
-  return save;
+  return destination;
 }
 
 int main() {

--- a/examples/rvv_strlen.c
+++ b/examples/rvv_strlen.c
@@ -3,22 +3,18 @@
 #include <string.h>
 
 // reference https://github.com/riscv/riscv-v-spec/blob/master/example/strlen.s
-size_t strlen_vec(char *src) {
+size_t strlen_vec(char *source) {
   size_t vlmax = __riscv_vsetvlmax_e8m8();
-  char *copy_src = src;
+  unsigned char *src = (unsigned char*)source;
   long first_set_bit = -1;
   size_t vl;
-  while (first_set_bit < 0) {
-    vint8m8_t vec_src = __riscv_vle8ff_v_i8m8(copy_src, &vl, vlmax);
-    vbool1_t string_terminate = __riscv_vmseq_vx_i8m8_b1(vec_src, 0, vl);
-
-    copy_src += vl;
-
+  for (; first_set_bit < 0; src += vl) {
+    vuint8m8_t vec_src = __riscv_vle8ff_v_u8m8(src, &vl, vlmax);
+    vbool1_t string_terminate = __riscv_vmseq_vx_u8m8_b1(vec_src, 0, vl);
     first_set_bit = __riscv_vfirst_m_b1(string_terminate, vl);
   }
-  copy_src -= vl - first_set_bit;
-
-  return (size_t)(copy_src - src);
+  src -= vl - first_set_bit;
+  return (size_t)((char*)src - source);
 }
 
 int main() {


### PR DESCRIPTION
This resolves https://github.com/riscv-non-isa/rvv-intrinsic-doc/issues/252, https://github.com/riscv-non-isa/rvv-intrinsic-doc/issues/244,  unsigned char instead of char, and cleans up the code a bit.

The problem with using `char` in combination with `vint8mX_t` is that `char` can be either signed or unsigned, so to remedy this problem, I've changed the examples to use `unsigned char` explicitly (and `vuint8m8_t`).

[rvv_reduce.c](https://github.com/riscv-non-isa/rvv-intrinsic-doc/commit/ac6d76f822764cef333ed5dd7c4e8d6798e7cb80) had an error, where a agnostic tail policy could make it produce the wrong results, this has been fixed by using the `_tu` intrinsic variant.

