### PR TITLE
Add workflow to test latest LLVM toolchain compilation for the intrinsics

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build the RVV C intrinsics specification
 
 on:
   push:

--- a/.github/workflows/clang-compilation.yml
+++ b/.github/workflows/clang-compilation.yml
@@ -1,0 +1,49 @@
+name: Clang (LLVM) intrinsic test case compilation
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prerequisites
+        run: |
+          sudo apt-get install autoconf automake autotools-dev curl python3 python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev dejagnu
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install junitparser
+      - name: Download LLVM
+        run: |
+          cd ..
+          rm -rf llvm-project
+          git clone https://github.com/llvm/llvm-project
+      - name: Build LLVM with Ninja
+        run: |
+          cd ../llvm-project
+          mkdir build && cd build
+          cmake -G Ninja \
+            -DCMAKE_C_COMPILER=gcc \
+            -DCMAKE_CXX_COMPILER=g++ \
+            -DLLVM_TARGETS_TO_BUILD="RISCV" \
+            -DLLVM_PARALLEL_LINK_JOBS=12 \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DLLVM_DEFAULT_TARGET_TRIPLE="riscv64-unknown-linux-gnu" \
+            -DLLVM_ENABLE_PROJECTS="clang;lld" \
+            ../llvm
+          ninja -j 4
+          echo $(pwd)
+          ls bin
+      - name: Run compilation test, non-overloaded intrinsics (default (TAMA) policy)
+        run: |
+          make -C rvv-intrinsic-generator run-api-testing COMPILER=$(pwd)/../llvm-project/build/bin/clang EXTRA_CFLAGS="-target riscv64"
+      - name: Run compilation test, overloaded intrinsics (default (TAMA) policy)
+        run: |
+          make -C rvv-intrinsic-generator run-overloaded-api-testing COMPILER=$(pwd)/../llvm-project/build/bin/clang EXTRA_CFLAGS="-target riscv64"
+      - name: Run compilation test, non-overloaded intrinsics (non-default policy)
+        run: |
+          make -C rvv-intrinsic-generator run-policy-api-testing COMPILER=$(pwd)/../llvm-project/build/bin/clang EXTRA_CFLAGS="-target riscv64"
+      - name: Run compilation test, overloaded intrinsics (non-default policy)
+        run: |
+          make -C rvv-intrinsic-generator run-policy-overloaded-api-testing COMPILER=$(pwd)/../llvm-project/build/bin/clang EXTRA_CFLAGS="-target riscv64"

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -1,4 +1,4 @@
-name: rvv-intrinsic
+name: rvv-intrinsic-generator
 
 on: [push]
 

--- a/rvv-intrinsic-generator/Makefile.api
+++ b/rvv-intrinsic-generator/Makefile.api
@@ -15,7 +15,8 @@
 ###############################################################################
 
 CFLAGS?=-O -Werror=implicit-function-declaration
-EXTRA_CFLAGS?=-march=rv64gcv_zfh_zvfh0p1 -menable-experimental-extensions
+ARCH_FLAG?=-march=rv64gcv_zfh_zvfh
+EXTRA_CFLAGS?=
 
 TEST_MULTILIB:=rv32gcv-ilp32d,rv64gcv-lp64d
 
@@ -37,4 +38,4 @@ clean:
 	rm *.log -f
 
 %.log: $(BASE_DIR)/%.c
-	-$(CC) $< -S -o /dev/null $(CFLAGS) $(EXTRA_CFLAGS) &> $@
+	-$(CC) $< -S -o /dev/null $(ARCH_FLAG) $(CFLAGS) $(EXTRA_CFLAGS) &> $@


### PR DESCRIPTION
Currently based on #267 since the pull request removes test cases that do not suppose to exist and causes compilation test failure.

