### PR TITLE
Add more details in the specification

### DIFF
--- a/auto-generated/api-testing/vcpop.c
+++ b/auto-generated/api-testing/vcpop.c
@@ -5,58 +5,58 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-unsigned long test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vcpop_m_b1(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vcpop_m_b2(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vcpop_m_b4(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vcpop_m_b8(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vcpop_m_b16(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vcpop_m_b32(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vcpop_m_b64(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vcpop_m_b1_m(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vcpop_m_b2_m(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vcpop_m_b4_m(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vcpop_m_b8_m(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vcpop_m_b16_m(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vcpop_m_b32_m(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vcpop_m_b64_m(vm, vs2, vl);
 }

--- a/auto-generated/api-testing/vfadd.c
+++ b/auto-generated/api-testing/vfadd.c
@@ -10,8 +10,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfadd_vv_f16mf4(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf4(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfadd_vv_f16mf2(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf2(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vfloat16m1_t test_vfadd_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfadd_vv_f16m1(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m1(vs2, rs1, vl);
 }
 
@@ -39,7 +37,7 @@ vfloat16m2_t test_vfadd_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfadd_vv_f16m2(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m2(vs2, rs1, vl);
 }
 
@@ -48,7 +46,7 @@ vfloat16m4_t test_vfadd_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfadd_vv_f16m4(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m4(vs2, rs1, vl);
 }
 
@@ -57,7 +55,7 @@ vfloat16m8_t test_vfadd_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfadd_vv_f16m8(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -149,7 +147,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
@@ -159,7 +157,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -168,8 +166,8 @@ vfloat16m1_t test_vfadd_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
   return __riscv_vfadd_vv_f16m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                   float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
+                                   size_t vl) {
   return __riscv_vfadd_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
@@ -178,7 +176,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfadd_vv_f16m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfadd_vf_f16m2_m(vm, vs2, rs1, vl);
 }
@@ -188,7 +186,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfadd_vv_f16m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfadd_vf_f16m4_m(vm, vs2, rs1, vl);
 }
@@ -198,7 +196,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vfadd_vv_f16m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfadd_vf_f16m8_m(vm, vs2, rs1, vl);
 }
@@ -298,7 +296,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfadd_vv_f16mf4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfadd_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfadd_vf_f16mf4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -308,7 +306,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfadd_vv_f16mf2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfadd_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfadd_vf_f16mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -318,8 +316,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfadd_vv_f16m1_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -328,8 +325,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfadd_vv_f16m2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -338,8 +334,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfadd_vv_f16m4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -348,8 +343,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfadd_vv_f16m8_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -449,7 +443,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +453,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -469,7 +463,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -479,7 +473,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -489,7 +483,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +493,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/api-testing/vfdiv.c
+++ b/auto-generated/api-testing/vfdiv.c
@@ -10,8 +10,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfdiv_vv_f16mf4(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf4(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfdiv_vv_f16mf2(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf2(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfdiv_vv_f16m1(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m1(vs2, rs1, vl);
 }
 
@@ -39,7 +37,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfdiv_vv_f16m2(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m2(vs2, rs1, vl);
 }
 
@@ -48,7 +46,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfdiv_vv_f16m4(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m4(vs2, rs1, vl);
 }
 
@@ -57,7 +55,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfdiv_vv_f16m8(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -149,7 +147,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
@@ -159,7 +157,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -168,8 +166,8 @@ vfloat16m1_t test_vfdiv_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
   return __riscv_vfdiv_vv_f16m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                   float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
+                                   size_t vl) {
   return __riscv_vfdiv_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
@@ -178,7 +176,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfdiv_vv_f16m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfdiv_vf_f16m2_m(vm, vs2, rs1, vl);
 }
@@ -188,7 +186,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfdiv_vv_f16m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfdiv_vf_f16m4_m(vm, vs2, rs1, vl);
 }
@@ -198,7 +196,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vfdiv_vv_f16m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfdiv_vf_f16m8_m(vm, vs2, rs1, vl);
 }
@@ -298,7 +296,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfdiv_vv_f16mf4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -308,7 +306,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfdiv_vv_f16mf2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -318,8 +316,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfdiv_vv_f16m1_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -328,8 +325,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfdiv_vv_f16m2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -338,8 +334,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfdiv_vv_f16m4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -348,8 +343,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfdiv_vv_f16m8_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -449,7 +443,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +453,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -469,7 +463,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfdiv_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -479,7 +473,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfdiv_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -489,7 +483,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfdiv_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +493,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfdiv_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/api-testing/vfirst.c
+++ b/auto-generated/api-testing/vfirst.c
@@ -5,58 +5,58 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-long test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
+int test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vfirst_m_b1(vs2, vl);
 }
 
-long test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
+int test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vfirst_m_b2(vs2, vl);
 }
 
-long test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
+int test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vfirst_m_b4(vs2, vl);
 }
 
-long test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
+int test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vfirst_m_b8(vs2, vl);
 }
 
-long test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
+int test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vfirst_m_b16(vs2, vl);
 }
 
-long test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
+int test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vfirst_m_b32(vs2, vl);
 }
 
-long test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
+int test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vfirst_m_b64(vs2, vl);
 }
 
-long test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+int test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vfirst_m_b1_m(vm, vs2, vl);
 }
 
-long test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+int test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vfirst_m_b2_m(vm, vs2, vl);
 }
 
-long test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+int test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vfirst_m_b4_m(vm, vs2, vl);
 }
 
-long test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+int test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vfirst_m_b8_m(vm, vs2, vl);
 }
 
-long test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+int test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vfirst_m_b16_m(vm, vs2, vl);
 }
 
-long test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+int test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vfirst_m_b32_m(vm, vs2, vl);
 }
 
-long test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+int test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vfirst_m_b64_m(vm, vs2, vl);
 }

--- a/auto-generated/api-testing/vfmacc.c
+++ b/auto-generated/api-testing/vfmacc.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmacc_vv_f16mf4(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmacc_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                     vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf4(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmacc_vv_f16mf2(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmacc_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                     vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf2(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmacc_vv_f16m1(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmacc_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                   vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m1(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmacc_vv_f16m2(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmacc_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                   vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m2(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmacc_vv_f16m4(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmacc_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                   vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m4(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmacc_vv_f16m8(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmacc_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                   vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m8(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmacc_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                      float16_t rs1, vfloat16mf4_t vs2,
+                                      _Float16 rs1, vfloat16mf4_t vs2,
                                       size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_m(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmacc_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                      float16_t rs1, vfloat16mf2_t vs2,
+                                      _Float16 rs1, vfloat16mf2_t vs2,
                                       size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_m(vm, vd, rs1, vs2, vl);
 }
@@ -185,9 +185,8 @@ vfloat16m1_t test_vfmacc_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
   return __riscv_vfmacc_vv_f16m1_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                    float16_t rs1, vfloat16m1_t vs2,
-                                    size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
+                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m1_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -197,7 +196,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfmacc_vv_f16m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m2_m(vm, vd, rs1, vs2, vl);
 }
@@ -208,7 +207,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfmacc_vv_f16m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m4_m(vm, vd, rs1, vs2, vl);
 }
@@ -219,7 +218,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfmacc_vv_f16m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m8_m(vm, vd, rs1, vs2, vl);
 }
@@ -334,7 +333,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmacc_vv_f16mf4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmacc_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -344,7 +343,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmacc_vv_f16mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmacc_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -354,7 +353,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmacc_vv_f16m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmacc_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m1_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -364,7 +363,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmacc_vv_f16m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmacc_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -374,7 +373,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmacc_vv_f16m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmacc_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -384,7 +383,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmacc_vv_f16m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmacc_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m8_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -486,7 +485,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -498,7 +497,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -510,7 +509,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmacc_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc_vf_f16m1_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -522,7 +521,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmacc_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc_vf_f16m2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -534,7 +533,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmacc_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc_vf_f16m4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -546,7 +545,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmacc_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc_vf_f16m8_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/api-testing/vfmadd.c
+++ b/auto-generated/api-testing/vfmadd.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmadd_vv_f16mf4(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmadd_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                     vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf4(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmadd_vv_f16mf2(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmadd_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                     vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf2(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmadd_vv_f16m1(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmadd_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                   vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m1(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmadd_vv_f16m2(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmadd_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                   vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m2(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmadd_vv_f16m4(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmadd_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                   vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m4(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmadd_vv_f16m8(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmadd_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                   vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m8(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                      float16_t rs1, vfloat16mf4_t vs2,
+                                      _Float16 rs1, vfloat16mf4_t vs2,
                                       size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_m(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                      float16_t rs1, vfloat16mf2_t vs2,
+                                      _Float16 rs1, vfloat16mf2_t vs2,
                                       size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_m(vm, vd, rs1, vs2, vl);
 }
@@ -185,9 +185,8 @@ vfloat16m1_t test_vfmadd_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
   return __riscv_vfmadd_vv_f16m1_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                    float16_t rs1, vfloat16m1_t vs2,
-                                    size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
+                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m1_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -197,7 +196,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfmadd_vv_f16m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m2_m(vm, vd, rs1, vs2, vl);
 }
@@ -208,7 +207,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfmadd_vv_f16m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m4_m(vm, vd, rs1, vs2, vl);
 }
@@ -219,7 +218,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfmadd_vv_f16m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m8_m(vm, vd, rs1, vs2, vl);
 }
@@ -334,7 +333,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmadd_vv_f16mf4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmadd_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -344,7 +343,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmadd_vv_f16mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmadd_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -354,7 +353,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmadd_vv_f16m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmadd_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m1_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -364,7 +363,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmadd_vv_f16m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmadd_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -374,7 +373,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmadd_vv_f16m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmadd_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -384,7 +383,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmadd_vv_f16m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmadd_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m8_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -486,7 +485,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -498,7 +497,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -510,7 +509,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd_vf_f16m1_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -522,7 +521,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd_vf_f16m2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -534,7 +533,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd_vf_f16m4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -546,7 +545,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd_vf_f16m8_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/api-testing/vfmax.c
+++ b/auto-generated/api-testing/vfmax.c
@@ -10,8 +10,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfmax_vv_f16mf4(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmax_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf4_t test_vfmax_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16mf4(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfmax_vv_f16mf2(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmax_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf2_t test_vfmax_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16mf2(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vfloat16m1_t test_vfmax_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfmax_vv_f16m1(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmax_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmax_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m1(vs2, rs1, vl);
 }
 
@@ -39,7 +37,7 @@ vfloat16m2_t test_vfmax_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfmax_vv_f16m2(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmax_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmax_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m2(vs2, rs1, vl);
 }
 
@@ -48,7 +46,7 @@ vfloat16m4_t test_vfmax_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfmax_vv_f16m4(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmax_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmax_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m4(vs2, rs1, vl);
 }
 
@@ -57,7 +55,7 @@ vfloat16m8_t test_vfmax_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfmax_vv_f16m8(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmax_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmax_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -149,7 +147,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfmax_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
@@ -159,7 +157,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfmax_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -168,8 +166,8 @@ vfloat16m1_t test_vfmax_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
   return __riscv_vfmax_vv_f16m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmax_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                   float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmax_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
+                                   size_t vl) {
   return __riscv_vfmax_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
@@ -178,7 +176,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfmax_vv_f16m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmax_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfmax_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfmax_vf_f16m2_m(vm, vs2, rs1, vl);
 }
@@ -188,7 +186,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfmax_vv_f16m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmax_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfmax_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfmax_vf_f16m4_m(vm, vs2, rs1, vl);
 }
@@ -198,7 +196,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vfmax_vv_f16m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmax_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfmax_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfmax_vf_f16m8_m(vm, vs2, rs1, vl);
 }

--- a/auto-generated/api-testing/vfmerge.c
+++ b/auto-generated/api-testing/vfmerge.c
@@ -5,33 +5,33 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfmerge_vfm_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfmerge_vfm_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                       vbool64_t v0, size_t vl) {
   return __riscv_vfmerge_vfm_f16mf4(vs2, rs1, v0, vl);
 }
 
-vfloat16mf2_t test_vfmerge_vfm_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfmerge_vfm_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                       vbool32_t v0, size_t vl) {
   return __riscv_vfmerge_vfm_f16mf2(vs2, rs1, v0, vl);
 }
 
-vfloat16m1_t test_vfmerge_vfm_f16m1(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t test_vfmerge_vfm_f16m1(vfloat16m1_t vs2, _Float16 rs1,
                                     vbool16_t v0, size_t vl) {
   return __riscv_vfmerge_vfm_f16m1(vs2, rs1, v0, vl);
 }
 
-vfloat16m2_t test_vfmerge_vfm_f16m2(vfloat16m2_t vs2, float16_t rs1,
-                                    vbool8_t v0, size_t vl) {
+vfloat16m2_t test_vfmerge_vfm_f16m2(vfloat16m2_t vs2, _Float16 rs1, vbool8_t v0,
+                                    size_t vl) {
   return __riscv_vfmerge_vfm_f16m2(vs2, rs1, v0, vl);
 }
 
-vfloat16m4_t test_vfmerge_vfm_f16m4(vfloat16m4_t vs2, float16_t rs1,
-                                    vbool4_t v0, size_t vl) {
+vfloat16m4_t test_vfmerge_vfm_f16m4(vfloat16m4_t vs2, _Float16 rs1, vbool4_t v0,
+                                    size_t vl) {
   return __riscv_vfmerge_vfm_f16m4(vs2, rs1, v0, vl);
 }
 
-vfloat16m8_t test_vfmerge_vfm_f16m8(vfloat16m8_t vs2, float16_t rs1,
-                                    vbool2_t v0, size_t vl) {
+vfloat16m8_t test_vfmerge_vfm_f16m8(vfloat16m8_t vs2, _Float16 rs1, vbool2_t v0,
+                                    size_t vl) {
   return __riscv_vfmerge_vfm_f16m8(vs2, rs1, v0, vl);
 }
 

--- a/auto-generated/api-testing/vfmin.c
+++ b/auto-generated/api-testing/vfmin.c
@@ -10,8 +10,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfmin_vv_f16mf4(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmin_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf4_t test_vfmin_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16mf4(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfmin_vv_f16mf2(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmin_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf2_t test_vfmin_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16mf2(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vfloat16m1_t test_vfmin_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfmin_vv_f16m1(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmin_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmin_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m1(vs2, rs1, vl);
 }
 
@@ -39,7 +37,7 @@ vfloat16m2_t test_vfmin_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfmin_vv_f16m2(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmin_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmin_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m2(vs2, rs1, vl);
 }
 
@@ -48,7 +46,7 @@ vfloat16m4_t test_vfmin_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfmin_vv_f16m4(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmin_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmin_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m4(vs2, rs1, vl);
 }
 
@@ -57,7 +55,7 @@ vfloat16m8_t test_vfmin_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfmin_vv_f16m8(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmin_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmin_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -149,7 +147,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfmin_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
@@ -159,7 +157,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfmin_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -168,8 +166,8 @@ vfloat16m1_t test_vfmin_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
   return __riscv_vfmin_vv_f16m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmin_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                   float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmin_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
+                                   size_t vl) {
   return __riscv_vfmin_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
@@ -178,7 +176,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfmin_vv_f16m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmin_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfmin_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfmin_vf_f16m2_m(vm, vs2, rs1, vl);
 }
@@ -188,7 +186,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfmin_vv_f16m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmin_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfmin_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfmin_vf_f16m4_m(vm, vs2, rs1, vl);
 }
@@ -198,7 +196,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vfmin_vv_f16m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmin_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfmin_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfmin_vf_f16m8_m(vm, vs2, rs1, vl);
 }

--- a/auto-generated/api-testing/vfmsac.c
+++ b/auto-generated/api-testing/vfmsac.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmsac_vv_f16mf4(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmsac_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                     vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf4(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmsac_vv_f16mf2(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmsac_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                     vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf2(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmsac_vv_f16m1(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmsac_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                   vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m1(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmsac_vv_f16m2(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsac_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                   vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m2(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmsac_vv_f16m4(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsac_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                   vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m4(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmsac_vv_f16m8(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsac_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                   vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m8(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsac_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                      float16_t rs1, vfloat16mf4_t vs2,
+                                      _Float16 rs1, vfloat16mf4_t vs2,
                                       size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_m(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsac_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                      float16_t rs1, vfloat16mf2_t vs2,
+                                      _Float16 rs1, vfloat16mf2_t vs2,
                                       size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_m(vm, vd, rs1, vs2, vl);
 }
@@ -185,9 +185,8 @@ vfloat16m1_t test_vfmsac_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
   return __riscv_vfmsac_vv_f16m1_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                    float16_t rs1, vfloat16m1_t vs2,
-                                    size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
+                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m1_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -197,7 +196,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfmsac_vv_f16m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m2_m(vm, vd, rs1, vs2, vl);
 }
@@ -208,7 +207,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfmsac_vv_f16m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m4_m(vm, vd, rs1, vs2, vl);
 }
@@ -219,7 +218,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfmsac_vv_f16m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m8_m(vm, vd, rs1, vs2, vl);
 }
@@ -334,7 +333,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmsac_vv_f16mf4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmsac_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -344,7 +343,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmsac_vv_f16mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmsac_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -354,7 +353,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmsac_vv_f16m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmsac_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m1_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -364,7 +363,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmsac_vv_f16m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsac_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -374,7 +373,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmsac_vv_f16m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsac_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -384,7 +383,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmsac_vv_f16m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsac_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m8_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -486,7 +485,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -498,7 +497,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -510,7 +509,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsac_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac_vf_f16m1_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -522,7 +521,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsac_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac_vf_f16m2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -534,7 +533,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsac_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac_vf_f16m4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -546,7 +545,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsac_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac_vf_f16m8_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/api-testing/vfmsub.c
+++ b/auto-generated/api-testing/vfmsub.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmsub_vv_f16mf4(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmsub_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                     vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf4(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmsub_vv_f16mf2(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmsub_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                     vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf2(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmsub_vv_f16m1(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmsub_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                   vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m1(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmsub_vv_f16m2(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsub_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                   vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m2(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmsub_vv_f16m4(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsub_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                   vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m4(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmsub_vv_f16m8(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsub_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                   vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m8(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                      float16_t rs1, vfloat16mf4_t vs2,
+                                      _Float16 rs1, vfloat16mf4_t vs2,
                                       size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_m(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                      float16_t rs1, vfloat16mf2_t vs2,
+                                      _Float16 rs1, vfloat16mf2_t vs2,
                                       size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_m(vm, vd, rs1, vs2, vl);
 }
@@ -185,9 +185,8 @@ vfloat16m1_t test_vfmsub_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
   return __riscv_vfmsub_vv_f16m1_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                    float16_t rs1, vfloat16m1_t vs2,
-                                    size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
+                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m1_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -197,7 +196,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfmsub_vv_f16m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m2_m(vm, vd, rs1, vs2, vl);
 }
@@ -208,7 +207,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfmsub_vv_f16m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m4_m(vm, vd, rs1, vs2, vl);
 }
@@ -219,7 +218,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfmsub_vv_f16m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m8_m(vm, vd, rs1, vs2, vl);
 }
@@ -334,7 +333,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmsub_vv_f16mf4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmsub_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -344,7 +343,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmsub_vv_f16mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmsub_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -354,7 +353,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmsub_vv_f16m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmsub_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m1_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -364,7 +363,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmsub_vv_f16m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsub_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -374,7 +373,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmsub_vv_f16m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsub_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -384,7 +383,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmsub_vv_f16m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsub_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m8_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -486,7 +485,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -498,7 +497,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -510,7 +509,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub_vf_f16m1_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -522,7 +521,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub_vf_f16m2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -534,7 +533,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub_vf_f16m4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -546,7 +545,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub_vf_f16m8_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/api-testing/vfmul.c
+++ b/auto-generated/api-testing/vfmul.c
@@ -10,8 +10,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfmul_vv_f16mf4(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf4(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfmul_vv_f16mf2(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf2(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vfloat16m1_t test_vfmul_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfmul_vv_f16m1(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m1(vs2, rs1, vl);
 }
 
@@ -39,7 +37,7 @@ vfloat16m2_t test_vfmul_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfmul_vv_f16m2(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m2(vs2, rs1, vl);
 }
 
@@ -48,7 +46,7 @@ vfloat16m4_t test_vfmul_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfmul_vv_f16m4(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m4(vs2, rs1, vl);
 }
 
@@ -57,7 +55,7 @@ vfloat16m8_t test_vfmul_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfmul_vv_f16m8(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -149,7 +147,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
@@ -159,7 +157,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -168,8 +166,8 @@ vfloat16m1_t test_vfmul_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
   return __riscv_vfmul_vv_f16m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                   float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
+                                   size_t vl) {
   return __riscv_vfmul_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
@@ -178,7 +176,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfmul_vv_f16m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfmul_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfmul_vf_f16m2_m(vm, vs2, rs1, vl);
 }
@@ -188,7 +186,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfmul_vv_f16m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfmul_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfmul_vf_f16m4_m(vm, vs2, rs1, vl);
 }
@@ -198,7 +196,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vfmul_vv_f16m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfmul_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfmul_vf_f16m8_m(vm, vs2, rs1, vl);
 }
@@ -298,7 +296,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfmul_vv_f16mf4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfmul_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmul_vf_f16mf4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -308,7 +306,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfmul_vv_f16mf2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfmul_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmul_vf_f16mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -318,8 +316,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfmul_vv_f16m1_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -328,8 +325,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfmul_vv_f16m2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -338,8 +334,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfmul_vv_f16m4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -348,8 +343,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfmul_vv_f16m8_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -449,7 +443,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +453,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -469,7 +463,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfmul_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -479,7 +473,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfmul_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -489,7 +483,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfmul_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +493,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfmul_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/api-testing/vfmv.c
+++ b/auto-generated/api-testing/vfmv.c
@@ -5,27 +5,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfmv_v_f_f16mf4(float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmv_v_f_f16mf4(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16mf4(rs1, vl);
 }
 
-vfloat16mf2_t test_vfmv_v_f_f16mf2(float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmv_v_f_f16mf2(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16mf2(rs1, vl);
 }
 
-vfloat16m1_t test_vfmv_v_f_f16m1(float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmv_v_f_f16m1(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16m1(rs1, vl);
 }
 
-vfloat16m2_t test_vfmv_v_f_f16m2(float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmv_v_f_f16m2(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16m2(rs1, vl);
 }
 
-vfloat16m4_t test_vfmv_v_f_f16m4(float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmv_v_f_f16m4(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16m4(rs1, vl);
 }
 
-vfloat16m8_t test_vfmv_v_f_f16m8(float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmv_v_f_f16m8(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16m8(rs1, vl);
 }
 
@@ -65,51 +65,51 @@ vfloat64m8_t test_vfmv_v_f_f64m8(float64_t rs1, size_t vl) {
   return __riscv_vfmv_v_f_f64m8(rs1, vl);
 }
 
-float16_t test_vfmv_f_s_f16mf4_f16(vfloat16mf4_t vs1) {
+_Float16 test_vfmv_f_s_f16mf4_f16(vfloat16mf4_t vs1) {
   return __riscv_vfmv_f_s_f16mf4_f16(vs1);
 }
 
-vfloat16mf4_t test_vfmv_s_f_f16mf4(float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmv_s_f_f16mf4(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16mf4(rs1, vl);
 }
 
-float16_t test_vfmv_f_s_f16mf2_f16(vfloat16mf2_t vs1) {
+_Float16 test_vfmv_f_s_f16mf2_f16(vfloat16mf2_t vs1) {
   return __riscv_vfmv_f_s_f16mf2_f16(vs1);
 }
 
-vfloat16mf2_t test_vfmv_s_f_f16mf2(float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmv_s_f_f16mf2(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16mf2(rs1, vl);
 }
 
-float16_t test_vfmv_f_s_f16m1_f16(vfloat16m1_t vs1) {
+_Float16 test_vfmv_f_s_f16m1_f16(vfloat16m1_t vs1) {
   return __riscv_vfmv_f_s_f16m1_f16(vs1);
 }
 
-vfloat16m1_t test_vfmv_s_f_f16m1(float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmv_s_f_f16m1(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16m1(rs1, vl);
 }
 
-float16_t test_vfmv_f_s_f16m2_f16(vfloat16m2_t vs1) {
+_Float16 test_vfmv_f_s_f16m2_f16(vfloat16m2_t vs1) {
   return __riscv_vfmv_f_s_f16m2_f16(vs1);
 }
 
-vfloat16m2_t test_vfmv_s_f_f16m2(float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmv_s_f_f16m2(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16m2(rs1, vl);
 }
 
-float16_t test_vfmv_f_s_f16m4_f16(vfloat16m4_t vs1) {
+_Float16 test_vfmv_f_s_f16m4_f16(vfloat16m4_t vs1) {
   return __riscv_vfmv_f_s_f16m4_f16(vs1);
 }
 
-vfloat16m4_t test_vfmv_s_f_f16m4(float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmv_s_f_f16m4(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16m4(rs1, vl);
 }
 
-float16_t test_vfmv_f_s_f16m8_f16(vfloat16m8_t vs1) {
+_Float16 test_vfmv_f_s_f16m8_f16(vfloat16m8_t vs1) {
   return __riscv_vfmv_f_s_f16m8_f16(vs1);
 }
 
-vfloat16m8_t test_vfmv_s_f_f16m8(float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmv_s_f_f16m8(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16m8(rs1, vl);
 }
 

--- a/auto-generated/api-testing/vfnmacc.c
+++ b/auto-generated/api-testing/vfnmacc.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmacc_vv_f16mf4(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmacc_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                      vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmacc_vv_f16mf2(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmacc_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                      vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmacc_vv_f16m1(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmacc_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m1(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmacc_vv_f16m2(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmacc_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                    vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m2(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmacc_vv_f16m4(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmacc_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                    vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m4(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmacc_vv_f16m8(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmacc_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                    vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m8(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmacc_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                       float16_t rs1, vfloat16mf4_t vs2,
+                                       _Float16 rs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_m(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmacc_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                       float16_t rs1, vfloat16mf2_t vs2,
+                                       _Float16 rs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_m(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmacc_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                     float16_t rs1, vfloat16m1_t vs2,
+                                     _Float16 rs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_m(vm, vd, rs1, vs2, vl);
 }
@@ -197,9 +197,8 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfnmacc_vv_f16m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                     float16_t rs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -209,9 +208,8 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfnmacc_vv_f16m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                     float16_t rs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -221,9 +219,8 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfnmacc_vv_f16m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                     float16_t rs1, vfloat16m8_t vs2,
-                                     size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
+                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -340,7 +337,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmacc_vv_f16mf4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -350,7 +347,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmacc_vv_f16mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -360,7 +357,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmacc_vv_f16m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmacc_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -370,7 +367,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmacc_vv_f16m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmacc_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -380,7 +377,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmacc_vv_f16m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmacc_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -390,7 +387,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmacc_vv_f16m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmacc_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -492,7 +489,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -504,7 +501,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -516,7 +513,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmacc_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -528,7 +525,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmacc_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -540,7 +537,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmacc_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -552,7 +549,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmacc_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/api-testing/vfnmadd.c
+++ b/auto-generated/api-testing/vfnmadd.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmadd_vv_f16mf4(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmadd_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                      vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmadd_vv_f16mf2(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmadd_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                      vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmadd_vv_f16m1(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmadd_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m1(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmadd_vv_f16m2(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmadd_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                    vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m2(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmadd_vv_f16m4(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmadd_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                    vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m4(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmadd_vv_f16m8(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmadd_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                    vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m8(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                       float16_t rs1, vfloat16mf4_t vs2,
+                                       _Float16 rs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_m(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                       float16_t rs1, vfloat16mf2_t vs2,
+                                       _Float16 rs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_m(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                     float16_t rs1, vfloat16m1_t vs2,
+                                     _Float16 rs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_m(vm, vd, rs1, vs2, vl);
 }
@@ -197,9 +197,8 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfnmadd_vv_f16m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                     float16_t rs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -209,9 +208,8 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfnmadd_vv_f16m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                     float16_t rs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -221,9 +219,8 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfnmadd_vv_f16m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                     float16_t rs1, vfloat16m8_t vs2,
-                                     size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
+                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -340,7 +337,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmadd_vv_f16mf4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -350,7 +347,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmadd_vv_f16mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -360,7 +357,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmadd_vv_f16m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmadd_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -370,7 +367,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmadd_vv_f16m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmadd_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -380,7 +377,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmadd_vv_f16m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmadd_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -390,7 +387,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmadd_vv_f16m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmadd_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -492,7 +489,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -504,7 +501,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -516,7 +513,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -528,7 +525,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -540,7 +537,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -552,7 +549,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/api-testing/vfnmsac.c
+++ b/auto-generated/api-testing/vfnmsac.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmsac_vv_f16mf4(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmsac_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                      vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmsac_vv_f16mf2(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmsac_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                      vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmsac_vv_f16m1(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmsac_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m1(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmsac_vv_f16m2(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmsac_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                    vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m2(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmsac_vv_f16m4(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmsac_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                    vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m4(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmsac_vv_f16m8(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmsac_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                    vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m8(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsac_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                       float16_t rs1, vfloat16mf4_t vs2,
+                                       _Float16 rs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_m(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsac_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                       float16_t rs1, vfloat16mf2_t vs2,
+                                       _Float16 rs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_m(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsac_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                     float16_t rs1, vfloat16m1_t vs2,
+                                     _Float16 rs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_m(vm, vd, rs1, vs2, vl);
 }
@@ -197,9 +197,8 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfnmsac_vv_f16m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                     float16_t rs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -209,9 +208,8 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfnmsac_vv_f16m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                     float16_t rs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -221,9 +219,8 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfnmsac_vv_f16m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                     float16_t rs1, vfloat16m8_t vs2,
-                                     size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
+                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -340,7 +337,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmsac_vv_f16mf4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -350,7 +347,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmsac_vv_f16mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -360,7 +357,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmsac_vv_f16m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmsac_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -370,7 +367,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmsac_vv_f16m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmsac_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -380,7 +377,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmsac_vv_f16m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmsac_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -390,7 +387,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmsac_vv_f16m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmsac_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -492,7 +489,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -504,7 +501,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -516,7 +513,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsac_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -528,7 +525,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsac_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -540,7 +537,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsac_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -552,7 +549,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsac_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/api-testing/vfnmsub.c
+++ b/auto-generated/api-testing/vfnmsub.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmsub_vv_f16mf4(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmsub_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                      vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmsub_vv_f16mf2(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmsub_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                      vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmsub_vv_f16m1(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmsub_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m1(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmsub_vv_f16m2(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmsub_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                    vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m2(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmsub_vv_f16m4(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmsub_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                    vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m4(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmsub_vv_f16m8(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmsub_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                    vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m8(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                       float16_t rs1, vfloat16mf4_t vs2,
+                                       _Float16 rs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_m(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                       float16_t rs1, vfloat16mf2_t vs2,
+                                       _Float16 rs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_m(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                     float16_t rs1, vfloat16m1_t vs2,
+                                     _Float16 rs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_m(vm, vd, rs1, vs2, vl);
 }
@@ -197,9 +197,8 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfnmsub_vv_f16m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                     float16_t rs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -209,9 +208,8 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfnmsub_vv_f16m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                     float16_t rs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -221,9 +219,8 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfnmsub_vv_f16m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                     float16_t rs1, vfloat16m8_t vs2,
-                                     size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
+                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -340,7 +337,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmsub_vv_f16mf4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -350,7 +347,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmsub_vv_f16mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -360,7 +357,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmsub_vv_f16m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmsub_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -370,7 +367,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmsub_vv_f16m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmsub_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -380,7 +377,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmsub_vv_f16m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmsub_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -390,7 +387,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmsub_vv_f16m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmsub_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -492,7 +489,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -504,7 +501,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -516,7 +513,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -528,7 +525,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -540,7 +537,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -552,7 +549,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/api-testing/vfrdiv.c
+++ b/auto-generated/api-testing/vfrdiv.c
@@ -5,29 +5,29 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfrdiv_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4(vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfrdiv_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2(vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m1(vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m2(vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m4(vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -69,32 +69,32 @@ vfloat64m8_t test_vfrdiv_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl) {
 }
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 
@@ -143,32 +143,32 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
   return __riscv_vfrdiv_vf_f64m8_m(vm, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t test_vfrdiv_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfrdiv_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfrdiv_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfrdiv_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -219,32 +219,32 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_rm(vfloat64m8_t vs2, float64_t rs1,
 }
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrdiv_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrdiv_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrdiv_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/api-testing/vfrsub.c
+++ b/auto-generated/api-testing/vfrsub.c
@@ -5,29 +5,29 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfrsub_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfrsub_vf_f16mf4(vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfrsub_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfrsub_vf_f16mf2(vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m1(vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m2(vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m4(vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -69,32 +69,32 @@ vfloat64m8_t test_vfrsub_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl) {
 }
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfrsub_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfrsub_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfrsub_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 
@@ -143,32 +143,32 @@ vfloat64m8_t test_vfrsub_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
   return __riscv_vfrsub_vf_f64m8_m(vm, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfrsub_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfrsub_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t test_vfrsub_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrsub_vf_f16m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfrsub_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrsub_vf_f16m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfrsub_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrsub_vf_f16m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfrsub_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrsub_vf_f16m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -219,32 +219,32 @@ vfloat64m8_t test_vfrsub_vf_f64m8_rm(vfloat64m8_t vs2, float64_t rs1,
 }
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/api-testing/vfsgnj.c
+++ b/auto-generated/api-testing/vfsgnj.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfsgnj_vv_f16mf4(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnj_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfsgnj_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfsgnj_vf_f16mf4(vs2, rs1, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfsgnj_vv_f16mf2(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnj_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfsgnj_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfsgnj_vf_f16mf2(vs2, rs1, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfsgnj_vv_f16m1(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnj_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnj_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m1(vs2, rs1, vl);
 }
 
@@ -39,7 +39,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfsgnj_vv_f16m2(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnj_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnj_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m2(vs2, rs1, vl);
 }
 
@@ -48,7 +48,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfsgnj_vv_f16m4(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnj_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnj_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m4(vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfsgnj_vv_f16m8(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnj_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnj_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -149,7 +149,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsgnj_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
@@ -159,7 +159,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsgnj_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -169,7 +169,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfsgnj_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
@@ -178,8 +178,8 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfsgnj_vv_f16m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnj_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnj_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfsgnj_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
@@ -188,8 +188,8 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfsgnj_vv_f16m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnj_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnj_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfsgnj_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
@@ -198,8 +198,8 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vfsgnj_vv_f16m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnj_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnj_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfsgnj_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/api-testing/vfsgnjn.c
+++ b/auto-generated/api-testing/vfsgnjn.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfsgnjn_vv_f16mf4(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjn_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfsgnjn_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf4(vs2, rs1, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfsgnjn_vv_f16mf2(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjn_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfsgnjn_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf2(vs2, rs1, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfsgnjn_vv_f16m1(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjn_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjn_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m1(vs2, rs1, vl);
 }
 
@@ -39,7 +39,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfsgnjn_vv_f16m2(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjn_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjn_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m2(vs2, rs1, vl);
 }
 
@@ -48,7 +48,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfsgnjn_vv_f16m4(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjn_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjn_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m4(vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfsgnjn_vv_f16m8(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjn_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjn_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -149,7 +149,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsgnjn_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
@@ -159,7 +159,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsgnjn_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -169,7 +169,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfsgnjn_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfsgnjn_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
@@ -189,7 +189,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfsgnjn_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
@@ -199,7 +199,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfsgnjn_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/api-testing/vfsgnjx.c
+++ b/auto-generated/api-testing/vfsgnjx.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfsgnjx_vv_f16mf4(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjx_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfsgnjx_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf4(vs2, rs1, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfsgnjx_vv_f16mf2(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjx_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfsgnjx_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf2(vs2, rs1, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfsgnjx_vv_f16m1(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjx_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjx_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m1(vs2, rs1, vl);
 }
 
@@ -39,7 +39,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfsgnjx_vv_f16m2(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjx_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjx_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m2(vs2, rs1, vl);
 }
 
@@ -48,7 +48,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfsgnjx_vv_f16m4(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjx_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjx_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m4(vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfsgnjx_vv_f16m8(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjx_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjx_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -149,7 +149,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsgnjx_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
@@ -159,7 +159,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsgnjx_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -169,7 +169,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfsgnjx_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfsgnjx_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
@@ -189,7 +189,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfsgnjx_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
@@ -199,7 +199,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfsgnjx_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/api-testing/vfslide1down.c
+++ b/auto-generated/api-testing/vfslide1down.c
@@ -5,32 +5,32 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfslide1down_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfslide1down_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfslide1down_vf_f16mf4(vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1down_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfslide1down_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfslide1down_vf_f16mf2(vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1down_vf_f16m1(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t test_vfslide1down_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfslide1down_vf_f16m1(vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1down_vf_f16m2(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfslide1down_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfslide1down_vf_f16m2(vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1down_vf_f16m4(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfslide1down_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfslide1down_vf_f16m4(vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1down_vf_f16m8(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfslide1down_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfslide1down_vf_f16m8(vs2, rs1, vl);
 }
@@ -81,32 +81,32 @@ vfloat64m8_t test_vfslide1down_vf_f64m8(vfloat64m8_t vs2, float64_t rs1,
 }
 
 vfloat16mf4_t test_vfslide1down_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                            float16_t rs1, size_t vl) {
+                                            _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1down_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                            float16_t rs1, size_t vl) {
+                                            _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1down_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1down_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1down_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1down_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/api-testing/vfslide1up.c
+++ b/auto-generated/api-testing/vfslide1up.c
@@ -5,32 +5,32 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfslide1up_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfslide1up_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfslide1up_vf_f16mf4(vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1up_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfslide1up_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfslide1up_vf_f16mf2(vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1up_vf_f16m1(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t test_vfslide1up_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfslide1up_vf_f16m1(vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1up_vf_f16m2(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfslide1up_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfslide1up_vf_f16m2(vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1up_vf_f16m4(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfslide1up_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfslide1up_vf_f16m4(vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1up_vf_f16m8(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfslide1up_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfslide1up_vf_f16m8(vs2, rs1, vl);
 }
@@ -81,32 +81,32 @@ vfloat64m8_t test_vfslide1up_vf_f64m8(vfloat64m8_t vs2, float64_t rs1,
 }
 
 vfloat16mf4_t test_vfslide1up_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1up_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1up_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1up_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1up_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1up_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/api-testing/vfsub.c
+++ b/auto-generated/api-testing/vfsub.c
@@ -10,8 +10,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfsub_vv_f16mf4(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf4(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfsub_vv_f16mf2(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf2(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vfloat16m1_t test_vfsub_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfsub_vv_f16m1(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m1(vs2, rs1, vl);
 }
 
@@ -39,7 +37,7 @@ vfloat16m2_t test_vfsub_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfsub_vv_f16m2(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m2(vs2, rs1, vl);
 }
 
@@ -48,7 +46,7 @@ vfloat16m4_t test_vfsub_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfsub_vv_f16m4(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m4(vs2, rs1, vl);
 }
 
@@ -57,7 +55,7 @@ vfloat16m8_t test_vfsub_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfsub_vv_f16m8(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -149,7 +147,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
@@ -159,7 +157,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -168,8 +166,8 @@ vfloat16m1_t test_vfsub_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
   return __riscv_vfsub_vv_f16m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                   float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
+                                   size_t vl) {
   return __riscv_vfsub_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
@@ -178,7 +176,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfsub_vv_f16m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfsub_vf_f16m2_m(vm, vs2, rs1, vl);
 }
@@ -188,7 +186,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfsub_vv_f16m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfsub_vf_f16m4_m(vm, vs2, rs1, vl);
 }
@@ -198,7 +196,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vfsub_vv_f16m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfsub_vf_f16m8_m(vm, vs2, rs1, vl);
 }
@@ -298,7 +296,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfsub_vv_f16mf4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfsub_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsub_vf_f16mf4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -308,7 +306,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfsub_vv_f16mf2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfsub_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsub_vf_f16mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -318,8 +316,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfsub_vv_f16m1_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -328,8 +325,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfsub_vv_f16m2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -338,8 +334,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfsub_vv_f16m4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -348,8 +343,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfsub_vv_f16m8_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -449,7 +443,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +453,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -469,7 +463,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -479,7 +473,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -489,7 +483,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +493,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/api-testing/vfwadd.c
+++ b/auto-generated/api-testing/vfwadd.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwadd_vv_f32mf2(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwadd_vf_f32mf2(vfloat16mf4_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfwadd_vf_f32mf2(vs2, rs1, vl);
 }
@@ -20,7 +20,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwadd_wv_f32mf2(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwadd_wf_f32mf2(vfloat32mf2_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfwadd_wf_f32mf2(vs2, rs1, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwadd_vv_f32m1(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m1(vs2, rs1, vl);
 }
 
@@ -39,7 +39,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1(vfloat32m1_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwadd_wv_f32m1(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1(vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1(vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m1(vs2, rs1, vl);
 }
 
@@ -48,7 +48,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwadd_vv_f32m2(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m2(vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2(vfloat32m2_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwadd_wv_f32m2(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2(vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2(vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m2(vs2, rs1, vl);
 }
 
@@ -66,7 +66,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwadd_vv_f32m4(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m4(vs2, rs1, vl);
 }
 
@@ -75,7 +75,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4(vfloat32m4_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwadd_wv_f32m4(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4(vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4(vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m4(vs2, rs1, vl);
 }
 
@@ -84,7 +84,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwadd_vv_f32m8(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m8(vs2, rs1, vl);
 }
 
@@ -93,7 +93,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8(vfloat32m8_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwadd_wv_f32m8(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8(vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8(vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m8(vs2, rs1, vl);
 }
 
@@ -175,7 +175,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -185,7 +185,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -195,7 +195,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m1_m(vm, vs2, rs1, vl);
 }
 
@@ -205,7 +205,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m1_m(vm, vs2, rs1, vl);
 }
 
@@ -215,7 +215,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m2_m(vm, vs2, rs1, vl);
 }
 
@@ -225,7 +225,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_m(vbool16_t vm, vfloat32m2_t vs2,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m2_m(vm, vs2, rs1, vl);
 }
 
@@ -234,8 +234,8 @@ vfloat32m4_t test_vfwadd_vv_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfwadd_vv_f32m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwadd_vf_f32m4_m(vm, vs2, rs1, vl);
 }
 
@@ -244,8 +244,8 @@ vfloat32m4_t test_vfwadd_wv_f32m4_m(vbool8_t vm, vfloat32m4_t vs2,
   return __riscv_vfwadd_wv_f32m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwadd_wf_f32m4_m(vm, vs2, rs1, vl);
 }
 
@@ -254,8 +254,8 @@ vfloat32m8_t test_vfwadd_vv_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfwadd_vv_f32m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwadd_vf_f32m8_m(vm, vs2, rs1, vl);
 }
 
@@ -264,8 +264,8 @@ vfloat32m8_t test_vfwadd_wv_f32m8_m(vbool4_t vm, vfloat32m8_t vs2,
   return __riscv_vfwadd_wv_f32m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwadd_wf_f32m8_m(vm, vs2, rs1, vl);
 }
 
@@ -354,7 +354,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwadd_vv_f32mf2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwadd_vf_f32mf2_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -364,7 +364,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwadd_wv_f32mf2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_rm(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwadd_wf_f32mf2_rm(vfloat32mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -374,7 +374,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwadd_vv_f32m1_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t test_vfwadd_vf_f32m1_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_vf_f32m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -384,7 +384,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm(vfloat32m1_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwadd_wv_f32m1_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_rm(vfloat32m1_t vs2, float16_t rs1,
+vfloat32m1_t test_vfwadd_wf_f32m1_rm(vfloat32m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_wf_f32m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -394,7 +394,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwadd_vv_f32m2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t test_vfwadd_vf_f32m2_rm(vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_vf_f32m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -404,7 +404,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm(vfloat32m2_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwadd_wv_f32m2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_rm(vfloat32m2_t vs2, float16_t rs1,
+vfloat32m2_t test_vfwadd_wf_f32m2_rm(vfloat32m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_wf_f32m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -414,7 +414,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwadd_vv_f32m4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t test_vfwadd_vf_f32m4_rm(vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_vf_f32m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -424,7 +424,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm(vfloat32m4_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwadd_wv_f32m4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_rm(vfloat32m4_t vs2, float16_t rs1,
+vfloat32m4_t test_vfwadd_wf_f32m4_rm(vfloat32m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_wf_f32m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -434,7 +434,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwadd_vv_f32m8_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t test_vfwadd_vf_f32m8_rm(vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_vf_f32m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -444,7 +444,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm(vfloat32m8_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwadd_wv_f32m8_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_rm(vfloat32m8_t vs2, float16_t rs1,
+vfloat32m8_t test_vfwadd_wf_f32m8_rm(vfloat32m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_wf_f32m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -535,7 +535,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -545,7 +545,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -555,7 +555,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -565,7 +565,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -575,7 +575,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -585,7 +585,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -595,7 +595,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
 }
 
 vfloat32m4_t test_vfwadd_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -605,7 +605,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2,
 }
 
 vfloat32m4_t test_vfwadd_wf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -615,7 +615,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
 }
 
 vfloat32m8_t test_vfwadd_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -625,7 +625,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2,
 }
 
 vfloat32m8_t test_vfwadd_wf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/api-testing/vfwmacc.c
+++ b/auto-generated/api-testing/vfwmacc.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwmacc_vv_f32mf2(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwmacc_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1,
                                      vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2(vd, vs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwmacc_vv_f32m1(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwmacc_vf_f32m1(vfloat32m1_t vd, _Float16 vs1,
                                    vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m1(vd, vs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwmacc_vv_f32m2(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwmacc_vf_f32m2(vfloat32m2_t vd, _Float16 vs1,
                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m2(vd, vs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwmacc_vv_f32m4(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwmacc_vf_f32m4(vfloat32m4_t vd, _Float16 vs1,
                                    vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m4(vd, vs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwmacc_vv_f32m8(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwmacc_vf_f32m8(vfloat32m8_t vd, _Float16 vs1,
                                    vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m8(vd, vs1, vs2, vl);
 }
@@ -102,7 +102,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmacc_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
-                                       float16_t vs1, vfloat16mf4_t vs2,
+                                       _Float16 vs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_m(vm, vd, vs1, vs2, vl);
 }
@@ -114,7 +114,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmacc_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
-                                     float16_t vs1, vfloat16mf2_t vs2,
+                                     _Float16 vs1, vfloat16mf2_t vs2,
                                      size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_m(vm, vd, vs1, vs2, vl);
 }
@@ -126,7 +126,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmacc_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
-                                     float16_t vs1, vfloat16m1_t vs2,
+                                     _Float16 vs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_m(vm, vd, vs1, vs2, vl);
 }
@@ -137,9 +137,8 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
   return __riscv_vfwmacc_vv_f32m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
-                                     float16_t vs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -149,9 +148,8 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
   return __riscv_vfwmacc_vv_f32m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
-                                     float16_t vs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -208,7 +206,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwmacc_vv_f32mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -218,7 +216,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwmacc_vv_f32m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwmacc_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1,
                                       vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -228,7 +226,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwmacc_vv_f32m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwmacc_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -238,7 +236,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwmacc_vv_f32m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwmacc_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -248,7 +246,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwmacc_vv_f32m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwmacc_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -300,7 +298,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
-                                          float16_t vs1, vfloat16mf4_t vs2,
+                                          _Float16 vs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -312,7 +310,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmacc_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
-                                        float16_t vs1, vfloat16mf2_t vs2,
+                                        _Float16 vs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -324,7 +322,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmacc_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
-                                        float16_t vs1, vfloat16m1_t vs2,
+                                        _Float16 vs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -336,7 +334,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmacc_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
-                                        float16_t vs1, vfloat16m2_t vs2,
+                                        _Float16 vs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -348,7 +346,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmacc_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
-                                        float16_t vs1, vfloat16m4_t vs2,
+                                        _Float16 vs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/api-testing/vfwmsac.c
+++ b/auto-generated/api-testing/vfwmsac.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwmsac_vv_f32mf2(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwmsac_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1,
                                      vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2(vd, vs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwmsac_vv_f32m1(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwmsac_vf_f32m1(vfloat32m1_t vd, _Float16 vs1,
                                    vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m1(vd, vs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwmsac_vv_f32m2(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwmsac_vf_f32m2(vfloat32m2_t vd, _Float16 vs1,
                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m2(vd, vs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwmsac_vv_f32m4(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwmsac_vf_f32m4(vfloat32m4_t vd, _Float16 vs1,
                                    vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m4(vd, vs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwmsac_vv_f32m8(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwmsac_vf_f32m8(vfloat32m8_t vd, _Float16 vs1,
                                    vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m8(vd, vs1, vs2, vl);
 }
@@ -102,7 +102,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmsac_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
-                                       float16_t vs1, vfloat16mf4_t vs2,
+                                       _Float16 vs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_m(vm, vd, vs1, vs2, vl);
 }
@@ -114,7 +114,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmsac_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
-                                     float16_t vs1, vfloat16mf2_t vs2,
+                                     _Float16 vs1, vfloat16mf2_t vs2,
                                      size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_m(vm, vd, vs1, vs2, vl);
 }
@@ -126,7 +126,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmsac_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
-                                     float16_t vs1, vfloat16m1_t vs2,
+                                     _Float16 vs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_m(vm, vd, vs1, vs2, vl);
 }
@@ -137,9 +137,8 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
   return __riscv_vfwmsac_vv_f32m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
-                                     float16_t vs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -149,9 +148,8 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
   return __riscv_vfwmsac_vv_f32m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
-                                     float16_t vs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -208,7 +206,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwmsac_vv_f32mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -218,7 +216,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwmsac_vv_f32m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwmsac_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1,
                                       vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -228,7 +226,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwmsac_vv_f32m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwmsac_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -238,7 +236,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwmsac_vv_f32m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwmsac_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -248,7 +246,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwmsac_vv_f32m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwmsac_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -300,7 +298,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
-                                          float16_t vs1, vfloat16mf4_t vs2,
+                                          _Float16 vs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -312,7 +310,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmsac_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
-                                        float16_t vs1, vfloat16mf2_t vs2,
+                                        _Float16 vs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -324,7 +322,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmsac_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
-                                        float16_t vs1, vfloat16m1_t vs2,
+                                        _Float16 vs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -336,7 +334,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmsac_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
-                                        float16_t vs1, vfloat16m2_t vs2,
+                                        _Float16 vs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -348,7 +346,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmsac_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
-                                        float16_t vs1, vfloat16m4_t vs2,
+                                        _Float16 vs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/api-testing/vfwmul.c
+++ b/auto-generated/api-testing/vfwmul.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwmul_vv_f32mf2(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwmul_vf_f32mf2(vfloat16mf4_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfwmul_vf_f32mf2(vs2, rs1, vl);
 }
@@ -20,7 +20,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwmul_vv_f32m1(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m1(vs2, rs1, vl);
 }
 
@@ -29,7 +29,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwmul_vv_f32m2(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m2(vs2, rs1, vl);
 }
 
@@ -38,7 +38,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwmul_vv_f32m4(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m4(vs2, rs1, vl);
 }
 
@@ -47,7 +47,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwmul_vv_f32m8(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m8(vs2, rs1, vl);
 }
 
@@ -93,7 +93,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -103,7 +103,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m1_m(vm, vs2, rs1, vl);
 }
 
@@ -113,7 +113,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m2_m(vm, vs2, rs1, vl);
 }
 
@@ -122,8 +122,8 @@ vfloat32m4_t test_vfwmul_vv_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfwmul_vv_f32m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwmul_vf_f32m4_m(vm, vs2, rs1, vl);
 }
 
@@ -132,8 +132,8 @@ vfloat32m8_t test_vfwmul_vv_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfwmul_vv_f32m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwmul_vf_f32m8_m(vm, vs2, rs1, vl);
 }
 
@@ -182,7 +182,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwmul_vv_f32mf2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwmul_vf_f32mf2_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -192,7 +192,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwmul_vv_f32m1_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t test_vfwmul_vf_f32m1_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwmul_vf_f32m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -202,7 +202,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwmul_vv_f32m2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t test_vfwmul_vf_f32m2_rm(vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwmul_vf_f32m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -212,7 +212,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwmul_vv_f32m4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t test_vfwmul_vf_f32m4_rm(vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwmul_vf_f32m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -222,7 +222,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwmul_vv_f32m8_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t test_vfwmul_vf_f32m8_rm(vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwmul_vf_f32m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -273,7 +273,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -293,7 +293,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -303,7 +303,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
 }
 
 vfloat32m4_t test_vfwmul_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -313,7 +313,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
 }
 
 vfloat32m8_t test_vfwmul_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/api-testing/vfwnmacc.c
+++ b/auto-generated/api-testing/vfwnmacc.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmacc_vv_f32mf2(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1,
                                       vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2(vd, vs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwnmacc_vv_f32m1(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwnmacc_vf_f32m1(vfloat32m1_t vd, _Float16 vs1,
                                     vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1(vd, vs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwnmacc_vv_f32m2(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwnmacc_vf_f32m2(vfloat32m2_t vd, _Float16 vs1,
                                     vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2(vd, vs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwnmacc_vv_f32m4(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwnmacc_vf_f32m4(vfloat32m4_t vd, _Float16 vs1,
                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4(vd, vs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwnmacc_vv_f32m8(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwnmacc_vf_f32m8(vfloat32m8_t vd, _Float16 vs1,
                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8(vd, vs1, vs2, vl);
 }
@@ -102,7 +102,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmacc_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
-                                        float16_t vs1, vfloat16mf4_t vs2,
+                                        _Float16 vs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_m(vm, vd, vs1, vs2, vl);
 }
@@ -114,7 +114,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmacc_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
-                                      float16_t vs1, vfloat16mf2_t vs2,
+                                      _Float16 vs1, vfloat16mf2_t vs2,
                                       size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_m(vm, vd, vs1, vs2, vl);
 }
@@ -126,7 +126,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmacc_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
-                                      float16_t vs1, vfloat16m1_t vs2,
+                                      _Float16 vs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_m(vm, vd, vs1, vs2, vl);
 }
@@ -138,7 +138,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmacc_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
-                                      float16_t vs1, vfloat16m2_t vs2,
+                                      _Float16 vs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_m(vm, vd, vs1, vs2, vl);
 }
@@ -150,7 +150,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmacc_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
-                                      float16_t vs1, vfloat16m4_t vs2,
+                                      _Float16 vs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_m(vm, vd, vs1, vs2, vl);
 }
@@ -208,7 +208,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmacc_vv_f32mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1,
                                          vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -218,7 +218,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwnmacc_vv_f32m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwnmacc_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -228,7 +228,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwnmacc_vv_f32m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwnmacc_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1,
                                        vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -238,7 +238,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwnmacc_vv_f32m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwnmacc_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1,
                                        vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -248,7 +248,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwnmacc_vv_f32m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwnmacc_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1,
                                        vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -300,7 +300,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
-                                           float16_t vs1, vfloat16mf4_t vs2,
+                                           _Float16 vs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -312,7 +312,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
-                                         float16_t vs1, vfloat16mf2_t vs2,
+                                         _Float16 vs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -324,7 +324,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
-                                         float16_t vs1, vfloat16m1_t vs2,
+                                         _Float16 vs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -336,7 +336,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
-                                         float16_t vs1, vfloat16m2_t vs2,
+                                         _Float16 vs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -348,7 +348,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
-                                         float16_t vs1, vfloat16m4_t vs2,
+                                         _Float16 vs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/api-testing/vfwnmsac.c
+++ b/auto-generated/api-testing/vfwnmsac.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmsac_vv_f32mf2(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1,
                                       vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2(vd, vs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwnmsac_vv_f32m1(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwnmsac_vf_f32m1(vfloat32m1_t vd, _Float16 vs1,
                                     vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1(vd, vs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwnmsac_vv_f32m2(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwnmsac_vf_f32m2(vfloat32m2_t vd, _Float16 vs1,
                                     vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2(vd, vs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwnmsac_vv_f32m4(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwnmsac_vf_f32m4(vfloat32m4_t vd, _Float16 vs1,
                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4(vd, vs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwnmsac_vv_f32m8(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwnmsac_vf_f32m8(vfloat32m8_t vd, _Float16 vs1,
                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8(vd, vs1, vs2, vl);
 }
@@ -102,7 +102,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmsac_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
-                                        float16_t vs1, vfloat16mf4_t vs2,
+                                        _Float16 vs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_m(vm, vd, vs1, vs2, vl);
 }
@@ -114,7 +114,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmsac_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
-                                      float16_t vs1, vfloat16mf2_t vs2,
+                                      _Float16 vs1, vfloat16mf2_t vs2,
                                       size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_m(vm, vd, vs1, vs2, vl);
 }
@@ -126,7 +126,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmsac_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
-                                      float16_t vs1, vfloat16m1_t vs2,
+                                      _Float16 vs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_m(vm, vd, vs1, vs2, vl);
 }
@@ -138,7 +138,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmsac_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
-                                      float16_t vs1, vfloat16m2_t vs2,
+                                      _Float16 vs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_m(vm, vd, vs1, vs2, vl);
 }
@@ -150,7 +150,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmsac_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
-                                      float16_t vs1, vfloat16m4_t vs2,
+                                      _Float16 vs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_m(vm, vd, vs1, vs2, vl);
 }
@@ -208,7 +208,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmsac_vv_f32mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1,
                                          vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -218,7 +218,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwnmsac_vv_f32m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwnmsac_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -228,7 +228,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwnmsac_vv_f32m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwnmsac_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1,
                                        vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -238,7 +238,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwnmsac_vv_f32m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwnmsac_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1,
                                        vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -248,7 +248,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwnmsac_vv_f32m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwnmsac_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1,
                                        vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -300,7 +300,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
-                                           float16_t vs1, vfloat16mf4_t vs2,
+                                           _Float16 vs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -312,7 +312,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
-                                         float16_t vs1, vfloat16mf2_t vs2,
+                                         _Float16 vs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -324,7 +324,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
-                                         float16_t vs1, vfloat16m1_t vs2,
+                                         _Float16 vs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -336,7 +336,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
-                                         float16_t vs1, vfloat16m2_t vs2,
+                                         _Float16 vs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -348,7 +348,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
-                                         float16_t vs1, vfloat16m4_t vs2,
+                                         _Float16 vs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/api-testing/vfwsub.c
+++ b/auto-generated/api-testing/vfwsub.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwsub_vv_f32mf2(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwsub_vf_f32mf2(vfloat16mf4_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfwsub_vf_f32mf2(vs2, rs1, vl);
 }
@@ -20,7 +20,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwsub_wv_f32mf2(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwsub_wf_f32mf2(vfloat32mf2_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfwsub_wf_f32mf2(vs2, rs1, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwsub_vv_f32m1(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m1(vs2, rs1, vl);
 }
 
@@ -39,7 +39,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1(vfloat32m1_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwsub_wv_f32m1(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1(vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1(vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m1(vs2, rs1, vl);
 }
 
@@ -48,7 +48,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwsub_vv_f32m2(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m2(vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2(vfloat32m2_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwsub_wv_f32m2(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2(vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2(vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m2(vs2, rs1, vl);
 }
 
@@ -66,7 +66,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwsub_vv_f32m4(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m4(vs2, rs1, vl);
 }
 
@@ -75,7 +75,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4(vfloat32m4_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwsub_wv_f32m4(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4(vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4(vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m4(vs2, rs1, vl);
 }
 
@@ -84,7 +84,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwsub_vv_f32m8(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m8(vs2, rs1, vl);
 }
 
@@ -93,7 +93,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8(vfloat32m8_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwsub_wv_f32m8(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8(vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8(vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m8(vs2, rs1, vl);
 }
 
@@ -175,7 +175,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -185,7 +185,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -195,7 +195,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m1_m(vm, vs2, rs1, vl);
 }
 
@@ -205,7 +205,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m1_m(vm, vs2, rs1, vl);
 }
 
@@ -215,7 +215,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m2_m(vm, vs2, rs1, vl);
 }
 
@@ -225,7 +225,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_m(vbool16_t vm, vfloat32m2_t vs2,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m2_m(vm, vs2, rs1, vl);
 }
 
@@ -234,8 +234,8 @@ vfloat32m4_t test_vfwsub_vv_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfwsub_vv_f32m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwsub_vf_f32m4_m(vm, vs2, rs1, vl);
 }
 
@@ -244,8 +244,8 @@ vfloat32m4_t test_vfwsub_wv_f32m4_m(vbool8_t vm, vfloat32m4_t vs2,
   return __riscv_vfwsub_wv_f32m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwsub_wf_f32m4_m(vm, vs2, rs1, vl);
 }
 
@@ -254,8 +254,8 @@ vfloat32m8_t test_vfwsub_vv_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfwsub_vv_f32m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwsub_vf_f32m8_m(vm, vs2, rs1, vl);
 }
 
@@ -264,8 +264,8 @@ vfloat32m8_t test_vfwsub_wv_f32m8_m(vbool4_t vm, vfloat32m8_t vs2,
   return __riscv_vfwsub_wv_f32m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwsub_wf_f32m8_m(vm, vs2, rs1, vl);
 }
 
@@ -354,7 +354,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwsub_vv_f32mf2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwsub_vf_f32mf2_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -364,7 +364,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwsub_wv_f32mf2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_rm(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwsub_wf_f32mf2_rm(vfloat32mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -374,7 +374,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwsub_vv_f32m1_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t test_vfwsub_vf_f32m1_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_vf_f32m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -384,7 +384,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm(vfloat32m1_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwsub_wv_f32m1_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_rm(vfloat32m1_t vs2, float16_t rs1,
+vfloat32m1_t test_vfwsub_wf_f32m1_rm(vfloat32m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_wf_f32m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -394,7 +394,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwsub_vv_f32m2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t test_vfwsub_vf_f32m2_rm(vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_vf_f32m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -404,7 +404,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm(vfloat32m2_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwsub_wv_f32m2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_rm(vfloat32m2_t vs2, float16_t rs1,
+vfloat32m2_t test_vfwsub_wf_f32m2_rm(vfloat32m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_wf_f32m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -414,7 +414,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwsub_vv_f32m4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t test_vfwsub_vf_f32m4_rm(vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_vf_f32m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -424,7 +424,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm(vfloat32m4_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwsub_wv_f32m4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_rm(vfloat32m4_t vs2, float16_t rs1,
+vfloat32m4_t test_vfwsub_wf_f32m4_rm(vfloat32m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_wf_f32m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -434,7 +434,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwsub_vv_f32m8_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t test_vfwsub_vf_f32m8_rm(vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_vf_f32m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -444,7 +444,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm(vfloat32m8_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwsub_wv_f32m8_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_rm(vfloat32m8_t vs2, float16_t rs1,
+vfloat32m8_t test_vfwsub_wf_f32m8_rm(vfloat32m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_wf_f32m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -535,7 +535,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -545,7 +545,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -555,7 +555,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -565,7 +565,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -575,7 +575,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -585,7 +585,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -595,7 +595,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
 }
 
 vfloat32m4_t test_vfwsub_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -605,7 +605,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2,
 }
 
 vfloat32m4_t test_vfwsub_wf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -615,7 +615,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
 }
 
 vfloat32m8_t test_vfwsub_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -625,7 +625,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2,
 }
 
 vfloat32m8_t test_vfwsub_wf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/api-testing/vmfeq.c
+++ b/auto-generated/api-testing/vmfeq.c
@@ -10,8 +10,7 @@ vbool64_t test_vmfeq_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vmfeq_vv_f16mf4_b64(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfeq_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool64_t test_vmfeq_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16mf4_b64(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vbool32_t test_vmfeq_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vmfeq_vv_f16mf2_b32(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfeq_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool32_t test_vmfeq_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16mf2_b32(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vbool16_t test_vmfeq_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vmfeq_vv_f16m1_b16(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfeq_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfeq_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m1_b16(vs2, rs1, vl);
 }
 
@@ -38,7 +36,7 @@ vbool8_t test_vmfeq_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfeq_vv_f16m2_b8(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfeq_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfeq_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m2_b8(vs2, rs1, vl);
 }
 
@@ -46,7 +44,7 @@ vbool4_t test_vmfeq_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfeq_vv_f16m4_b4(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfeq_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfeq_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m4_b4(vs2, rs1, vl);
 }
 
@@ -54,7 +52,7 @@ vbool2_t test_vmfeq_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfeq_vv_f16m8_b2(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfeq_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfeq_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m8_b2(vs2, rs1, vl);
 }
 
@@ -143,7 +141,7 @@ vbool64_t test_vmfeq_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vbool64_t test_vmfeq_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16mf4_b64_m(vm, vs2, rs1, vl);
 }
 
@@ -153,7 +151,7 @@ vbool32_t test_vmfeq_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vbool32_t test_vmfeq_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16mf2_b32_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +161,7 @@ vbool16_t test_vmfeq_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vbool16_t test_vmfeq_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m1_b16_m(vm, vs2, rs1, vl);
 }
 
@@ -172,7 +170,7 @@ vbool8_t test_vmfeq_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vmfeq_vv_f16m2_b8_m(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfeq_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vbool8_t test_vmfeq_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfeq_vf_f16m2_b8_m(vm, vs2, rs1, vl);
 }
@@ -182,7 +180,7 @@ vbool4_t test_vmfeq_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vmfeq_vv_f16m4_b4_m(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfeq_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vbool4_t test_vmfeq_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfeq_vf_f16m4_b4_m(vm, vs2, rs1, vl);
 }
@@ -192,7 +190,7 @@ vbool2_t test_vmfeq_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vmfeq_vv_f16m8_b2_m(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfeq_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vbool2_t test_vmfeq_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfeq_vf_f16m8_b2_m(vm, vs2, rs1, vl);
 }

--- a/auto-generated/api-testing/vmfge.c
+++ b/auto-generated/api-testing/vmfge.c
@@ -10,8 +10,7 @@ vbool64_t test_vmfge_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vmfge_vv_f16mf4_b64(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfge_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool64_t test_vmfge_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16mf4_b64(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vbool32_t test_vmfge_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vmfge_vv_f16mf2_b32(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfge_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool32_t test_vmfge_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16mf2_b32(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vbool16_t test_vmfge_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vmfge_vv_f16m1_b16(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfge_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfge_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m1_b16(vs2, rs1, vl);
 }
 
@@ -38,7 +36,7 @@ vbool8_t test_vmfge_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfge_vv_f16m2_b8(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfge_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfge_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m2_b8(vs2, rs1, vl);
 }
 
@@ -46,7 +44,7 @@ vbool4_t test_vmfge_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfge_vv_f16m4_b4(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfge_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfge_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m4_b4(vs2, rs1, vl);
 }
 
@@ -54,7 +52,7 @@ vbool2_t test_vmfge_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfge_vv_f16m8_b2(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfge_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfge_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m8_b2(vs2, rs1, vl);
 }
 
@@ -143,7 +141,7 @@ vbool64_t test_vmfge_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vbool64_t test_vmfge_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16mf4_b64_m(vm, vs2, rs1, vl);
 }
 
@@ -153,7 +151,7 @@ vbool32_t test_vmfge_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vbool32_t test_vmfge_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16mf2_b32_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +161,7 @@ vbool16_t test_vmfge_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vbool16_t test_vmfge_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m1_b16_m(vm, vs2, rs1, vl);
 }
 
@@ -172,7 +170,7 @@ vbool8_t test_vmfge_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vmfge_vv_f16m2_b8_m(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfge_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vbool8_t test_vmfge_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfge_vf_f16m2_b8_m(vm, vs2, rs1, vl);
 }
@@ -182,7 +180,7 @@ vbool4_t test_vmfge_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vmfge_vv_f16m4_b4_m(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfge_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vbool4_t test_vmfge_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfge_vf_f16m4_b4_m(vm, vs2, rs1, vl);
 }
@@ -192,7 +190,7 @@ vbool2_t test_vmfge_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vmfge_vv_f16m8_b2_m(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfge_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vbool2_t test_vmfge_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfge_vf_f16m8_b2_m(vm, vs2, rs1, vl);
 }

--- a/auto-generated/api-testing/vmfgt.c
+++ b/auto-generated/api-testing/vmfgt.c
@@ -10,8 +10,7 @@ vbool64_t test_vmfgt_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vmfgt_vv_f16mf4_b64(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfgt_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool64_t test_vmfgt_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16mf4_b64(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vbool32_t test_vmfgt_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vmfgt_vv_f16mf2_b32(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfgt_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool32_t test_vmfgt_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16mf2_b32(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vbool16_t test_vmfgt_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vmfgt_vv_f16m1_b16(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfgt_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfgt_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m1_b16(vs2, rs1, vl);
 }
 
@@ -38,7 +36,7 @@ vbool8_t test_vmfgt_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfgt_vv_f16m2_b8(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfgt_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfgt_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m2_b8(vs2, rs1, vl);
 }
 
@@ -46,7 +44,7 @@ vbool4_t test_vmfgt_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfgt_vv_f16m4_b4(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfgt_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfgt_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m4_b4(vs2, rs1, vl);
 }
 
@@ -54,7 +52,7 @@ vbool2_t test_vmfgt_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfgt_vv_f16m8_b2(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfgt_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfgt_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m8_b2(vs2, rs1, vl);
 }
 
@@ -143,7 +141,7 @@ vbool64_t test_vmfgt_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vbool64_t test_vmfgt_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16mf4_b64_m(vm, vs2, rs1, vl);
 }
 
@@ -153,7 +151,7 @@ vbool32_t test_vmfgt_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vbool32_t test_vmfgt_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16mf2_b32_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +161,7 @@ vbool16_t test_vmfgt_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vbool16_t test_vmfgt_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m1_b16_m(vm, vs2, rs1, vl);
 }
 
@@ -172,7 +170,7 @@ vbool8_t test_vmfgt_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vmfgt_vv_f16m2_b8_m(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfgt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vbool8_t test_vmfgt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfgt_vf_f16m2_b8_m(vm, vs2, rs1, vl);
 }
@@ -182,7 +180,7 @@ vbool4_t test_vmfgt_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vmfgt_vv_f16m4_b4_m(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfgt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vbool4_t test_vmfgt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfgt_vf_f16m4_b4_m(vm, vs2, rs1, vl);
 }
@@ -192,7 +190,7 @@ vbool2_t test_vmfgt_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vmfgt_vv_f16m8_b2_m(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfgt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vbool2_t test_vmfgt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfgt_vf_f16m8_b2_m(vm, vs2, rs1, vl);
 }

--- a/auto-generated/api-testing/vmfle.c
+++ b/auto-generated/api-testing/vmfle.c
@@ -10,8 +10,7 @@ vbool64_t test_vmfle_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vmfle_vv_f16mf4_b64(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfle_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool64_t test_vmfle_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16mf4_b64(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vbool32_t test_vmfle_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vmfle_vv_f16mf2_b32(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfle_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool32_t test_vmfle_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16mf2_b32(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vbool16_t test_vmfle_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vmfle_vv_f16m1_b16(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfle_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfle_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m1_b16(vs2, rs1, vl);
 }
 
@@ -38,7 +36,7 @@ vbool8_t test_vmfle_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfle_vv_f16m2_b8(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfle_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfle_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m2_b8(vs2, rs1, vl);
 }
 
@@ -46,7 +44,7 @@ vbool4_t test_vmfle_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfle_vv_f16m4_b4(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfle_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfle_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m4_b4(vs2, rs1, vl);
 }
 
@@ -54,7 +52,7 @@ vbool2_t test_vmfle_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfle_vv_f16m8_b2(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfle_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfle_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m8_b2(vs2, rs1, vl);
 }
 
@@ -143,7 +141,7 @@ vbool64_t test_vmfle_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vbool64_t test_vmfle_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16mf4_b64_m(vm, vs2, rs1, vl);
 }
 
@@ -153,7 +151,7 @@ vbool32_t test_vmfle_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vbool32_t test_vmfle_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16mf2_b32_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +161,7 @@ vbool16_t test_vmfle_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vbool16_t test_vmfle_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m1_b16_m(vm, vs2, rs1, vl);
 }
 
@@ -172,7 +170,7 @@ vbool8_t test_vmfle_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vmfle_vv_f16m2_b8_m(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfle_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vbool8_t test_vmfle_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfle_vf_f16m2_b8_m(vm, vs2, rs1, vl);
 }
@@ -182,7 +180,7 @@ vbool4_t test_vmfle_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vmfle_vv_f16m4_b4_m(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfle_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vbool4_t test_vmfle_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfle_vf_f16m4_b4_m(vm, vs2, rs1, vl);
 }
@@ -192,7 +190,7 @@ vbool2_t test_vmfle_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vmfle_vv_f16m8_b2_m(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfle_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vbool2_t test_vmfle_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfle_vf_f16m8_b2_m(vm, vs2, rs1, vl);
 }

--- a/auto-generated/api-testing/vmflt.c
+++ b/auto-generated/api-testing/vmflt.c
@@ -10,8 +10,7 @@ vbool64_t test_vmflt_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vmflt_vv_f16mf4_b64(vs2, vs1, vl);
 }
 
-vbool64_t test_vmflt_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool64_t test_vmflt_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16mf4_b64(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vbool32_t test_vmflt_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vmflt_vv_f16mf2_b32(vs2, vs1, vl);
 }
 
-vbool32_t test_vmflt_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool32_t test_vmflt_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16mf2_b32(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vbool16_t test_vmflt_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vmflt_vv_f16m1_b16(vs2, vs1, vl);
 }
 
-vbool16_t test_vmflt_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmflt_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m1_b16(vs2, rs1, vl);
 }
 
@@ -38,7 +36,7 @@ vbool8_t test_vmflt_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmflt_vv_f16m2_b8(vs2, vs1, vl);
 }
 
-vbool8_t test_vmflt_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmflt_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m2_b8(vs2, rs1, vl);
 }
 
@@ -46,7 +44,7 @@ vbool4_t test_vmflt_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmflt_vv_f16m4_b4(vs2, vs1, vl);
 }
 
-vbool4_t test_vmflt_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmflt_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m4_b4(vs2, rs1, vl);
 }
 
@@ -54,7 +52,7 @@ vbool2_t test_vmflt_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmflt_vv_f16m8_b2(vs2, vs1, vl);
 }
 
-vbool2_t test_vmflt_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmflt_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m8_b2(vs2, rs1, vl);
 }
 
@@ -143,7 +141,7 @@ vbool64_t test_vmflt_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vbool64_t test_vmflt_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16mf4_b64_m(vm, vs2, rs1, vl);
 }
 
@@ -153,7 +151,7 @@ vbool32_t test_vmflt_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vbool32_t test_vmflt_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16mf2_b32_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +161,7 @@ vbool16_t test_vmflt_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vbool16_t test_vmflt_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m1_b16_m(vm, vs2, rs1, vl);
 }
 
@@ -172,7 +170,7 @@ vbool8_t test_vmflt_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vmflt_vv_f16m2_b8_m(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmflt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vbool8_t test_vmflt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmflt_vf_f16m2_b8_m(vm, vs2, rs1, vl);
 }
@@ -182,7 +180,7 @@ vbool4_t test_vmflt_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vmflt_vv_f16m4_b4_m(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmflt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vbool4_t test_vmflt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmflt_vf_f16m4_b4_m(vm, vs2, rs1, vl);
 }
@@ -192,7 +190,7 @@ vbool2_t test_vmflt_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vmflt_vv_f16m8_b2_m(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmflt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vbool2_t test_vmflt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmflt_vf_f16m8_b2_m(vm, vs2, rs1, vl);
 }

--- a/auto-generated/api-testing/vmfne.c
+++ b/auto-generated/api-testing/vmfne.c
@@ -10,8 +10,7 @@ vbool64_t test_vmfne_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vmfne_vv_f16mf4_b64(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfne_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool64_t test_vmfne_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16mf4_b64(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vbool32_t test_vmfne_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vmfne_vv_f16mf2_b32(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfne_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool32_t test_vmfne_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16mf2_b32(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vbool16_t test_vmfne_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vmfne_vv_f16m1_b16(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfne_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfne_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m1_b16(vs2, rs1, vl);
 }
 
@@ -38,7 +36,7 @@ vbool8_t test_vmfne_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfne_vv_f16m2_b8(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfne_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfne_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m2_b8(vs2, rs1, vl);
 }
 
@@ -46,7 +44,7 @@ vbool4_t test_vmfne_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfne_vv_f16m4_b4(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfne_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfne_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m4_b4(vs2, rs1, vl);
 }
 
@@ -54,7 +52,7 @@ vbool2_t test_vmfne_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfne_vv_f16m8_b2(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfne_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfne_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m8_b2(vs2, rs1, vl);
 }
 
@@ -143,7 +141,7 @@ vbool64_t test_vmfne_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vbool64_t test_vmfne_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16mf4_b64_m(vm, vs2, rs1, vl);
 }
 
@@ -153,7 +151,7 @@ vbool32_t test_vmfne_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vbool32_t test_vmfne_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16mf2_b32_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +161,7 @@ vbool16_t test_vmfne_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vbool16_t test_vmfne_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m1_b16_m(vm, vs2, rs1, vl);
 }
 
@@ -172,7 +170,7 @@ vbool8_t test_vmfne_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vmfne_vv_f16m2_b8_m(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfne_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vbool8_t test_vmfne_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfne_vf_f16m2_b8_m(vm, vs2, rs1, vl);
 }
@@ -182,7 +180,7 @@ vbool4_t test_vmfne_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vmfne_vv_f16m4_b4_m(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfne_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vbool4_t test_vmfne_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfne_vf_f16m4_b4_m(vm, vs2, rs1, vl);
 }
@@ -192,7 +190,7 @@ vbool2_t test_vmfne_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vmfne_vv_f16m8_b2_m(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfne_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vbool2_t test_vmfne_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfne_vf_f16m8_b2_m(vm, vs2, rs1, vl);
 }

--- a/auto-generated/gnu-api-tests/vcpop.c
+++ b/auto-generated/gnu-api-tests/vcpop.c
@@ -7,59 +7,59 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-unsigned long test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vcpop_m_b1(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vcpop_m_b2(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vcpop_m_b4(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vcpop_m_b8(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vcpop_m_b16(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vcpop_m_b32(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vcpop_m_b64(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vcpop_m_b1_m(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vcpop_m_b2_m(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vcpop_m_b4_m(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vcpop_m_b8_m(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vcpop_m_b16_m(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vcpop_m_b32_m(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vcpop_m_b64_m(vm, vs2, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vcpop\.[ivxfswum.]+\s+} 14 } } */

--- a/auto-generated/gnu-api-tests/vfadd.c
+++ b/auto-generated/gnu-api-tests/vfadd.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vfadd_vv_f16mf4(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf4(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vfadd_vv_f16mf2(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf2(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfadd_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl) 
   return __riscv_vfadd_vv_f16m1(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m1(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfadd_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) 
   return __riscv_vfadd_vv_f16m2(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m2(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfadd_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) 
   return __riscv_vfadd_vv_f16m4(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m4(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfadd_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) 
   return __riscv_vfadd_vv_f16m8(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vfadd_vv_f16mf4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vfadd_vv_f16mf2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t 
   return __riscv_vfadd_vv_f16m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t v
   return __riscv_vfadd_vv_f16m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t v
   return __riscv_vfadd_vv_f16m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t v
   return __riscv_vfadd_vv_f16m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size
   return __riscv_vfadd_vv_f16mf4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size
   return __riscv_vfadd_vv_f16mf2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t v
   return __riscv_vfadd_vv_f16m1_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t v
   return __riscv_vfadd_vv_f16m2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t v
   return __riscv_vfadd_vv_f16m4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t v
   return __riscv_vfadd_vv_f16m8_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat1
   return __riscv_vfadd_vv_f16mf4_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat1
   return __riscv_vfadd_vv_f16mf2_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1
   return __riscv_vfadd_vv_f16m1_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_
   return __riscv_vfadd_vv_f16m2_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_
   return __riscv_vfadd_vv_f16m4_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_
   return __riscv_vfadd_vv_f16m8_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfdiv.c
+++ b/auto-generated/gnu-api-tests/vfdiv.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vfdiv_vv_f16mf4(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf4(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vfdiv_vv_f16mf2(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf2(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl) 
   return __riscv_vfdiv_vv_f16m1(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m1(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) 
   return __riscv_vfdiv_vv_f16m2(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m2(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) 
   return __riscv_vfdiv_vv_f16m4(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m4(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) 
   return __riscv_vfdiv_vv_f16m8(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vfdiv_vv_f16mf4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vfdiv_vv_f16mf2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t 
   return __riscv_vfdiv_vv_f16m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t v
   return __riscv_vfdiv_vv_f16m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t v
   return __riscv_vfdiv_vv_f16m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t v
   return __riscv_vfdiv_vv_f16m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size
   return __riscv_vfdiv_vv_f16mf4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size
   return __riscv_vfdiv_vv_f16mf2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t v
   return __riscv_vfdiv_vv_f16m1_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t v
   return __riscv_vfdiv_vv_f16m2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t v
   return __riscv_vfdiv_vv_f16m4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t v
   return __riscv_vfdiv_vv_f16m8_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat1
   return __riscv_vfdiv_vv_f16mf4_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat1
   return __riscv_vfdiv_vv_f16mf2_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1
   return __riscv_vfdiv_vv_f16m1_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_
   return __riscv_vfdiv_vv_f16m2_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_
   return __riscv_vfdiv_vv_f16m4_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_
   return __riscv_vfdiv_vv_f16m8_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfirst.c
+++ b/auto-generated/gnu-api-tests/vfirst.c
@@ -7,59 +7,59 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-long test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
+int test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vfirst_m_b1(vs2, vl);
 }
 
-long test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
+int test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vfirst_m_b2(vs2, vl);
 }
 
-long test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
+int test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vfirst_m_b4(vs2, vl);
 }
 
-long test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
+int test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vfirst_m_b8(vs2, vl);
 }
 
-long test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
+int test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vfirst_m_b16(vs2, vl);
 }
 
-long test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
+int test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vfirst_m_b32(vs2, vl);
 }
 
-long test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
+int test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vfirst_m_b64(vs2, vl);
 }
 
-long test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+int test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vfirst_m_b1_m(vm, vs2, vl);
 }
 
-long test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+int test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vfirst_m_b2_m(vm, vs2, vl);
 }
 
-long test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+int test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vfirst_m_b4_m(vm, vs2, vl);
 }
 
-long test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+int test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vfirst_m_b8_m(vm, vs2, vl);
 }
 
-long test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+int test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vfirst_m_b16_m(vm, vs2, vl);
 }
 
-long test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+int test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vfirst_m_b32_m(vm, vs2, vl);
 }
 
-long test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+int test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vfirst_m_b64_m(vm, vs2, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfirst\.[ivxfswum.]+\s+} 14 } } */

--- a/auto-generated/gnu-api-tests/vfmacc.c
+++ b/auto-generated/gnu-api-tests/vfmacc.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfloat1
   return __riscv_vfmacc_vv_f16mf4(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf4(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfloat1
   return __riscv_vfmacc_vv_f16mf2(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf2(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_
   return __riscv_vfmacc_vv_f16m1(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m1(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_
   return __riscv_vfmacc_vv_f16m2(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m2(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_
   return __riscv_vfmacc_vv_f16m4(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m4(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_
   return __riscv_vfmacc_vv_f16m8(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m8(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfmacc_vv_f16mf4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfmacc_vv_f16mf2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfmacc_vv_f16m1_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m1_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfmacc_vv_f16m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfmacc_vv_f16m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfmacc_vv_f16m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m8_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1, vflo
   return __riscv_vfmacc_vv_f16mf4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1, vflo
   return __riscv_vfmacc_vv_f16mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16
   return __riscv_vfmacc_vv_f16m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m1_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16
   return __riscv_vfmacc_vv_f16m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16
   return __riscv_vfmacc_vv_f16m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16
   return __riscv_vfmacc_vv_f16m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m8_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfmacc_vv_f16mf4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfmacc_vv_f16mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfmacc_vv_f16m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m1_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfmacc_vv_f16m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfmacc_vv_f16m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfmacc_vv_f16m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m8_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfmadd.c
+++ b/auto-generated/gnu-api-tests/vfmadd.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfloat1
   return __riscv_vfmadd_vv_f16mf4(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf4(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfloat1
   return __riscv_vfmadd_vv_f16mf2(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf2(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_
   return __riscv_vfmadd_vv_f16m1(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m1(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_
   return __riscv_vfmadd_vv_f16m2(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m2(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_
   return __riscv_vfmadd_vv_f16m4(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m4(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_
   return __riscv_vfmadd_vv_f16m8(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m8(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfmadd_vv_f16mf4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfmadd_vv_f16mf2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfmadd_vv_f16m1_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m1_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfmadd_vv_f16m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfmadd_vv_f16m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfmadd_vv_f16m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m8_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1, vflo
   return __riscv_vfmadd_vv_f16mf4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1, vflo
   return __riscv_vfmadd_vv_f16mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16
   return __riscv_vfmadd_vv_f16m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m1_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16
   return __riscv_vfmadd_vv_f16m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16
   return __riscv_vfmadd_vv_f16m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16
   return __riscv_vfmadd_vv_f16m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m8_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfmadd_vv_f16mf4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfmadd_vv_f16mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfmadd_vv_f16m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m1_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfmadd_vv_f16m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfmadd_vv_f16m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfmadd_vv_f16m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m8_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfmax.c
+++ b/auto-generated/gnu-api-tests/vfmax.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vfmax_vv_f16mf4(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmax_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmax_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16mf4(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vfmax_vv_f16mf2(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmax_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmax_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16mf2(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmax_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl) 
   return __riscv_vfmax_vv_f16m1(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmax_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmax_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m1(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmax_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) 
   return __riscv_vfmax_vv_f16m2(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmax_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmax_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m2(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmax_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) 
   return __riscv_vfmax_vv_f16m4(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmax_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmax_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m4(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmax_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) 
   return __riscv_vfmax_vv_f16m8(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmax_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmax_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vfmax_vv_f16mf4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmax_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmax_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vfmax_vv_f16mf2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmax_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmax_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmax_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t 
   return __riscv_vfmax_vv_f16m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmax_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmax_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t v
   return __riscv_vfmax_vv_f16m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmax_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmax_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t v
   return __riscv_vfmax_vv_f16m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmax_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmax_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t v
   return __riscv_vfmax_vv_f16m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmax_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmax_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfmerge.c
+++ b/auto-generated/gnu-api-tests/vfmerge.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfmerge_vfm_f16mf4(vfloat16mf4_t vs2, float16_t rs1, vbool64_t v0, size_t vl) {
+vfloat16mf4_t test_vfmerge_vfm_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, vbool64_t v0, size_t vl) {
   return __riscv_vfmerge_vfm_f16mf4(vs2, rs1, v0, vl);
 }
 
-vfloat16mf2_t test_vfmerge_vfm_f16mf2(vfloat16mf2_t vs2, float16_t rs1, vbool32_t v0, size_t vl) {
+vfloat16mf2_t test_vfmerge_vfm_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, vbool32_t v0, size_t vl) {
   return __riscv_vfmerge_vfm_f16mf2(vs2, rs1, v0, vl);
 }
 
-vfloat16m1_t test_vfmerge_vfm_f16m1(vfloat16m1_t vs2, float16_t rs1, vbool16_t v0, size_t vl) {
+vfloat16m1_t test_vfmerge_vfm_f16m1(vfloat16m1_t vs2, _Float16 rs1, vbool16_t v0, size_t vl) {
   return __riscv_vfmerge_vfm_f16m1(vs2, rs1, v0, vl);
 }
 
-vfloat16m2_t test_vfmerge_vfm_f16m2(vfloat16m2_t vs2, float16_t rs1, vbool8_t v0, size_t vl) {
+vfloat16m2_t test_vfmerge_vfm_f16m2(vfloat16m2_t vs2, _Float16 rs1, vbool8_t v0, size_t vl) {
   return __riscv_vfmerge_vfm_f16m2(vs2, rs1, v0, vl);
 }
 
-vfloat16m4_t test_vfmerge_vfm_f16m4(vfloat16m4_t vs2, float16_t rs1, vbool4_t v0, size_t vl) {
+vfloat16m4_t test_vfmerge_vfm_f16m4(vfloat16m4_t vs2, _Float16 rs1, vbool4_t v0, size_t vl) {
   return __riscv_vfmerge_vfm_f16m4(vs2, rs1, v0, vl);
 }
 
-vfloat16m8_t test_vfmerge_vfm_f16m8(vfloat16m8_t vs2, float16_t rs1, vbool2_t v0, size_t vl) {
+vfloat16m8_t test_vfmerge_vfm_f16m8(vfloat16m8_t vs2, _Float16 rs1, vbool2_t v0, size_t vl) {
   return __riscv_vfmerge_vfm_f16m8(vs2, rs1, v0, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfmin.c
+++ b/auto-generated/gnu-api-tests/vfmin.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vfmin_vv_f16mf4(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmin_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmin_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16mf4(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vfmin_vv_f16mf2(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmin_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmin_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16mf2(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmin_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl) 
   return __riscv_vfmin_vv_f16m1(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmin_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmin_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m1(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmin_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) 
   return __riscv_vfmin_vv_f16m2(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmin_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmin_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m2(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmin_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) 
   return __riscv_vfmin_vv_f16m4(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmin_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmin_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m4(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmin_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) 
   return __riscv_vfmin_vv_f16m8(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmin_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmin_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vfmin_vv_f16mf4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmin_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmin_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vfmin_vv_f16mf2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmin_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmin_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmin_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t 
   return __riscv_vfmin_vv_f16m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmin_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmin_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t v
   return __riscv_vfmin_vv_f16m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmin_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmin_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t v
   return __riscv_vfmin_vv_f16m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmin_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmin_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t v
   return __riscv_vfmin_vv_f16m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmin_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmin_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfmsac.c
+++ b/auto-generated/gnu-api-tests/vfmsac.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfloat1
   return __riscv_vfmsac_vv_f16mf4(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf4(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfloat1
   return __riscv_vfmsac_vv_f16mf2(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf2(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_
   return __riscv_vfmsac_vv_f16m1(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m1(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_
   return __riscv_vfmsac_vv_f16m2(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m2(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_
   return __riscv_vfmsac_vv_f16m4(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m4(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_
   return __riscv_vfmsac_vv_f16m8(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m8(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfmsac_vv_f16mf4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfmsac_vv_f16mf2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfmsac_vv_f16m1_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m1_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfmsac_vv_f16m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfmsac_vv_f16m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfmsac_vv_f16m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m8_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1, vflo
   return __riscv_vfmsac_vv_f16mf4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1, vflo
   return __riscv_vfmsac_vv_f16mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16
   return __riscv_vfmsac_vv_f16m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m1_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16
   return __riscv_vfmsac_vv_f16m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16
   return __riscv_vfmsac_vv_f16m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16
   return __riscv_vfmsac_vv_f16m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m8_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfmsac_vv_f16mf4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfmsac_vv_f16mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfmsac_vv_f16m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m1_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfmsac_vv_f16m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfmsac_vv_f16m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfmsac_vv_f16m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m8_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfmsub.c
+++ b/auto-generated/gnu-api-tests/vfmsub.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfloat1
   return __riscv_vfmsub_vv_f16mf4(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf4(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfloat1
   return __riscv_vfmsub_vv_f16mf2(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf2(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_
   return __riscv_vfmsub_vv_f16m1(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m1(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_
   return __riscv_vfmsub_vv_f16m2(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m2(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_
   return __riscv_vfmsub_vv_f16m4(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m4(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_
   return __riscv_vfmsub_vv_f16m8(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m8(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfmsub_vv_f16mf4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfmsub_vv_f16mf2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfmsub_vv_f16m1_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m1_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfmsub_vv_f16m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfmsub_vv_f16m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfmsub_vv_f16m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m8_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1, vflo
   return __riscv_vfmsub_vv_f16mf4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1, vflo
   return __riscv_vfmsub_vv_f16mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16
   return __riscv_vfmsub_vv_f16m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m1_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16
   return __riscv_vfmsub_vv_f16m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16
   return __riscv_vfmsub_vv_f16m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16
   return __riscv_vfmsub_vv_f16m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m8_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfmsub_vv_f16mf4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfmsub_vv_f16mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfmsub_vv_f16m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m1_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfmsub_vv_f16m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfmsub_vv_f16m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfmsub_vv_f16m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m8_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfmul.c
+++ b/auto-generated/gnu-api-tests/vfmul.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vfmul_vv_f16mf4(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf4(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vfmul_vv_f16mf2(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf2(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmul_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl) 
   return __riscv_vfmul_vv_f16m1(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m1(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmul_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) 
   return __riscv_vfmul_vv_f16m2(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m2(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmul_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) 
   return __riscv_vfmul_vv_f16m4(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m4(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmul_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) 
   return __riscv_vfmul_vv_f16m8(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vfmul_vv_f16mf4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vfmul_vv_f16mf2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t 
   return __riscv_vfmul_vv_f16m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t v
   return __riscv_vfmul_vv_f16m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t v
   return __riscv_vfmul_vv_f16m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t v
   return __riscv_vfmul_vv_f16m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size
   return __riscv_vfmul_vv_f16mf4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size
   return __riscv_vfmul_vv_f16mf2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t v
   return __riscv_vfmul_vv_f16m1_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t v
   return __riscv_vfmul_vv_f16m2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t v
   return __riscv_vfmul_vv_f16m4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t v
   return __riscv_vfmul_vv_f16m8_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat1
   return __riscv_vfmul_vv_f16mf4_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat1
   return __riscv_vfmul_vv_f16mf2_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1
   return __riscv_vfmul_vv_f16m1_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_
   return __riscv_vfmul_vv_f16m2_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_
   return __riscv_vfmul_vv_f16m4_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_
   return __riscv_vfmul_vv_f16m8_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfmv.c
+++ b/auto-generated/gnu-api-tests/vfmv.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfmv_v_f_f16mf4(float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmv_v_f_f16mf4(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16mf4(rs1, vl);
 }
 
-vfloat16mf2_t test_vfmv_v_f_f16mf2(float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmv_v_f_f16mf2(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16mf2(rs1, vl);
 }
 
-vfloat16m1_t test_vfmv_v_f_f16m1(float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmv_v_f_f16m1(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16m1(rs1, vl);
 }
 
-vfloat16m2_t test_vfmv_v_f_f16m2(float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmv_v_f_f16m2(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16m2(rs1, vl);
 }
 
-vfloat16m4_t test_vfmv_v_f_f16m4(float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmv_v_f_f16m4(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16m4(rs1, vl);
 }
 
-vfloat16m8_t test_vfmv_v_f_f16m8(float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmv_v_f_f16m8(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16m8(rs1, vl);
 }
 
@@ -67,51 +67,51 @@ vfloat64m8_t test_vfmv_v_f_f64m8(float64_t rs1, size_t vl) {
   return __riscv_vfmv_v_f_f64m8(rs1, vl);
 }
 
-float16_t test_vfmv_f_s_f16mf4_f16(vfloat16mf4_t vs1) {
+_Float16 test_vfmv_f_s_f16mf4_f16(vfloat16mf4_t vs1) {
   return __riscv_vfmv_f_s_f16mf4_f16(vs1);
 }
 
-vfloat16mf4_t test_vfmv_s_f_f16mf4(float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmv_s_f_f16mf4(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16mf4(rs1, vl);
 }
 
-float16_t test_vfmv_f_s_f16mf2_f16(vfloat16mf2_t vs1) {
+_Float16 test_vfmv_f_s_f16mf2_f16(vfloat16mf2_t vs1) {
   return __riscv_vfmv_f_s_f16mf2_f16(vs1);
 }
 
-vfloat16mf2_t test_vfmv_s_f_f16mf2(float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmv_s_f_f16mf2(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16mf2(rs1, vl);
 }
 
-float16_t test_vfmv_f_s_f16m1_f16(vfloat16m1_t vs1) {
+_Float16 test_vfmv_f_s_f16m1_f16(vfloat16m1_t vs1) {
   return __riscv_vfmv_f_s_f16m1_f16(vs1);
 }
 
-vfloat16m1_t test_vfmv_s_f_f16m1(float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmv_s_f_f16m1(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16m1(rs1, vl);
 }
 
-float16_t test_vfmv_f_s_f16m2_f16(vfloat16m2_t vs1) {
+_Float16 test_vfmv_f_s_f16m2_f16(vfloat16m2_t vs1) {
   return __riscv_vfmv_f_s_f16m2_f16(vs1);
 }
 
-vfloat16m2_t test_vfmv_s_f_f16m2(float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmv_s_f_f16m2(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16m2(rs1, vl);
 }
 
-float16_t test_vfmv_f_s_f16m4_f16(vfloat16m4_t vs1) {
+_Float16 test_vfmv_f_s_f16m4_f16(vfloat16m4_t vs1) {
   return __riscv_vfmv_f_s_f16m4_f16(vs1);
 }
 
-vfloat16m4_t test_vfmv_s_f_f16m4(float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmv_s_f_f16m4(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16m4(rs1, vl);
 }
 
-float16_t test_vfmv_f_s_f16m8_f16(vfloat16m8_t vs1) {
+_Float16 test_vfmv_f_s_f16m8_f16(vfloat16m8_t vs1) {
   return __riscv_vfmv_f_s_f16m8_f16(vs1);
 }
 
-vfloat16m8_t test_vfmv_s_f_f16m8(float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmv_s_f_f16m8(_Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16m8(rs1, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfnmacc.c
+++ b/auto-generated/gnu-api-tests/vfnmacc.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfloat
   return __riscv_vfnmacc_vv_f16mf4(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfloat
   return __riscv_vfnmacc_vv_f16mf2(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1
   return __riscv_vfnmacc_vv_f16m1(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m1(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2
   return __riscv_vfnmacc_vv_f16m2(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m2(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4
   return __riscv_vfnmacc_vv_f16m4(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m4(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8
   return __riscv_vfnmacc_vv_f16m8(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m8(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfnmacc_vv_f16mf4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfnmacc_vv_f16mf2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfnmacc_vv_f16m1_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfnmacc_vv_f16m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfnmacc_vv_f16m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfnmacc_vv_f16m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfnmacc_vv_f16mf4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfnmacc_vv_f16mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfnmacc_vv_f16m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfnmacc_vv_f16m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfnmacc_vv_f16m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat1
   return __riscv_vfnmacc_vv_f16m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfnmacc_vv_f16mf4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfnmacc_vv_f16mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfnmacc_vv_f16m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfnmacc_vv_f16m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfnmacc_vv_f16m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfnmacc_vv_f16m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfnmadd.c
+++ b/auto-generated/gnu-api-tests/vfnmadd.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfloat
   return __riscv_vfnmadd_vv_f16mf4(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfloat
   return __riscv_vfnmadd_vv_f16mf2(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1
   return __riscv_vfnmadd_vv_f16m1(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m1(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2
   return __riscv_vfnmadd_vv_f16m2(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m2(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4
   return __riscv_vfnmadd_vv_f16m4(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m4(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8
   return __riscv_vfnmadd_vv_f16m8(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m8(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfnmadd_vv_f16mf4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfnmadd_vv_f16mf2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfnmadd_vv_f16m1_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfnmadd_vv_f16m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfnmadd_vv_f16m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfnmadd_vv_f16m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfnmadd_vv_f16mf4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfnmadd_vv_f16mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfnmadd_vv_f16m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfnmadd_vv_f16m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfnmadd_vv_f16m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat1
   return __riscv_vfnmadd_vv_f16m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfnmadd_vv_f16mf4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfnmadd_vv_f16mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfnmadd_vv_f16m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfnmadd_vv_f16m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfnmadd_vv_f16m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfnmadd_vv_f16m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfnmsac.c
+++ b/auto-generated/gnu-api-tests/vfnmsac.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfloat
   return __riscv_vfnmsac_vv_f16mf4(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfloat
   return __riscv_vfnmsac_vv_f16mf2(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1
   return __riscv_vfnmsac_vv_f16m1(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m1(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2
   return __riscv_vfnmsac_vv_f16m2(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m2(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4
   return __riscv_vfnmsac_vv_f16m4(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m4(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8
   return __riscv_vfnmsac_vv_f16m8(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m8(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfnmsac_vv_f16mf4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfnmsac_vv_f16mf2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfnmsac_vv_f16m1_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfnmsac_vv_f16m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfnmsac_vv_f16m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfnmsac_vv_f16m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfnmsac_vv_f16mf4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfnmsac_vv_f16mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfnmsac_vv_f16m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfnmsac_vv_f16m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfnmsac_vv_f16m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat1
   return __riscv_vfnmsac_vv_f16m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfnmsac_vv_f16mf4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfnmsac_vv_f16mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfnmsac_vv_f16m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfnmsac_vv_f16m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfnmsac_vv_f16m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfnmsac_vv_f16m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfnmsub.c
+++ b/auto-generated/gnu-api-tests/vfnmsub.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfloat
   return __riscv_vfnmsub_vv_f16mf4(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfloat
   return __riscv_vfnmsub_vv_f16mf2(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1
   return __riscv_vfnmsub_vv_f16m1(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m1(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2
   return __riscv_vfnmsub_vv_f16m2(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m2(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4
   return __riscv_vfnmsub_vv_f16m4(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m4(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8
   return __riscv_vfnmsub_vv_f16m8(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m8(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfnmsub_vv_f16mf4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfnmsub_vv_f16mf2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfnmsub_vv_f16m1_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfnmsub_vv_f16m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfnmsub_vv_f16m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfnmsub_vv_f16m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_m(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfnmsub_vv_f16mf4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfnmsub_vv_f16mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfnmsub_vv_f16m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfnmsub_vv_f16m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfnmsub_vv_f16m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat1
   return __riscv_vfnmsub_vv_f16m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_rm(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfnmsub_vv_f16mf4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfnmsub_vv_f16mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfnmsub_vv_f16m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfnmsub_vv_f16m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfnmsub_vv_f16m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfnmsub_vv_f16m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_rm_m(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfrdiv.c
+++ b/auto-generated/gnu-api-tests/vfrdiv.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4(vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2(vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m1(vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m2(vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m4(vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -67,27 +67,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f64m8(vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 
@@ -127,27 +127,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1
   return __riscv_vfrdiv_vf_f64m8_m(vm, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -187,27 +187,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_rm(vfloat64m8_t vs2, float64_t rs1, size_t vl)
   return __riscv_vfrdiv_vf_f64m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfrsub.c
+++ b/auto-generated/gnu-api-tests/vfrsub.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf4(vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf2(vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m1(vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m2(vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m4(vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -67,27 +67,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl) {
   return __riscv_vfrsub_vf_f64m8(vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 
@@ -127,27 +127,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1
   return __riscv_vfrsub_vf_f64m8_m(vm, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -187,27 +187,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8_rm(vfloat64m8_t vs2, float64_t rs1, size_t vl)
   return __riscv_vfrsub_vf_f64m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfsgnj.c
+++ b/auto-generated/gnu-api-tests/vfsgnj.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t
   return __riscv_vfsgnj_vv_f16mf4(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnj_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnj_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16mf4(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t
   return __riscv_vfsgnj_vv_f16mf2(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnj_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnj_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16mf2(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vfsgnj_vv_f16m1(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnj_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnj_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m1(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl)
   return __riscv_vfsgnj_vv_f16m2(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnj_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnj_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m2(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl)
   return __riscv_vfsgnj_vv_f16m4(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnj_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnj_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m4(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl)
   return __riscv_vfsgnj_vv_f16m8(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnj_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnj_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16m
   return __riscv_vfsgnj_vv_f16mf4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnj_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnj_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16m
   return __riscv_vfsgnj_vv_f16mf2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnj_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnj_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vfsgnj_vv_f16m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnj_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnj_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t 
   return __riscv_vfsgnj_vv_f16m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnj_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnj_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t 
   return __riscv_vfsgnj_vv_f16m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnj_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnj_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t 
   return __riscv_vfsgnj_vv_f16m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnj_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnj_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfsgnjn.c
+++ b/auto-generated/gnu-api-tests/vfsgnjn.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_
   return __riscv_vfsgnjn_vv_f16mf4(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjn_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjn_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf4(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_
   return __riscv_vfsgnjn_vv_f16mf2(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjn_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjn_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf2(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl
   return __riscv_vfsgnjn_vv_f16m1(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjn_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjn_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m1(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl
   return __riscv_vfsgnjn_vv_f16m2(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjn_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjn_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m2(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl
   return __riscv_vfsgnjn_vv_f16m4(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjn_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjn_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m4(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl
   return __riscv_vfsgnjn_vv_f16m8(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjn_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjn_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16
   return __riscv_vfsgnjn_vv_f16mf4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjn_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjn_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16
   return __riscv_vfsgnjn_vv_f16mf2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjn_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjn_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_
   return __riscv_vfsgnjn_vv_f16m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjn_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjn_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t
   return __riscv_vfsgnjn_vv_f16m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjn_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjn_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t
   return __riscv_vfsgnjn_vv_f16m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjn_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjn_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t
   return __riscv_vfsgnjn_vv_f16m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjn_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjn_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfsgnjx.c
+++ b/auto-generated/gnu-api-tests/vfsgnjx.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_
   return __riscv_vfsgnjx_vv_f16mf4(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjx_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjx_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf4(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_
   return __riscv_vfsgnjx_vv_f16mf2(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjx_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjx_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf2(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl
   return __riscv_vfsgnjx_vv_f16m1(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjx_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjx_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m1(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl
   return __riscv_vfsgnjx_vv_f16m2(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjx_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjx_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m2(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl
   return __riscv_vfsgnjx_vv_f16m4(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjx_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjx_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m4(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl
   return __riscv_vfsgnjx_vv_f16m8(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjx_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjx_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16
   return __riscv_vfsgnjx_vv_f16mf4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjx_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjx_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16
   return __riscv_vfsgnjx_vv_f16mf2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjx_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjx_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_
   return __riscv_vfsgnjx_vv_f16m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjx_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjx_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t
   return __riscv_vfsgnjx_vv_f16m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjx_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjx_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t
   return __riscv_vfsgnjx_vv_f16m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjx_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjx_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t
   return __riscv_vfsgnjx_vv_f16m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjx_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjx_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfslide1down.c
+++ b/auto-generated/gnu-api-tests/vfslide1down.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfslide1down_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1down_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16mf4(vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1down_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1down_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16mf2(vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1down_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1down_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m1(vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1down_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1down_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m2(vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1down_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1down_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m4(vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1down_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1down_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -67,27 +67,27 @@ vfloat64m8_t test_vfslide1down_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t 
   return __riscv_vfslide1down_vf_f64m8(vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfslide1down_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1down_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1down_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1down_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1down_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1down_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1down_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1down_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1down_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1down_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1down_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1down_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfslide1up.c
+++ b/auto-generated/gnu-api-tests/vfslide1up.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfslide1up_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1up_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16mf4(vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1up_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1up_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16mf2(vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1up_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1up_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m1(vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1up_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1up_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m2(vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1up_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1up_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m4(vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1up_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1up_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -67,27 +67,27 @@ vfloat64m8_t test_vfslide1up_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl
   return __riscv_vfslide1up_vf_f64m8(vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfslide1up_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1up_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1up_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1up_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1up_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1up_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1up_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1up_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1up_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1up_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1up_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1up_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfsub.c
+++ b/auto-generated/gnu-api-tests/vfsub.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vfsub_vv_f16mf4(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf4(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vfsub_vv_f16mf2(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf2(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfsub_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl) 
   return __riscv_vfsub_vv_f16m1(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m1(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfsub_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) 
   return __riscv_vfsub_vv_f16m2(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m2(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfsub_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) 
   return __riscv_vfsub_vv_f16m4(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m4(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfsub_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) 
   return __riscv_vfsub_vv_f16m8(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m8(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vfsub_vv_f16mf4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf4_m(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vfsub_vv_f16mf2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t 
   return __riscv_vfsub_vv_f16m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m1_m(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t v
   return __riscv_vfsub_vv_f16m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m2_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t v
   return __riscv_vfsub_vv_f16m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m4_m(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t v
   return __riscv_vfsub_vv_f16m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m8_m(vm, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size
   return __riscv_vfsub_vv_f16mf4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size
   return __riscv_vfsub_vv_f16mf2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t v
   return __riscv_vfsub_vv_f16m1_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t v
   return __riscv_vfsub_vv_f16m2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t v
   return __riscv_vfsub_vv_f16m4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t v
   return __riscv_vfsub_vv_f16m8_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat1
   return __riscv_vfsub_vv_f16mf4_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat1
   return __riscv_vfsub_vv_f16mf2_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1
   return __riscv_vfsub_vv_f16m1_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_
   return __riscv_vfsub_vv_f16m2_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_
   return __riscv_vfsub_vv_f16m4_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_
   return __riscv_vfsub_vv_f16m8_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfwadd.c
+++ b/auto-generated/gnu-api-tests/vfwadd.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t
   return __riscv_vfwadd_vv_f32mf2(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32mf2(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2(vfloat32mf2_t vs2, vfloat16mf4_t vs1, size_t
   return __riscv_vfwadd_wv_f32mf2(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2(vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2(vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32mf2(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t v
   return __riscv_vfwadd_vv_f32m1(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m1(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1(vfloat32m1_t vs2, vfloat16mf2_t vs1, size_t vl
   return __riscv_vfwadd_wv_f32m1(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1(vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1(vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m1(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vfwadd_vv_f32m2(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m2(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2(vfloat32m2_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vfwadd_wv_f32m2(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2(vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2(vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m2(vs2, rs1, vl);
 }
 
@@ -59,7 +59,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl)
   return __riscv_vfwadd_vv_f32m4(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m4(vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4(vfloat32m4_t vs2, vfloat16m2_t vs1, size_t vl)
   return __riscv_vfwadd_wv_f32m4(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4(vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4(vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m4(vs2, rs1, vl);
 }
 
@@ -75,7 +75,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl)
   return __riscv_vfwadd_vv_f32m8(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m8(vs2, rs1, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8(vfloat32m8_t vs2, vfloat16m4_t vs1, size_t vl)
   return __riscv_vfwadd_wv_f32m8(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8(vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8(vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m8(vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16m
   return __riscv_vfwadd_vv_f32mf2_m(vm, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2, vfloat16m
   return __riscv_vfwadd_wv_f32mf2_m(vm, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2
   return __riscv_vfwadd_vv_f32m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m1_m(vm, vs2, rs1, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_m(vbool32_t vm, vfloat32m1_t vs2, vfloat16mf2_
   return __riscv_vfwadd_wv_f32m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m1_m(vm, vs2, rs1, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vfwadd_vv_f32m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m2_m(vm, vs2, rs1, vl);
 }
 
@@ -195,7 +195,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_m(vbool16_t vm, vfloat32m2_t vs2, vfloat16m1_t
   return __riscv_vfwadd_wv_f32m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_m(vbool16_t vm, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_m(vbool16_t vm, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m2_m(vm, vs2, rs1, vl);
 }
 
@@ -203,7 +203,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t 
   return __riscv_vfwadd_vv_f32m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m4_m(vm, vs2, rs1, vl);
 }
 
@@ -211,7 +211,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_m(vbool8_t vm, vfloat32m4_t vs2, vfloat16m2_t 
   return __riscv_vfwadd_wv_f32m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m4_m(vm, vs2, rs1, vl);
 }
 
@@ -219,7 +219,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t 
   return __riscv_vfwadd_vv_f32m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m8_m(vm, vs2, rs1, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_m(vbool4_t vm, vfloat32m8_t vs2, vfloat16m4_t 
   return __riscv_vfwadd_wv_f32m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m8_m(vm, vs2, rs1, vl);
 }
 
@@ -299,7 +299,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1, siz
   return __riscv_vfwadd_vv_f32mf2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_rm(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_rm(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -307,7 +307,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm(vfloat32mf2_t vs2, vfloat16mf4_t vs1, siz
   return __riscv_vfwadd_wv_f32mf2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_rm(vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_rm(vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -315,7 +315,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_
   return __riscv_vfwadd_vv_f32m1_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_rm(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_rm(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -323,7 +323,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm(vfloat32m1_t vs2, vfloat16mf2_t vs1, size_t
   return __riscv_vfwadd_wv_f32m1_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_rm(vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_rm(vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -331,7 +331,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t 
   return __riscv_vfwadd_vv_f32m2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_rm(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -339,7 +339,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm(vfloat32m2_t vs2, vfloat16m1_t vs1, size_t 
   return __riscv_vfwadd_wv_f32m2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_rm(vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_rm(vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -347,7 +347,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t 
   return __riscv_vfwadd_vv_f32m4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_rm(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -355,7 +355,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm(vfloat32m4_t vs2, vfloat16m2_t vs1, size_t 
   return __riscv_vfwadd_wv_f32m4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_rm(vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_rm(vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -363,7 +363,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t 
   return __riscv_vfwadd_vv_f32m8_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_rm(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm(vfloat32m8_t vs2, vfloat16m4_t vs1, size_t 
   return __riscv_vfwadd_wv_f32m8_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_rm(vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_rm(vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -443,7 +443,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat
   return __riscv_vfwadd_vv_f32mf2_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -451,7 +451,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2, vfloat
   return __riscv_vfwadd_wv_f32mf2_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +459,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16
   return __riscv_vfwadd_vv_f32m1_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -467,7 +467,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2, vfloat16m
   return __riscv_vfwadd_wv_f32m1_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -475,7 +475,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m
   return __riscv_vfwadd_vv_f32m2_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -483,7 +483,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2, vfloat16m
   return __riscv_vfwadd_wv_f32m2_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2
   return __riscv_vfwadd_vv_f32m4_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2, vfloat16m2
   return __riscv_vfwadd_wv_f32m4_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4
   return __riscv_vfwadd_vv_f32m8_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2, vfloat16m4
   return __riscv_vfwadd_wv_f32m8_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfwmacc.c
+++ b/auto-generated/gnu-api-tests/vfwmacc.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1, vfloat
   return __riscv_vfwmacc_vv_f32mf2(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2(vd, vs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloat16m
   return __riscv_vfwmacc_vv_f32m1(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m1(vd, vs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat16m1
   return __riscv_vfwmacc_vv_f32m2(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m2(vd, vs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat16m2
   return __riscv_vfwmacc_vv_f32m4(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m4(vd, vs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat16m4
   return __riscv_vfwmacc_vv_f32m8(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m8(vd, vs1, vs2, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, vfloat16m
   return __riscv_vfwmacc_vv_f32mf2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_
   return __riscv_vfwmacc_vv_f32m1_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t
   return __riscv_vfwmacc_vv_f32m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t 
   return __riscv_vfwmacc_vv_f32m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t 
   return __riscv_vfwmacc_vv_f32m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfwmacc_vv_f32mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloat
   return __riscv_vfwmacc_vv_f32m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfwmacc_vv_f32m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfwmacc_vv_f32m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfwmacc_vv_f32m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwmacc_vv_f32mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, vfloat16m
   return __riscv_vfwmacc_vv_f32m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, vfloat16m
   return __riscv_vfwmacc_vv_f32m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, vfloat16m2
   return __riscv_vfwmacc_vv_f32m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, vfloat16m4
   return __riscv_vfwmacc_vv_f32m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfwmsac.c
+++ b/auto-generated/gnu-api-tests/vfwmsac.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1, vfloat
   return __riscv_vfwmsac_vv_f32mf2(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2(vd, vs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloat16m
   return __riscv_vfwmsac_vv_f32m1(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m1(vd, vs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat16m1
   return __riscv_vfwmsac_vv_f32m2(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m2(vd, vs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat16m2
   return __riscv_vfwmsac_vv_f32m4(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m4(vd, vs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat16m4
   return __riscv_vfwmsac_vv_f32m8(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m8(vd, vs1, vs2, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, vfloat16m
   return __riscv_vfwmsac_vv_f32mf2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_
   return __riscv_vfwmsac_vv_f32m1_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t
   return __riscv_vfwmsac_vv_f32m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t 
   return __riscv_vfwmsac_vv_f32m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t 
   return __riscv_vfwmsac_vv_f32m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfwmsac_vv_f32mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloat
   return __riscv_vfwmsac_vv_f32m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfwmsac_vv_f32m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfwmsac_vv_f32m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfwmsac_vv_f32m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwmsac_vv_f32mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, vfloat16m
   return __riscv_vfwmsac_vv_f32m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, vfloat16m
   return __riscv_vfwmsac_vv_f32m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, vfloat16m2
   return __riscv_vfwmsac_vv_f32m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, vfloat16m4
   return __riscv_vfwmsac_vv_f32m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfwmul.c
+++ b/auto-generated/gnu-api-tests/vfwmul.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t
   return __riscv_vfwmul_vv_f32mf2(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32mf2(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t v
   return __riscv_vfwmul_vv_f32m1(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m1(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vfwmul_vv_f32m2(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m2(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl)
   return __riscv_vfwmul_vv_f32m4(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m4(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl)
   return __riscv_vfwmul_vv_f32m8(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m8(vs2, rs1, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16m
   return __riscv_vfwmul_vv_f32mf2_m(vm, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2
   return __riscv_vfwmul_vv_f32m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m1_m(vm, vs2, rs1, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vfwmul_vv_f32m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m2_m(vm, vs2, rs1, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t 
   return __riscv_vfwmul_vv_f32m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m4_m(vm, vs2, rs1, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t 
   return __riscv_vfwmul_vv_f32m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m8_m(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1, siz
   return __riscv_vfwmul_vv_f32mf2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_rm(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_rm(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_
   return __riscv_vfwmul_vv_f32m1_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_rm(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_rm(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t 
   return __riscv_vfwmul_vv_f32m2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_rm(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t 
   return __riscv_vfwmul_vv_f32m4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_rm(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t 
   return __riscv_vfwmul_vv_f32m8_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_rm(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat
   return __riscv_vfwmul_vv_f32mf2_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16
   return __riscv_vfwmul_vv_f32m1_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m
   return __riscv_vfwmul_vv_f32m2_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2
   return __riscv_vfwmul_vv_f32m4_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4
   return __riscv_vfwmul_vv_f32m8_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfwnmacc.c
+++ b/auto-generated/gnu-api-tests/vfwnmacc.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1, vfloa
   return __riscv_vfwnmacc_vv_f32mf2(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2(vd, vs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloat16
   return __riscv_vfwnmacc_vv_f32m1(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1(vd, vs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat16m
   return __riscv_vfwnmacc_vv_f32m2(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2(vd, vs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat16m
   return __riscv_vfwnmacc_vv_f32m4(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4(vd, vs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat16m
   return __riscv_vfwnmacc_vv_f32m8(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8(vd, vs1, vs2, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, vfloat16
   return __riscv_vfwnmacc_vv_f32mf2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2
   return __riscv_vfwnmacc_vv_f32m1_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_
   return __riscv_vfwnmacc_vv_f32m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t
   return __riscv_vfwnmacc_vv_f32m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t
   return __riscv_vfwnmacc_vv_f32m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1, vf
   return __riscv_vfwnmacc_vv_f32mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloa
   return __riscv_vfwnmacc_vv_f32m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat
   return __riscv_vfwnmacc_vv_f32m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat
   return __riscv_vfwnmacc_vv_f32m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat
   return __riscv_vfwnmacc_vv_f32m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwnmacc_vv_f32mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, vfloat16
   return __riscv_vfwnmacc_vv_f32m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, vfloat16
   return __riscv_vfwnmacc_vv_f32m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, vfloat16m
   return __riscv_vfwnmacc_vv_f32m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, vfloat16m
   return __riscv_vfwnmacc_vv_f32m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfwnmsac.c
+++ b/auto-generated/gnu-api-tests/vfwnmsac.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1, vfloa
   return __riscv_vfwnmsac_vv_f32mf2(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2(vd, vs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloat16
   return __riscv_vfwnmsac_vv_f32m1(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1(vd, vs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat16m
   return __riscv_vfwnmsac_vv_f32m2(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2(vd, vs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat16m
   return __riscv_vfwnmsac_vv_f32m4(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4(vd, vs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat16m
   return __riscv_vfwnmsac_vv_f32m8(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8(vd, vs1, vs2, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, vfloat16
   return __riscv_vfwnmsac_vv_f32mf2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2
   return __riscv_vfwnmsac_vv_f32m1_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_
   return __riscv_vfwnmsac_vv_f32m2_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t
   return __riscv_vfwnmsac_vv_f32m4_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t
   return __riscv_vfwnmsac_vv_f32m8_m(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_m(vm, vd, vs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1, vf
   return __riscv_vfwnmsac_vv_f32mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloa
   return __riscv_vfwnmsac_vv_f32m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat
   return __riscv_vfwnmsac_vv_f32m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat
   return __riscv_vfwnmsac_vv_f32m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat
   return __riscv_vfwnmsac_vv_f32m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_rm(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwnmsac_vv_f32mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, vfloat16
   return __riscv_vfwnmsac_vv_f32m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, vfloat16
   return __riscv_vfwnmsac_vv_f32m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, vfloat16m
   return __riscv_vfwnmsac_vv_f32m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, vfloat16m
   return __riscv_vfwnmsac_vv_f32m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_rm_m(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vfwsub.c
+++ b/auto-generated/gnu-api-tests/vfwsub.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t
   return __riscv_vfwsub_vv_f32mf2(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32mf2(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2(vfloat32mf2_t vs2, vfloat16mf4_t vs1, size_t
   return __riscv_vfwsub_wv_f32mf2(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2(vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2(vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32mf2(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t v
   return __riscv_vfwsub_vv_f32m1(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m1(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1(vfloat32m1_t vs2, vfloat16mf2_t vs1, size_t vl
   return __riscv_vfwsub_wv_f32m1(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1(vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1(vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m1(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vfwsub_vv_f32m2(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m2(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2(vfloat32m2_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vfwsub_wv_f32m2(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2(vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2(vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m2(vs2, rs1, vl);
 }
 
@@ -59,7 +59,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl)
   return __riscv_vfwsub_vv_f32m4(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m4(vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4(vfloat32m4_t vs2, vfloat16m2_t vs1, size_t vl)
   return __riscv_vfwsub_wv_f32m4(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4(vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4(vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m4(vs2, rs1, vl);
 }
 
@@ -75,7 +75,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl)
   return __riscv_vfwsub_vv_f32m8(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m8(vs2, rs1, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8(vfloat32m8_t vs2, vfloat16m4_t vs1, size_t vl)
   return __riscv_vfwsub_wv_f32m8(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8(vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8(vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m8(vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16m
   return __riscv_vfwsub_vv_f32mf2_m(vm, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2, vfloat16m
   return __riscv_vfwsub_wv_f32mf2_m(vm, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_m(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2
   return __riscv_vfwsub_vv_f32m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m1_m(vm, vs2, rs1, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_m(vbool32_t vm, vfloat32m1_t vs2, vfloat16mf2_
   return __riscv_vfwsub_wv_f32m1_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m1_m(vm, vs2, rs1, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vfwsub_vv_f32m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m2_m(vm, vs2, rs1, vl);
 }
 
@@ -195,7 +195,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_m(vbool16_t vm, vfloat32m2_t vs2, vfloat16m1_t
   return __riscv_vfwsub_wv_f32m2_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_m(vbool16_t vm, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_m(vbool16_t vm, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m2_m(vm, vs2, rs1, vl);
 }
 
@@ -203,7 +203,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t 
   return __riscv_vfwsub_vv_f32m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m4_m(vm, vs2, rs1, vl);
 }
 
@@ -211,7 +211,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_m(vbool8_t vm, vfloat32m4_t vs2, vfloat16m2_t 
   return __riscv_vfwsub_wv_f32m4_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m4_m(vm, vs2, rs1, vl);
 }
 
@@ -219,7 +219,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t 
   return __riscv_vfwsub_vv_f32m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m8_m(vm, vs2, rs1, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_m(vbool4_t vm, vfloat32m8_t vs2, vfloat16m4_t 
   return __riscv_vfwsub_wv_f32m8_m(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m8_m(vm, vs2, rs1, vl);
 }
 
@@ -299,7 +299,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1, siz
   return __riscv_vfwsub_vv_f32mf2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_rm(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_rm(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -307,7 +307,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm(vfloat32mf2_t vs2, vfloat16mf4_t vs1, siz
   return __riscv_vfwsub_wv_f32mf2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_rm(vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_rm(vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -315,7 +315,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_
   return __riscv_vfwsub_vv_f32m1_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_rm(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_rm(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -323,7 +323,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm(vfloat32m1_t vs2, vfloat16mf2_t vs1, size_t
   return __riscv_vfwsub_wv_f32m1_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_rm(vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_rm(vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m1_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -331,7 +331,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t 
   return __riscv_vfwsub_vv_f32m2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_rm(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -339,7 +339,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm(vfloat32m2_t vs2, vfloat16m1_t vs1, size_t 
   return __riscv_vfwsub_wv_f32m2_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_rm(vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_rm(vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m2_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -347,7 +347,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t 
   return __riscv_vfwsub_vv_f32m4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_rm(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -355,7 +355,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm(vfloat32m4_t vs2, vfloat16m2_t vs1, size_t 
   return __riscv_vfwsub_wv_f32m4_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_rm(vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_rm(vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m4_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -363,7 +363,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t 
   return __riscv_vfwsub_vv_f32m8_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_rm(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm(vfloat32m8_t vs2, vfloat16m4_t vs1, size_t 
   return __riscv_vfwsub_wv_f32m8_rm(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_rm(vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_rm(vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m8_rm(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -443,7 +443,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat
   return __riscv_vfwsub_vv_f32mf2_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -451,7 +451,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2, vfloat
   return __riscv_vfwsub_wv_f32mf2_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +459,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16
   return __riscv_vfwsub_vv_f32m1_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -467,7 +467,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2, vfloat16m
   return __riscv_vfwsub_wv_f32m1_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m1_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -475,7 +475,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m
   return __riscv_vfwsub_vv_f32m2_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -483,7 +483,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2, vfloat16m
   return __riscv_vfwsub_wv_f32m2_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m2_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2
   return __riscv_vfwsub_vv_f32m4_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2, vfloat16m2
   return __riscv_vfwsub_wv_f32m4_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m4_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4
   return __riscv_vfwsub_vv_f32m8_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2, vfloat16m4
   return __riscv_vfwsub_wv_f32m8_rm_m(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m8_rm_m(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vmfeq.c
+++ b/auto-generated/gnu-api-tests/vmfeq.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfeq_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vmfeq_vv_f16mf4_b64(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfeq_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfeq_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16mf4_b64(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfeq_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vmfeq_vv_f16mf2_b32(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfeq_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfeq_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16mf2_b32(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfeq_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vmfeq_vv_f16m1_b16(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfeq_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfeq_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m1_b16(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfeq_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfeq_vv_f16m2_b8(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfeq_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfeq_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m2_b8(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfeq_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfeq_vv_f16m4_b4(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfeq_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfeq_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m4_b4(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfeq_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfeq_vv_f16m8_b2(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfeq_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfeq_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m8_b2(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vbool64_t test_vmfeq_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vmfeq_vv_f16mf4_b64_m(vm, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfeq_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfeq_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16mf4_b64_m(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vbool32_t test_vmfeq_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vmfeq_vv_f16mf2_b32_m(vm, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfeq_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfeq_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16mf2_b32_m(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vbool16_t test_vmfeq_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vmfeq_vv_f16m1_b16_m(vm, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfeq_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfeq_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m1_b16_m(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vbool8_t test_vmfeq_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs
   return __riscv_vmfeq_vv_f16m2_b8_m(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfeq_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfeq_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m2_b8_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vbool4_t test_vmfeq_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs
   return __riscv_vmfeq_vv_f16m4_b4_m(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfeq_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfeq_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m4_b4_m(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vbool2_t test_vmfeq_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs
   return __riscv_vmfeq_vv_f16m8_b2_m(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfeq_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfeq_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m8_b2_m(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vmfge.c
+++ b/auto-generated/gnu-api-tests/vmfge.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfge_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vmfge_vv_f16mf4_b64(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfge_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfge_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16mf4_b64(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfge_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vmfge_vv_f16mf2_b32(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfge_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfge_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16mf2_b32(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfge_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vmfge_vv_f16m1_b16(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfge_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfge_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m1_b16(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfge_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfge_vv_f16m2_b8(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfge_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfge_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m2_b8(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfge_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfge_vv_f16m4_b4(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfge_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfge_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m4_b4(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfge_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfge_vv_f16m8_b2(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfge_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfge_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m8_b2(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vbool64_t test_vmfge_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vmfge_vv_f16mf4_b64_m(vm, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfge_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfge_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16mf4_b64_m(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vbool32_t test_vmfge_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vmfge_vv_f16mf2_b32_m(vm, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfge_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfge_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16mf2_b32_m(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vbool16_t test_vmfge_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vmfge_vv_f16m1_b16_m(vm, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfge_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfge_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m1_b16_m(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vbool8_t test_vmfge_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs
   return __riscv_vmfge_vv_f16m2_b8_m(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfge_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfge_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m2_b8_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vbool4_t test_vmfge_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs
   return __riscv_vmfge_vv_f16m4_b4_m(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfge_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfge_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m4_b4_m(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vbool2_t test_vmfge_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs
   return __riscv_vmfge_vv_f16m8_b2_m(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfge_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfge_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m8_b2_m(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vmfgt.c
+++ b/auto-generated/gnu-api-tests/vmfgt.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfgt_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vmfgt_vv_f16mf4_b64(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfgt_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfgt_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16mf4_b64(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfgt_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vmfgt_vv_f16mf2_b32(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfgt_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfgt_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16mf2_b32(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfgt_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vmfgt_vv_f16m1_b16(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfgt_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfgt_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m1_b16(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfgt_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfgt_vv_f16m2_b8(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfgt_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfgt_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m2_b8(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfgt_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfgt_vv_f16m4_b4(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfgt_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfgt_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m4_b4(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfgt_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfgt_vv_f16m8_b2(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfgt_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfgt_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m8_b2(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vbool64_t test_vmfgt_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vmfgt_vv_f16mf4_b64_m(vm, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfgt_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfgt_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16mf4_b64_m(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vbool32_t test_vmfgt_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vmfgt_vv_f16mf2_b32_m(vm, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfgt_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfgt_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16mf2_b32_m(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vbool16_t test_vmfgt_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vmfgt_vv_f16m1_b16_m(vm, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfgt_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfgt_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m1_b16_m(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vbool8_t test_vmfgt_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs
   return __riscv_vmfgt_vv_f16m2_b8_m(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfgt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfgt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m2_b8_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vbool4_t test_vmfgt_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs
   return __riscv_vmfgt_vv_f16m4_b4_m(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfgt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfgt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m4_b4_m(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vbool2_t test_vmfgt_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs
   return __riscv_vmfgt_vv_f16m8_b2_m(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfgt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfgt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m8_b2_m(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vmfle.c
+++ b/auto-generated/gnu-api-tests/vmfle.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfle_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vmfle_vv_f16mf4_b64(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfle_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfle_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16mf4_b64(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfle_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vmfle_vv_f16mf2_b32(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfle_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfle_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16mf2_b32(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfle_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vmfle_vv_f16m1_b16(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfle_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfle_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m1_b16(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfle_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfle_vv_f16m2_b8(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfle_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfle_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m2_b8(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfle_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfle_vv_f16m4_b4(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfle_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfle_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m4_b4(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfle_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfle_vv_f16m8_b2(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfle_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfle_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m8_b2(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vbool64_t test_vmfle_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vmfle_vv_f16mf4_b64_m(vm, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfle_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfle_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16mf4_b64_m(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vbool32_t test_vmfle_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vmfle_vv_f16mf2_b32_m(vm, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfle_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfle_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16mf2_b32_m(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vbool16_t test_vmfle_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vmfle_vv_f16m1_b16_m(vm, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfle_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfle_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m1_b16_m(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vbool8_t test_vmfle_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs
   return __riscv_vmfle_vv_f16m2_b8_m(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfle_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfle_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m2_b8_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vbool4_t test_vmfle_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs
   return __riscv_vmfle_vv_f16m4_b4_m(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfle_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfle_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m4_b4_m(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vbool2_t test_vmfle_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs
   return __riscv_vmfle_vv_f16m8_b2_m(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfle_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfle_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m8_b2_m(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vmflt.c
+++ b/auto-generated/gnu-api-tests/vmflt.c
@@ -11,7 +11,7 @@ vbool64_t test_vmflt_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vmflt_vv_f16mf4_b64(vs2, vs1, vl);
 }
 
-vbool64_t test_vmflt_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmflt_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16mf4_b64(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmflt_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vmflt_vv_f16mf2_b32(vs2, vs1, vl);
 }
 
-vbool32_t test_vmflt_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmflt_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16mf2_b32(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmflt_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vmflt_vv_f16m1_b16(vs2, vs1, vl);
 }
 
-vbool16_t test_vmflt_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmflt_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m1_b16(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmflt_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmflt_vv_f16m2_b8(vs2, vs1, vl);
 }
 
-vbool8_t test_vmflt_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmflt_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m2_b8(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmflt_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmflt_vv_f16m4_b4(vs2, vs1, vl);
 }
 
-vbool4_t test_vmflt_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmflt_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m4_b4(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmflt_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmflt_vv_f16m8_b2(vs2, vs1, vl);
 }
 
-vbool2_t test_vmflt_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmflt_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m8_b2(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vbool64_t test_vmflt_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vmflt_vv_f16mf4_b64_m(vm, vs2, vs1, vl);
 }
 
-vbool64_t test_vmflt_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmflt_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16mf4_b64_m(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vbool32_t test_vmflt_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vmflt_vv_f16mf2_b32_m(vm, vs2, vs1, vl);
 }
 
-vbool32_t test_vmflt_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmflt_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16mf2_b32_m(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vbool16_t test_vmflt_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vmflt_vv_f16m1_b16_m(vm, vs2, vs1, vl);
 }
 
-vbool16_t test_vmflt_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmflt_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m1_b16_m(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vbool8_t test_vmflt_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs
   return __riscv_vmflt_vv_f16m2_b8_m(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmflt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmflt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m2_b8_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vbool4_t test_vmflt_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs
   return __riscv_vmflt_vv_f16m4_b4_m(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmflt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmflt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m4_b4_m(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vbool2_t test_vmflt_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs
   return __riscv_vmflt_vv_f16m8_b2_m(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmflt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmflt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m8_b2_m(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-api-tests/vmfne.c
+++ b/auto-generated/gnu-api-tests/vmfne.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfne_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vmfne_vv_f16mf4_b64(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfne_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfne_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16mf4_b64(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfne_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vmfne_vv_f16mf2_b32(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfne_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfne_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16mf2_b32(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfne_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vmfne_vv_f16m1_b16(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfne_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfne_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m1_b16(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfne_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfne_vv_f16m2_b8(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfne_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfne_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m2_b8(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfne_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfne_vv_f16m4_b4(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfne_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfne_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m4_b4(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfne_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfne_vv_f16m8_b2(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfne_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfne_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m8_b2(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vbool64_t test_vmfne_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vmfne_vv_f16mf4_b64_m(vm, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfne_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfne_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16mf4_b64_m(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vbool32_t test_vmfne_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vmfne_vv_f16mf2_b32_m(vm, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfne_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfne_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16mf2_b32_m(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vbool16_t test_vmfne_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vmfne_vv_f16m1_b16_m(vm, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfne_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfne_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m1_b16_m(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vbool8_t test_vmfne_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs
   return __riscv_vmfne_vv_f16m2_b8_m(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfne_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfne_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m2_b8_m(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vbool4_t test_vmfne_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs
   return __riscv_vmfne_vv_f16m4_b4_m(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfne_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfne_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m4_b4_m(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vbool2_t test_vmfne_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs
   return __riscv_vmfne_vv_f16m8_b2_m(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfne_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfne_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m8_b2_m(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vcpop.c
+++ b/auto-generated/gnu-overloaded-tests/vcpop.c
@@ -7,59 +7,59 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-unsigned long test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vcpop\.[ivxfswum.]+\s+} 14 } } */

--- a/auto-generated/gnu-overloaded-tests/vfadd.c
+++ b/auto-generated/gnu-overloaded-tests/vfadd.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vfadd(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vfadd(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfadd_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl) 
   return __riscv_vfadd(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfadd_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) 
   return __riscv_vfadd(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfadd_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) 
   return __riscv_vfadd(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfadd_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) 
   return __riscv_vfadd(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vfadd(vm, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vfadd(vm, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t 
   return __riscv_vfadd(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t v
   return __riscv_vfadd(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t v
   return __riscv_vfadd(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t v
   return __riscv_vfadd(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size
   return __riscv_vfadd(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size
   return __riscv_vfadd(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t v
   return __riscv_vfadd(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t v
   return __riscv_vfadd(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t v
   return __riscv_vfadd(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t v
   return __riscv_vfadd(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat1
   return __riscv_vfadd(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat1
   return __riscv_vfadd(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1
   return __riscv_vfadd(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_
   return __riscv_vfadd(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_
   return __riscv_vfadd(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_
   return __riscv_vfadd(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfdiv.c
+++ b/auto-generated/gnu-overloaded-tests/vfdiv.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vfdiv(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vfdiv(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl) 
   return __riscv_vfdiv(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) 
   return __riscv_vfdiv(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) 
   return __riscv_vfdiv(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) 
   return __riscv_vfdiv(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vfdiv(vm, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vfdiv(vm, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t 
   return __riscv_vfdiv(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t v
   return __riscv_vfdiv(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t v
   return __riscv_vfdiv(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t v
   return __riscv_vfdiv(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size
   return __riscv_vfdiv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size
   return __riscv_vfdiv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t v
   return __riscv_vfdiv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t v
   return __riscv_vfdiv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t v
   return __riscv_vfdiv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t v
   return __riscv_vfdiv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat1
   return __riscv_vfdiv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat1
   return __riscv_vfdiv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1
   return __riscv_vfdiv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_
   return __riscv_vfdiv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_
   return __riscv_vfdiv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_
   return __riscv_vfdiv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfirst.c
+++ b/auto-generated/gnu-overloaded-tests/vfirst.c
@@ -7,59 +7,59 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-long test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
+int test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
+int test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
+int test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
+int test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
+int test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
+int test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
+int test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+int test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-long test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+int test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-long test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+int test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-long test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+int test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-long test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+int test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-long test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+int test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-long test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+int test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfirst\.[ivxfswum.]+\s+} 14 } } */

--- a/auto-generated/gnu-overloaded-tests/vfmacc.c
+++ b/auto-generated/gnu-overloaded-tests/vfmacc.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfloat1
   return __riscv_vfmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfloat1
   return __riscv_vfmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_
   return __riscv_vfmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_
   return __riscv_vfmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_
   return __riscv_vfmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_
   return __riscv_vfmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1, vflo
   return __riscv_vfmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1, vflo
   return __riscv_vfmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16
   return __riscv_vfmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16
   return __riscv_vfmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16
   return __riscv_vfmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16
   return __riscv_vfmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfmadd.c
+++ b/auto-generated/gnu-overloaded-tests/vfmadd.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfloat1
   return __riscv_vfmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfloat1
   return __riscv_vfmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_
   return __riscv_vfmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_
   return __riscv_vfmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_
   return __riscv_vfmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_
   return __riscv_vfmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfmadd(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfmadd(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfmadd(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfmadd(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfmadd(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfmadd(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1, vflo
   return __riscv_vfmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1, vflo
   return __riscv_vfmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16
   return __riscv_vfmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16
   return __riscv_vfmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16
   return __riscv_vfmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16
   return __riscv_vfmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfmadd(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfmadd(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfmadd(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfmadd(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfmadd(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfmadd(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfmax.c
+++ b/auto-generated/gnu-overloaded-tests/vfmax.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vfmax(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmax_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmax_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vfmax(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmax_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmax_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmax_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl) 
   return __riscv_vfmax(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmax_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmax_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmax_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) 
   return __riscv_vfmax(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmax_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmax_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmax_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) 
   return __riscv_vfmax(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmax_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmax_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmax_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) 
   return __riscv_vfmax(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmax_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmax_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vfmax(vm, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmax_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmax_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vfmax(vm, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmax_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmax_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmax_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t 
   return __riscv_vfmax(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmax_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmax_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t v
   return __riscv_vfmax(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmax_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmax_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t v
   return __riscv_vfmax(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmax_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmax_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t v
   return __riscv_vfmax(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmax_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmax_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfmerge.c
+++ b/auto-generated/gnu-overloaded-tests/vfmerge.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfmerge_vfm_f16mf4(vfloat16mf4_t vs2, float16_t rs1, vbool64_t v0, size_t vl) {
+vfloat16mf4_t test_vfmerge_vfm_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, vbool64_t v0, size_t vl) {
   return __riscv_vfmerge(vs2, rs1, v0, vl);
 }
 
-vfloat16mf2_t test_vfmerge_vfm_f16mf2(vfloat16mf2_t vs2, float16_t rs1, vbool32_t v0, size_t vl) {
+vfloat16mf2_t test_vfmerge_vfm_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, vbool32_t v0, size_t vl) {
   return __riscv_vfmerge(vs2, rs1, v0, vl);
 }
 
-vfloat16m1_t test_vfmerge_vfm_f16m1(vfloat16m1_t vs2, float16_t rs1, vbool16_t v0, size_t vl) {
+vfloat16m1_t test_vfmerge_vfm_f16m1(vfloat16m1_t vs2, _Float16 rs1, vbool16_t v0, size_t vl) {
   return __riscv_vfmerge(vs2, rs1, v0, vl);
 }
 
-vfloat16m2_t test_vfmerge_vfm_f16m2(vfloat16m2_t vs2, float16_t rs1, vbool8_t v0, size_t vl) {
+vfloat16m2_t test_vfmerge_vfm_f16m2(vfloat16m2_t vs2, _Float16 rs1, vbool8_t v0, size_t vl) {
   return __riscv_vfmerge(vs2, rs1, v0, vl);
 }
 
-vfloat16m4_t test_vfmerge_vfm_f16m4(vfloat16m4_t vs2, float16_t rs1, vbool4_t v0, size_t vl) {
+vfloat16m4_t test_vfmerge_vfm_f16m4(vfloat16m4_t vs2, _Float16 rs1, vbool4_t v0, size_t vl) {
   return __riscv_vfmerge(vs2, rs1, v0, vl);
 }
 
-vfloat16m8_t test_vfmerge_vfm_f16m8(vfloat16m8_t vs2, float16_t rs1, vbool2_t v0, size_t vl) {
+vfloat16m8_t test_vfmerge_vfm_f16m8(vfloat16m8_t vs2, _Float16 rs1, vbool2_t v0, size_t vl) {
   return __riscv_vfmerge(vs2, rs1, v0, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfmin.c
+++ b/auto-generated/gnu-overloaded-tests/vfmin.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vfmin(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmin_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmin_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vfmin(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmin_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmin_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmin_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl) 
   return __riscv_vfmin(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmin_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmin_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmin_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) 
   return __riscv_vfmin(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmin_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmin_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmin_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) 
   return __riscv_vfmin(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmin_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmin_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmin_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) 
   return __riscv_vfmin(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmin_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmin_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vfmin(vm, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmin_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmin_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vfmin(vm, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmin_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmin_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmin_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t 
   return __riscv_vfmin(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmin_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmin_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t v
   return __riscv_vfmin(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmin_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmin_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t v
   return __riscv_vfmin(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmin_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmin_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t v
   return __riscv_vfmin(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmin_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmin_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfmsac.c
+++ b/auto-generated/gnu-overloaded-tests/vfmsac.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfloat1
   return __riscv_vfmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfloat1
   return __riscv_vfmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_
   return __riscv_vfmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_
   return __riscv_vfmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_
   return __riscv_vfmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_
   return __riscv_vfmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1, vflo
   return __riscv_vfmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1, vflo
   return __riscv_vfmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16
   return __riscv_vfmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16
   return __riscv_vfmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16
   return __riscv_vfmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16
   return __riscv_vfmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfmsub.c
+++ b/auto-generated/gnu-overloaded-tests/vfmsub.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfloat1
   return __riscv_vfmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfloat1
   return __riscv_vfmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_
   return __riscv_vfmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_
   return __riscv_vfmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_
   return __riscv_vfmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_
   return __riscv_vfmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfmsub(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfmsub(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfmsub(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfmsub(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfmsub(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfmsub(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1, vflo
   return __riscv_vfmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1, vflo
   return __riscv_vfmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16
   return __riscv_vfmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16
   return __riscv_vfmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16
   return __riscv_vfmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16
   return __riscv_vfmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfmsub(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfmsub(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfmsub(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfmsub(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfmsub(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfmsub(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfmul.c
+++ b/auto-generated/gnu-overloaded-tests/vfmul.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vfmul(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vfmul(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmul_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl) 
   return __riscv_vfmul(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmul_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) 
   return __riscv_vfmul(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmul_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) 
   return __riscv_vfmul(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmul_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) 
   return __riscv_vfmul(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vfmul(vm, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vfmul(vm, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t 
   return __riscv_vfmul(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t v
   return __riscv_vfmul(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t v
   return __riscv_vfmul(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t v
   return __riscv_vfmul(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size
   return __riscv_vfmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size
   return __riscv_vfmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t v
   return __riscv_vfmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t v
   return __riscv_vfmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t v
   return __riscv_vfmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t v
   return __riscv_vfmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat1
   return __riscv_vfmul(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat1
   return __riscv_vfmul(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1
   return __riscv_vfmul(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_
   return __riscv_vfmul(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_
   return __riscv_vfmul(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_
   return __riscv_vfmul(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfmv.c
+++ b/auto-generated/gnu-overloaded-tests/vfmv.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-float16_t test_vfmv_f_s_f16mf4_f16(vfloat16mf4_t vs1) {
+_Float16 test_vfmv_f_s_f16mf4_f16(vfloat16mf4_t vs1) {
   return __riscv_vfmv_f(vs1);
 }
 
-float16_t test_vfmv_f_s_f16mf2_f16(vfloat16mf2_t vs1) {
+_Float16 test_vfmv_f_s_f16mf2_f16(vfloat16mf2_t vs1) {
   return __riscv_vfmv_f(vs1);
 }
 
-float16_t test_vfmv_f_s_f16m1_f16(vfloat16m1_t vs1) {
+_Float16 test_vfmv_f_s_f16m1_f16(vfloat16m1_t vs1) {
   return __riscv_vfmv_f(vs1);
 }
 
-float16_t test_vfmv_f_s_f16m2_f16(vfloat16m2_t vs1) {
+_Float16 test_vfmv_f_s_f16m2_f16(vfloat16m2_t vs1) {
   return __riscv_vfmv_f(vs1);
 }
 
-float16_t test_vfmv_f_s_f16m4_f16(vfloat16m4_t vs1) {
+_Float16 test_vfmv_f_s_f16m4_f16(vfloat16m4_t vs1) {
   return __riscv_vfmv_f(vs1);
 }
 
-float16_t test_vfmv_f_s_f16m8_f16(vfloat16m8_t vs1) {
+_Float16 test_vfmv_f_s_f16m8_f16(vfloat16m8_t vs1) {
   return __riscv_vfmv_f(vs1);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfnmacc.c
+++ b/auto-generated/gnu-overloaded-tests/vfnmacc.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfloat
   return __riscv_vfnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfloat
   return __riscv_vfnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1
   return __riscv_vfnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2
   return __riscv_vfnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4
   return __riscv_vfnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8
   return __riscv_vfnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfnmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfnmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfnmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfnmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfnmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfnmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat1
   return __riscv_vfnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfnmadd.c
+++ b/auto-generated/gnu-overloaded-tests/vfnmadd.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfloat
   return __riscv_vfnmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfloat
   return __riscv_vfnmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1
   return __riscv_vfnmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2
   return __riscv_vfnmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4
   return __riscv_vfnmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8
   return __riscv_vfnmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfnmadd(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfnmadd(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfnmadd(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfnmadd(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfnmadd(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfnmadd(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfnmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfnmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfnmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfnmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfnmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat1
   return __riscv_vfnmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfnmadd(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfnmadd(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfnmadd(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfnmadd(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfnmadd(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfnmadd(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfnmsac.c
+++ b/auto-generated/gnu-overloaded-tests/vfnmsac.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfloat
   return __riscv_vfnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfloat
   return __riscv_vfnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1
   return __riscv_vfnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2
   return __riscv_vfnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4
   return __riscv_vfnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8
   return __riscv_vfnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfnmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfnmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfnmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfnmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfnmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfnmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat1
   return __riscv_vfnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfnmsub.c
+++ b/auto-generated/gnu-overloaded-tests/vfnmsub.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfloat
   return __riscv_vfnmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfloat
   return __riscv_vfnmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1
   return __riscv_vfnmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2
   return __riscv_vfnmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4
   return __riscv_vfnmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8
   return __riscv_vfnmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfnmsub(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfnmsub(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfnmsub(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfnmsub(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfnmsub(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfnmsub(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfnmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfnmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfnmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfnmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfnmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat1
   return __riscv_vfnmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfnmsub(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfnmsub(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfnmsub(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfnmsub(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfnmsub(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfnmsub(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfrdiv.c
+++ b/auto-generated/gnu-overloaded-tests/vfrdiv.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, vl);
 }
 
@@ -67,27 +67,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, vl);
 }
 
@@ -127,27 +127,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1
   return __riscv_vfrdiv(vm, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -187,27 +187,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_rm(vfloat64m8_t vs2, float64_t rs1, size_t vl)
   return __riscv_vfrdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfrsub.c
+++ b/auto-generated/gnu-overloaded-tests/vfrsub.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vs2, rs1, vl);
 }
 
@@ -67,27 +67,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl) {
   return __riscv_vfrsub(vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, vl);
 }
 
@@ -127,27 +127,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1
   return __riscv_vfrsub(vm, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -187,27 +187,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8_rm(vfloat64m8_t vs2, float64_t rs1, size_t vl)
   return __riscv_vfrsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfsgnj.c
+++ b/auto-generated/gnu-overloaded-tests/vfsgnj.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t
   return __riscv_vfsgnj(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnj_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnj_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t
   return __riscv_vfsgnj(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnj_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnj_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vfsgnj(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnj_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnj_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl)
   return __riscv_vfsgnj(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnj_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnj_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl)
   return __riscv_vfsgnj(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnj_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnj_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl)
   return __riscv_vfsgnj(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnj_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnj_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16m
   return __riscv_vfsgnj(vm, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnj_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnj_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16m
   return __riscv_vfsgnj(vm, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnj_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnj_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vfsgnj(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnj_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnj_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t 
   return __riscv_vfsgnj(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnj_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnj_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t 
   return __riscv_vfsgnj(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnj_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnj_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t 
   return __riscv_vfsgnj(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnj_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnj_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfsgnjn.c
+++ b/auto-generated/gnu-overloaded-tests/vfsgnjn.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_
   return __riscv_vfsgnjn(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjn_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjn_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_
   return __riscv_vfsgnjn(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjn_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjn_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl
   return __riscv_vfsgnjn(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjn_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjn_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl
   return __riscv_vfsgnjn(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjn_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjn_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl
   return __riscv_vfsgnjn(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjn_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjn_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl
   return __riscv_vfsgnjn(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjn_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjn_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16
   return __riscv_vfsgnjn(vm, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjn_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjn_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16
   return __riscv_vfsgnjn(vm, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjn_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjn_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_
   return __riscv_vfsgnjn(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjn_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjn_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t
   return __riscv_vfsgnjn(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjn_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjn_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t
   return __riscv_vfsgnjn(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjn_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjn_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t
   return __riscv_vfsgnjn(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjn_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjn_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfsgnjx.c
+++ b/auto-generated/gnu-overloaded-tests/vfsgnjx.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_
   return __riscv_vfsgnjx(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjx_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjx_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_
   return __riscv_vfsgnjx(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjx_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjx_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl
   return __riscv_vfsgnjx(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjx_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjx_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl
   return __riscv_vfsgnjx(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjx_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjx_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl
   return __riscv_vfsgnjx(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjx_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjx_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl
   return __riscv_vfsgnjx(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjx_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjx_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16
   return __riscv_vfsgnjx(vm, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjx_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjx_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16
   return __riscv_vfsgnjx(vm, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjx_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjx_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_
   return __riscv_vfsgnjx(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjx_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjx_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t
   return __riscv_vfsgnjx(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjx_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjx_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t
   return __riscv_vfsgnjx(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjx_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjx_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t
   return __riscv_vfsgnjx(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjx_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjx_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfslide1down.c
+++ b/auto-generated/gnu-overloaded-tests/vfslide1down.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfslide1down_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1down_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down(vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1down_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1down_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down(vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1down_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1down_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down(vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1down_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1down_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down(vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1down_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1down_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down(vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1down_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1down_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down(vs2, rs1, vl);
 }
 
@@ -67,27 +67,27 @@ vfloat64m8_t test_vfslide1down_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t 
   return __riscv_vfslide1down(vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfslide1down_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1down_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down(vm, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1down_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1down_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down(vm, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1down_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1down_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down(vm, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1down_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1down_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down(vm, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1down_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1down_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down(vm, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1down_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1down_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfslide1up.c
+++ b/auto-generated/gnu-overloaded-tests/vfslide1up.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfslide1up_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1up_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up(vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1up_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1up_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up(vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1up_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1up_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up(vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1up_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1up_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up(vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1up_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1up_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up(vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1up_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1up_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up(vs2, rs1, vl);
 }
 
@@ -67,27 +67,27 @@ vfloat64m8_t test_vfslide1up_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl
   return __riscv_vfslide1up(vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfslide1up_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1up_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up(vm, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1up_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1up_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up(vm, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1up_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1up_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up(vm, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1up_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1up_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up(vm, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1up_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1up_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up(vm, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1up_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1up_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfsub.c
+++ b/auto-generated/gnu-overloaded-tests/vfsub.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vfsub(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vfsub(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfsub_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl) 
   return __riscv_vfsub(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfsub_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) 
   return __riscv_vfsub(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfsub_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) 
   return __riscv_vfsub(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfsub_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) 
   return __riscv_vfsub(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vfsub(vm, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vfsub(vm, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t 
   return __riscv_vfsub(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t v
   return __riscv_vfsub(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t v
   return __riscv_vfsub(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t v
   return __riscv_vfsub(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size
   return __riscv_vfsub(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size
   return __riscv_vfsub(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t v
   return __riscv_vfsub(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t v
   return __riscv_vfsub(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t v
   return __riscv_vfsub(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t v
   return __riscv_vfsub(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat1
   return __riscv_vfsub(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat1
   return __riscv_vfsub(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1
   return __riscv_vfsub(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_
   return __riscv_vfsub(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_
   return __riscv_vfsub(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_
   return __riscv_vfsub(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfwadd.c
+++ b/auto-generated/gnu-overloaded-tests/vfwadd.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t
   return __riscv_vfwadd_vv(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2(vfloat32mf2_t vs2, vfloat16mf4_t vs1, size_t
   return __riscv_vfwadd_wv(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2(vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2(vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t v
   return __riscv_vfwadd_vv(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1(vfloat32m1_t vs2, vfloat16mf2_t vs1, size_t vl
   return __riscv_vfwadd_wv(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1(vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1(vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vfwadd_vv(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2(vfloat32m2_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vfwadd_wv(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2(vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2(vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, vl);
 }
 
@@ -59,7 +59,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl)
   return __riscv_vfwadd_vv(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4(vfloat32m4_t vs2, vfloat16m2_t vs1, size_t vl)
   return __riscv_vfwadd_wv(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4(vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4(vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, vl);
 }
 
@@ -75,7 +75,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl)
   return __riscv_vfwadd_vv(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8(vfloat32m8_t vs2, vfloat16m4_t vs1, size_t vl)
   return __riscv_vfwadd_wv(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8(vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8(vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16m
   return __riscv_vfwadd_vv(vm, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2, vfloat16m
   return __riscv_vfwadd_wv(vm, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2
   return __riscv_vfwadd_vv(vm, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_m(vbool32_t vm, vfloat32m1_t vs2, vfloat16mf2_
   return __riscv_vfwadd_wv(vm, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vfwadd_vv(vm, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, vl);
 }
 
@@ -195,7 +195,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_m(vbool16_t vm, vfloat32m2_t vs2, vfloat16m1_t
   return __riscv_vfwadd_wv(vm, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_m(vbool16_t vm, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_m(vbool16_t vm, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, vl);
 }
 
@@ -203,7 +203,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t 
   return __riscv_vfwadd_vv(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, vl);
 }
 
@@ -211,7 +211,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_m(vbool8_t vm, vfloat32m4_t vs2, vfloat16m2_t 
   return __riscv_vfwadd_wv(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, vl);
 }
 
@@ -219,7 +219,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t 
   return __riscv_vfwadd_vv(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_m(vbool4_t vm, vfloat32m8_t vs2, vfloat16m4_t 
   return __riscv_vfwadd_wv(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, vl);
 }
 
@@ -299,7 +299,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1, siz
   return __riscv_vfwadd_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_rm(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_rm(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -307,7 +307,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm(vfloat32mf2_t vs2, vfloat16mf4_t vs1, siz
   return __riscv_vfwadd_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_rm(vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_rm(vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -315,7 +315,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_
   return __riscv_vfwadd_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_rm(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_rm(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -323,7 +323,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm(vfloat32m1_t vs2, vfloat16mf2_t vs1, size_t
   return __riscv_vfwadd_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_rm(vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_rm(vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -331,7 +331,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t 
   return __riscv_vfwadd_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_rm(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -339,7 +339,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm(vfloat32m2_t vs2, vfloat16m1_t vs1, size_t 
   return __riscv_vfwadd_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_rm(vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_rm(vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -347,7 +347,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t 
   return __riscv_vfwadd_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_rm(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -355,7 +355,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm(vfloat32m4_t vs2, vfloat16m2_t vs1, size_t 
   return __riscv_vfwadd_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_rm(vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_rm(vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -363,7 +363,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t 
   return __riscv_vfwadd_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_rm(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm(vfloat32m8_t vs2, vfloat16m4_t vs1, size_t 
   return __riscv_vfwadd_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_rm(vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_rm(vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -443,7 +443,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat
   return __riscv_vfwadd_vv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -451,7 +451,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2, vfloat
   return __riscv_vfwadd_wv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +459,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16
   return __riscv_vfwadd_vv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -467,7 +467,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2, vfloat16m
   return __riscv_vfwadd_wv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -475,7 +475,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m
   return __riscv_vfwadd_vv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -483,7 +483,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2, vfloat16m
   return __riscv_vfwadd_wv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2
   return __riscv_vfwadd_vv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2, vfloat16m2
   return __riscv_vfwadd_wv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4
   return __riscv_vfwadd_vv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2, vfloat16m4
   return __riscv_vfwadd_wv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfwmacc.c
+++ b/auto-generated/gnu-overloaded-tests/vfwmacc.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1, vfloat
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloat16m
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat16m1
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat16m2
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat16m4
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, vfloat16m
   return __riscv_vfwmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_
   return __riscv_vfwmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t
   return __riscv_vfwmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t 
   return __riscv_vfwmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t 
   return __riscv_vfwmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloat
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, vfloat16m
   return __riscv_vfwmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, vfloat16m
   return __riscv_vfwmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, vfloat16m2
   return __riscv_vfwmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, vfloat16m4
   return __riscv_vfwmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfwmsac.c
+++ b/auto-generated/gnu-overloaded-tests/vfwmsac.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1, vfloat
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloat16m
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat16m1
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat16m2
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat16m4
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, vfloat16m
   return __riscv_vfwmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_
   return __riscv_vfwmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t
   return __riscv_vfwmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t 
   return __riscv_vfwmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t 
   return __riscv_vfwmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloat
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, vfloat16m
   return __riscv_vfwmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, vfloat16m
   return __riscv_vfwmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, vfloat16m2
   return __riscv_vfwmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, vfloat16m4
   return __riscv_vfwmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfwmul.c
+++ b/auto-generated/gnu-overloaded-tests/vfwmul.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t
   return __riscv_vfwmul(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t v
   return __riscv_vfwmul(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vfwmul(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl)
   return __riscv_vfwmul(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl)
   return __riscv_vfwmul(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vs2, rs1, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16m
   return __riscv_vfwmul(vm, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2
   return __riscv_vfwmul(vm, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vfwmul(vm, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t 
   return __riscv_vfwmul(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t 
   return __riscv_vfwmul(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1, siz
   return __riscv_vfwmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_rm(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_rm(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_
   return __riscv_vfwmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_rm(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_rm(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t 
   return __riscv_vfwmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_rm(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t 
   return __riscv_vfwmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_rm(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t 
   return __riscv_vfwmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_rm(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat
   return __riscv_vfwmul(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16
   return __riscv_vfwmul(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m
   return __riscv_vfwmul(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2
   return __riscv_vfwmul(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4
   return __riscv_vfwmul(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfwnmacc.c
+++ b/auto-generated/gnu-overloaded-tests/vfwnmacc.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1, vfloa
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloat16
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat16m
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat16m
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat16m
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, vfloat16
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1, vf
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloa
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, vfloat16
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, vfloat16
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, vfloat16m
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, vfloat16m
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfwnmsac.c
+++ b/auto-generated/gnu-overloaded-tests/vfwnmsac.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1, vfloa
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloat16
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat16m
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat16m
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat16m
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, vfloat16
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1, vf
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloa
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, vfloat16
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, vfloat16
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, vfloat16m
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, vfloat16m
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vfwsub.c
+++ b/auto-generated/gnu-overloaded-tests/vfwsub.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t
   return __riscv_vfwsub_vv(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2(vfloat32mf2_t vs2, vfloat16mf4_t vs1, size_t
   return __riscv_vfwsub_wv(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2(vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2(vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t v
   return __riscv_vfwsub_vv(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1(vfloat32m1_t vs2, vfloat16mf2_t vs1, size_t vl
   return __riscv_vfwsub_wv(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1(vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1(vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vfwsub_vv(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2(vfloat32m2_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vfwsub_wv(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2(vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2(vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, vl);
 }
 
@@ -59,7 +59,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl)
   return __riscv_vfwsub_vv(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4(vfloat32m4_t vs2, vfloat16m2_t vs1, size_t vl)
   return __riscv_vfwsub_wv(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4(vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4(vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, vl);
 }
 
@@ -75,7 +75,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl)
   return __riscv_vfwsub_vv(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8(vfloat32m8_t vs2, vfloat16m4_t vs1, size_t vl)
   return __riscv_vfwsub_wv(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8(vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8(vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16m
   return __riscv_vfwsub_vv(vm, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2, vfloat16m
   return __riscv_vfwsub_wv(vm, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2
   return __riscv_vfwsub_vv(vm, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_m(vbool32_t vm, vfloat32m1_t vs2, vfloat16mf2_
   return __riscv_vfwsub_wv(vm, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vfwsub_vv(vm, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, vl);
 }
 
@@ -195,7 +195,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_m(vbool16_t vm, vfloat32m2_t vs2, vfloat16m1_t
   return __riscv_vfwsub_wv(vm, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_m(vbool16_t vm, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_m(vbool16_t vm, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, vl);
 }
 
@@ -203,7 +203,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t 
   return __riscv_vfwsub_vv(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, vl);
 }
 
@@ -211,7 +211,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_m(vbool8_t vm, vfloat32m4_t vs2, vfloat16m2_t 
   return __riscv_vfwsub_wv(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, vl);
 }
 
@@ -219,7 +219,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t 
   return __riscv_vfwsub_vv(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_m(vbool4_t vm, vfloat32m8_t vs2, vfloat16m4_t 
   return __riscv_vfwsub_wv(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, vl);
 }
 
@@ -299,7 +299,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1, siz
   return __riscv_vfwsub_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_rm(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_rm(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -307,7 +307,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm(vfloat32mf2_t vs2, vfloat16mf4_t vs1, siz
   return __riscv_vfwsub_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_rm(vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_rm(vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -315,7 +315,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_
   return __riscv_vfwsub_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_rm(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_rm(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -323,7 +323,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm(vfloat32m1_t vs2, vfloat16mf2_t vs1, size_t
   return __riscv_vfwsub_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_rm(vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_rm(vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -331,7 +331,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t 
   return __riscv_vfwsub_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_rm(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -339,7 +339,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm(vfloat32m2_t vs2, vfloat16m1_t vs1, size_t 
   return __riscv_vfwsub_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_rm(vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_rm(vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -347,7 +347,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t 
   return __riscv_vfwsub_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_rm(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -355,7 +355,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm(vfloat32m4_t vs2, vfloat16m2_t vs1, size_t 
   return __riscv_vfwsub_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_rm(vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_rm(vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -363,7 +363,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t 
   return __riscv_vfwsub_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_rm(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm(vfloat32m8_t vs2, vfloat16m4_t vs1, size_t 
   return __riscv_vfwsub_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_rm(vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_rm(vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -443,7 +443,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat
   return __riscv_vfwsub_vv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -451,7 +451,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2, vfloat
   return __riscv_vfwsub_wv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +459,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16
   return __riscv_vfwsub_vv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -467,7 +467,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2, vfloat16m
   return __riscv_vfwsub_wv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -475,7 +475,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m
   return __riscv_vfwsub_vv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -483,7 +483,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2, vfloat16m
   return __riscv_vfwsub_wv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2
   return __riscv_vfwsub_vv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2, vfloat16m2
   return __riscv_vfwsub_wv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4
   return __riscv_vfwsub_vv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2, vfloat16m4
   return __riscv_vfwsub_wv(vm, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vmfeq.c
+++ b/auto-generated/gnu-overloaded-tests/vmfeq.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfeq_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vmfeq(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfeq_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfeq_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfeq_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vmfeq(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfeq_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfeq_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfeq_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vmfeq(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfeq_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfeq_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfeq_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfeq(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfeq_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfeq_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfeq_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfeq(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfeq_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfeq_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfeq_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfeq(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfeq_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfeq_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vbool64_t test_vmfeq_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vmfeq(vm, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfeq_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfeq_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vbool32_t test_vmfeq_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vmfeq(vm, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfeq_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfeq_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vbool16_t test_vmfeq_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vmfeq(vm, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfeq_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfeq_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vbool8_t test_vmfeq_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs
   return __riscv_vmfeq(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfeq_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfeq_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vbool4_t test_vmfeq_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs
   return __riscv_vmfeq(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfeq_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfeq_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vbool2_t test_vmfeq_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs
   return __riscv_vmfeq(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfeq_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfeq_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vmfge.c
+++ b/auto-generated/gnu-overloaded-tests/vmfge.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfge_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vmfge(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfge_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfge_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfge_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vmfge(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfge_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfge_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfge_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vmfge(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfge_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfge_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfge_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfge(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfge_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfge_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfge_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfge(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfge_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfge_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfge_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfge(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfge_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfge_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vbool64_t test_vmfge_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vmfge(vm, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfge_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfge_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vbool32_t test_vmfge_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vmfge(vm, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfge_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfge_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vbool16_t test_vmfge_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vmfge(vm, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfge_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfge_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vbool8_t test_vmfge_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs
   return __riscv_vmfge(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfge_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfge_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vbool4_t test_vmfge_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs
   return __riscv_vmfge(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfge_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfge_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vbool2_t test_vmfge_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs
   return __riscv_vmfge(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfge_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfge_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vmfgt.c
+++ b/auto-generated/gnu-overloaded-tests/vmfgt.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfgt_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vmfgt(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfgt_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfgt_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfgt_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vmfgt(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfgt_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfgt_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfgt_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vmfgt(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfgt_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfgt_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfgt_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfgt(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfgt_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfgt_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfgt_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfgt(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfgt_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfgt_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfgt_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfgt(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfgt_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfgt_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vbool64_t test_vmfgt_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vmfgt(vm, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfgt_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfgt_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vbool32_t test_vmfgt_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vmfgt(vm, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfgt_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfgt_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vbool16_t test_vmfgt_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vmfgt(vm, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfgt_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfgt_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vbool8_t test_vmfgt_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs
   return __riscv_vmfgt(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfgt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfgt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vbool4_t test_vmfgt_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs
   return __riscv_vmfgt(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfgt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfgt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vbool2_t test_vmfgt_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs
   return __riscv_vmfgt(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfgt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfgt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vmfle.c
+++ b/auto-generated/gnu-overloaded-tests/vmfle.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfle_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vmfle(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfle_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfle_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfle_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vmfle(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfle_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfle_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfle_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vmfle(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfle_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfle_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfle_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfle(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfle_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfle_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfle_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfle(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfle_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfle_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfle_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfle(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfle_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfle_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vbool64_t test_vmfle_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vmfle(vm, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfle_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfle_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vbool32_t test_vmfle_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vmfle(vm, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfle_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfle_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vbool16_t test_vmfle_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vmfle(vm, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfle_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfle_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vbool8_t test_vmfle_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs
   return __riscv_vmfle(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfle_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfle_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vbool4_t test_vmfle_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs
   return __riscv_vmfle(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfle_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfle_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vbool2_t test_vmfle_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs
   return __riscv_vmfle(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfle_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfle_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vmflt.c
+++ b/auto-generated/gnu-overloaded-tests/vmflt.c
@@ -11,7 +11,7 @@ vbool64_t test_vmflt_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vmflt(vs2, vs1, vl);
 }
 
-vbool64_t test_vmflt_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmflt_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmflt_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vmflt(vs2, vs1, vl);
 }
 
-vbool32_t test_vmflt_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmflt_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmflt_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vmflt(vs2, vs1, vl);
 }
 
-vbool16_t test_vmflt_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmflt_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmflt_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmflt(vs2, vs1, vl);
 }
 
-vbool8_t test_vmflt_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmflt_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmflt_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmflt(vs2, vs1, vl);
 }
 
-vbool4_t test_vmflt_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmflt_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmflt_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmflt(vs2, vs1, vl);
 }
 
-vbool2_t test_vmflt_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmflt_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vbool64_t test_vmflt_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vmflt(vm, vs2, vs1, vl);
 }
 
-vbool64_t test_vmflt_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmflt_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vbool32_t test_vmflt_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vmflt(vm, vs2, vs1, vl);
 }
 
-vbool32_t test_vmflt_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmflt_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vbool16_t test_vmflt_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vmflt(vm, vs2, vs1, vl);
 }
 
-vbool16_t test_vmflt_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmflt_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vbool8_t test_vmflt_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs
   return __riscv_vmflt(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmflt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmflt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vbool4_t test_vmflt_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs
   return __riscv_vmflt(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmflt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmflt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vbool2_t test_vmflt_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs
   return __riscv_vmflt(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmflt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmflt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/gnu-overloaded-tests/vmfne.c
+++ b/auto-generated/gnu-overloaded-tests/vmfne.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfne_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t 
   return __riscv_vmfne(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfne_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfne_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfne_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t 
   return __riscv_vmfne(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfne_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfne_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfne_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl)
   return __riscv_vmfne(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfne_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfne_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfne_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfne(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfne_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfne_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfne_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfne(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfne_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfne_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfne_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfne(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfne_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfne_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vbool64_t test_vmfne_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf
   return __riscv_vmfne(vm, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfne_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfne_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vm, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vbool32_t test_vmfne_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf
   return __riscv_vmfne(vm, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfne_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfne_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vm, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vbool16_t test_vmfne_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t
   return __riscv_vmfne(vm, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfne_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfne_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vm, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vbool8_t test_vmfne_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs
   return __riscv_vmfne(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfne_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfne_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vbool4_t test_vmfne_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs
   return __riscv_vmfne(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfne_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfne_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vm, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vbool2_t test_vmfne_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs
   return __riscv_vmfne(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfne_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfne_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/intrinsic_funcs.adoc
+++ b/auto-generated/intrinsic_funcs.adoc
@@ -48970,21 +48970,21 @@ vbool64_t __riscv_vmnot_m_b64(vbool64_t vs, size_t vl);
 
 [,c]
 ----
-unsigned long __riscv_vcpop_m_b1(vbool1_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b2(vbool2_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b4(vbool4_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b8(vbool8_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b16(vbool16_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b32(vbool32_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b64(vbool64_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b1(vbool1_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b2(vbool2_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b4(vbool4_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b8(vbool8_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b16(vbool16_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b32(vbool32_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b64(vbool64_t vs2, size_t vl);
 // masked functions
-unsigned long __riscv_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
 ----
 
 [[vfirst-find-first-set-mask-bit]]
@@ -48992,21 +48992,21 @@ unsigned long __riscv_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
 
 [,c]
 ----
-long __riscv_vfirst_m_b1(vbool1_t vs2, size_t vl);
-long __riscv_vfirst_m_b2(vbool2_t vs2, size_t vl);
-long __riscv_vfirst_m_b4(vbool4_t vs2, size_t vl);
-long __riscv_vfirst_m_b8(vbool8_t vs2, size_t vl);
-long __riscv_vfirst_m_b16(vbool16_t vs2, size_t vl);
-long __riscv_vfirst_m_b32(vbool32_t vs2, size_t vl);
-long __riscv_vfirst_m_b64(vbool64_t vs2, size_t vl);
+int __riscv_vfirst_m_b1(vbool1_t vs2, size_t vl);
+int __riscv_vfirst_m_b2(vbool2_t vs2, size_t vl);
+int __riscv_vfirst_m_b4(vbool4_t vs2, size_t vl);
+int __riscv_vfirst_m_b8(vbool8_t vs2, size_t vl);
+int __riscv_vfirst_m_b16(vbool16_t vs2, size_t vl);
+int __riscv_vfirst_m_b32(vbool32_t vs2, size_t vl);
+int __riscv_vfirst_m_b64(vbool64_t vs2, size_t vl);
 // masked functions
-long __riscv_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl);
-long __riscv_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl);
-long __riscv_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl);
-long __riscv_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl);
-long __riscv_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl);
-long __riscv_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl);
-long __riscv_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
+int __riscv_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl);
+int __riscv_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl);
+int __riscv_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl);
+int __riscv_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl);
+int __riscv_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl);
+int __riscv_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl);
+int __riscv_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
 ----
 
 [[vmsbfm-set-before-first-mask-bit]]

--- a/auto-generated/intrinsic_funcs.adoc
+++ b/auto-generated/intrinsic_funcs.adoc
@@ -38215,24 +38215,24 @@ vuint32m4_t __riscv_vnclipu_wx_u32m4_m(vbool8_t vm, vuint64m8_t vs2, size_t rs1,
 ----
 vfloat16mf4_t __riscv_vfadd_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vfloat16mf4_t __riscv_vfadd_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfadd_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16mf2_t __riscv_vfadd_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vfloat16mf2_t __riscv_vfadd_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfadd_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m1_t __riscv_vfadd_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                     size_t vl);
-vfloat16m1_t __riscv_vfadd_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfadd_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfadd_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                     size_t vl);
-vfloat16m2_t __riscv_vfadd_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfadd_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfadd_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                     size_t vl);
-vfloat16m4_t __riscv_vfadd_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfadd_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfadd_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                     size_t vl);
-vfloat16m8_t __riscv_vfadd_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfadd_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfadd_vv_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vfloat32mf2_t __riscv_vfadd_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
@@ -38263,24 +38263,24 @@ vfloat64m8_t __riscv_vfadd_vv_f64m8(vfloat64m8_t vs2, vfloat64m8_t vs1,
 vfloat64m8_t __riscv_vfadd_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfsub_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vfloat16mf4_t __riscv_vfsub_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsub_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16mf2_t __riscv_vfsub_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vfloat16mf2_t __riscv_vfsub_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsub_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m1_t __riscv_vfsub_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                     size_t vl);
-vfloat16m1_t __riscv_vfsub_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfsub_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsub_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                     size_t vl);
-vfloat16m2_t __riscv_vfsub_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfsub_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsub_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                     size_t vl);
-vfloat16m4_t __riscv_vfsub_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfsub_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsub_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                     size_t vl);
-vfloat16m8_t __riscv_vfsub_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfsub_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsub_vv_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vfloat32mf2_t __riscv_vfsub_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
@@ -38309,18 +38309,14 @@ vfloat64m4_t __riscv_vfsub_vf_f64m4(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfsub_vv_f64m8(vfloat64m8_t vs2, vfloat64m8_t vs1,
                                     size_t vl);
 vfloat64m8_t __riscv_vfsub_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
-vfloat16mf4_t __riscv_vfrsub_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfrsub_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl);
-vfloat16mf2_t __riscv_vfrsub_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfrsub_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl);
-vfloat16m1_t __riscv_vfrsub_vf_f16m1(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
-vfloat16m2_t __riscv_vfrsub_vf_f16m2(vfloat16m2_t vs2, float16_t rs1,
-                                     size_t vl);
-vfloat16m4_t __riscv_vfrsub_vf_f16m4(vfloat16m4_t vs2, float16_t rs1,
-                                     size_t vl);
-vfloat16m8_t __riscv_vfrsub_vf_f16m8(vfloat16m8_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat16m1_t __riscv_vfrsub_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
+vfloat16m2_t __riscv_vfrsub_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m4_t __riscv_vfrsub_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
+vfloat16m8_t __riscv_vfrsub_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrsub_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
                                        size_t vl);
 vfloat32m1_t __riscv_vfrsub_vf_f32m1(vfloat32m1_t vs2, float32_t rs1,
@@ -38358,27 +38354,27 @@ vfloat64m8_t __riscv_vfneg_v_f64m8(vfloat64m8_t vs, size_t vl);
 vfloat16mf4_t __riscv_vfadd_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfadd_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfadd_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
                                       vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfadd_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
                                       vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfadd_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
                                       vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfadd_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
                                       vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfadd_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfadd_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -38418,27 +38414,27 @@ vfloat64m8_t __riscv_vfadd_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfsub_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsub_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsub_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
                                       vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsub_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
                                       vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsub_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
                                       vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsub_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
                                       vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsub_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsub_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -38476,17 +38472,17 @@ vfloat64m8_t __riscv_vfsub_vv_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfsub_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
                                       float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfrsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfrsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfrsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfrsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfrsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfrsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrsub_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                          float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfrsub_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
@@ -38525,27 +38521,27 @@ vfloat64m4_t __riscv_vfneg_v_f64m4_m(vbool16_t vm, vfloat64m4_t vs, size_t vl);
 vfloat64m8_t __riscv_vfneg_v_f64m8_m(vbool8_t vm, vfloat64m8_t vs, size_t vl);
 vfloat16mf4_t __riscv_vfadd_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfadd_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfadd_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                          unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfadd_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfadd_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfadd_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                          unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfadd_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfadd_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfadd_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfadd_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfadd_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfadd_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfadd_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfadd_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfadd_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfadd_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfadd_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfadd_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfadd_vv_f32mf2_rm(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                          unsigned int frm, size_t vl);
@@ -38585,27 +38581,27 @@ vfloat64m8_t __riscv_vfadd_vf_f64m8_rm(vfloat64m8_t vs2, float64_t rs1,
                                        unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfsub_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfsub_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsub_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                          unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfsub_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfsub_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsub_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                          unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfsub_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfsub_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfsub_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfsub_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfsub_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfsub_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfsub_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfsub_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfsub_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfsub_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfsub_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfsub_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfsub_vv_f32mf2_rm(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                          unsigned int frm, size_t vl);
@@ -38643,17 +38639,17 @@ vfloat64m8_t __riscv_vfsub_vv_f64m8_rm(vfloat64m8_t vs2, vfloat64m8_t vs1,
                                        unsigned int frm, size_t vl);
 vfloat64m8_t __riscv_vfsub_vf_f64m8_rm(vfloat64m8_t vs2, float64_t rs1,
                                        unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfrsub_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfrsub_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfrsub_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfrsub_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfrsub_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfrsub_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfrsub_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfrsub_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfrsub_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfrsub_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfrsub_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfrsub_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrsub_vf_f32mf2_rm(vfloat32mf2_t vs2, float32_t rs1,
                                           unsigned int frm, size_t vl);
@@ -38678,37 +38674,37 @@ vfloat16mf4_t __riscv_vfadd_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
                                            vfloat16mf4_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfadd_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
                                            vfloat16mf2_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16m1_t __riscv_vfadd_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
                                          vfloat16m1_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m1_t __riscv_vfadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfadd_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
                                          vfloat16m2_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfadd_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
                                          vfloat16m4_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfadd_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
                                          vfloat16m8_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfadd_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                            vfloat32mf2_t vs1, unsigned int frm,
@@ -38768,37 +38764,37 @@ vfloat16mf4_t __riscv_vfsub_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
                                            vfloat16mf4_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfsub_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
                                            vfloat16mf2_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16m1_t __riscv_vfsub_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
                                          vfloat16m1_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m1_t __riscv_vfsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfsub_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
                                          vfloat16m2_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfsub_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
                                          vfloat16m4_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfsub_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
                                          vfloat16m8_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfsub_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                            vfloat32mf2_t vs1, unsigned int frm,
@@ -38855,22 +38851,22 @@ vfloat64m8_t __riscv_vfsub_vf_f64m8_rm_m(vbool8_t vm, vfloat64m8_t vs2,
                                          float64_t rs1, unsigned int frm,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfrsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfrsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat16m1_t __riscv_vfrsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m2_t __riscv_vfrsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m4_t __riscv_vfrsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m8_t __riscv_vfrsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfrsub_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                             float32_t rs1, unsigned int frm,
@@ -38908,44 +38904,37 @@ vfloat64m8_t __riscv_vfrsub_vf_f64m8_rm_m(vbool8_t vm, vfloat64m8_t vs2,
 ----
 vfloat32mf2_t __riscv_vfwadd_vv_f32mf2(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                        size_t vl);
-vfloat32mf2_t __riscv_vfwadd_vf_f32mf2(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_vf_f32mf2(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_f32mf2(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                        size_t vl);
-vfloat32mf2_t __riscv_vfwadd_wf_f32mf2(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_wf_f32mf2(vfloat32mf2_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_f32m1(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                      size_t vl);
-vfloat32m1_t __riscv_vfwadd_vf_f32m1(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwadd_vf_f32m1(vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_f32m1(vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                      size_t vl);
-vfloat32m1_t __riscv_vfwadd_wf_f32m1(vfloat32m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m1_t __riscv_vfwadd_wf_f32m1(vfloat32m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_f32m2(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vfloat32m2_t __riscv_vfwadd_vf_f32m2(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m2_t __riscv_vfwadd_vf_f32m2(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_f32m2(vfloat32m2_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vfloat32m2_t __riscv_vfwadd_wf_f32m2(vfloat32m2_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m2_t __riscv_vfwadd_wf_f32m2(vfloat32m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_f32m4(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                      size_t vl);
-vfloat32m4_t __riscv_vfwadd_vf_f32m4(vfloat16m2_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m4_t __riscv_vfwadd_vf_f32m4(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_f32m4(vfloat32m4_t vs2, vfloat16m2_t vs1,
                                      size_t vl);
-vfloat32m4_t __riscv_vfwadd_wf_f32m4(vfloat32m4_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m4_t __riscv_vfwadd_wf_f32m4(vfloat32m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_f32m8(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                      size_t vl);
-vfloat32m8_t __riscv_vfwadd_vf_f32m8(vfloat16m4_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m8_t __riscv_vfwadd_vf_f32m8(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_f32m8(vfloat32m8_t vs2, vfloat16m4_t vs1,
                                      size_t vl);
-vfloat32m8_t __riscv_vfwadd_wf_f32m8(vfloat32m8_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m8_t __riscv_vfwadd_wf_f32m8(vfloat32m8_t vs2, _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_f64m1(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                      size_t vl);
 vfloat64m1_t __riscv_vfwadd_vf_f64m1(vfloat32mf2_t vs2, float32_t rs1,
@@ -38980,44 +38969,37 @@ vfloat64m8_t __riscv_vfwadd_wf_f64m8(vfloat64m8_t vs2, float32_t rs1,
                                      size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vv_f32mf2(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                        size_t vl);
-vfloat32mf2_t __riscv_vfwsub_vf_f32mf2(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_vf_f32mf2(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_f32mf2(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                        size_t vl);
-vfloat32mf2_t __riscv_vfwsub_wf_f32mf2(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_wf_f32mf2(vfloat32mf2_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_f32m1(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                      size_t vl);
-vfloat32m1_t __riscv_vfwsub_vf_f32m1(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwsub_vf_f32m1(vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_f32m1(vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                      size_t vl);
-vfloat32m1_t __riscv_vfwsub_wf_f32m1(vfloat32m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m1_t __riscv_vfwsub_wf_f32m1(vfloat32m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_f32m2(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vfloat32m2_t __riscv_vfwsub_vf_f32m2(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m2_t __riscv_vfwsub_vf_f32m2(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_f32m2(vfloat32m2_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vfloat32m2_t __riscv_vfwsub_wf_f32m2(vfloat32m2_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m2_t __riscv_vfwsub_wf_f32m2(vfloat32m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_f32m4(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                      size_t vl);
-vfloat32m4_t __riscv_vfwsub_vf_f32m4(vfloat16m2_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m4_t __riscv_vfwsub_vf_f32m4(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_f32m4(vfloat32m4_t vs2, vfloat16m2_t vs1,
                                      size_t vl);
-vfloat32m4_t __riscv_vfwsub_wf_f32m4(vfloat32m4_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m4_t __riscv_vfwsub_wf_f32m4(vfloat32m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_f32m8(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                      size_t vl);
-vfloat32m8_t __riscv_vfwsub_vf_f32m8(vfloat16m4_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m8_t __riscv_vfwsub_vf_f32m8(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_f32m8(vfloat32m8_t vs2, vfloat16m4_t vs1,
                                      size_t vl);
-vfloat32m8_t __riscv_vfwsub_wf_f32m8(vfloat32m8_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m8_t __riscv_vfwsub_wf_f32m8(vfloat32m8_t vs2, _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_f64m1(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                      size_t vl);
 vfloat64m1_t __riscv_vfwsub_vf_f64m1(vfloat32mf2_t vs2, float32_t rs1,
@@ -39054,43 +39036,43 @@ vfloat64m8_t __riscv_vfwsub_wf_f64m8(vfloat64m8_t vs2, float32_t rs1,
 vfloat32mf2_t __riscv_vfwadd_vv_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
                                          vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                          vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
                                        vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
                                        vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_f32m2_m(vbool16_t vm, vfloat32m2_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_f32m2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
                                        vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_f32m4_m(vbool8_t vm, vfloat32m4_t vs2,
                                        vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
                                        vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_f32m8_m(vbool4_t vm, vfloat32m8_t vs2,
                                        vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_f64m1_m(vbool64_t vm, vfloat32mf2_t vs2,
                                        vfloat32mf2_t vs1, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vf_f64m1_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -39126,43 +39108,43 @@ vfloat64m8_t __riscv_vfwadd_wf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
 vfloat32mf2_t __riscv_vfwsub_vv_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
                                          vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                          vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
                                        vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
                                        vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_f32m2_m(vbool16_t vm, vfloat32m2_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_f32m2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
                                        vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_f32m4_m(vbool8_t vm, vfloat32m4_t vs2,
                                        vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
                                        vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_f32m8_m(vbool4_t vm, vfloat32m8_t vs2,
                                        vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_f64m1_m(vbool64_t vm, vfloat32mf2_t vs2,
                                        vfloat32mf2_t vs1, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vf_f64m1_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -39197,43 +39179,43 @@ vfloat64m8_t __riscv_vfwsub_wf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
                                        float32_t rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vv_f32mf2_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                           unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwadd_vf_f32mf2_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_vf_f32mf2_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_f32mf2_rm(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                           unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwadd_wf_f32mf2_rm(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_wf_f32mf2_rm(vfloat32mf2_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_f32m1_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwadd_vf_f32m1_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwadd_vf_f32m1_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_f32m1_rm(vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwadd_wf_f32m1_rm(vfloat32m1_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwadd_wf_f32m1_rm(vfloat32m1_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_f32m2_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwadd_vf_f32m2_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwadd_vf_f32m2_rm(vfloat16m1_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_f32m2_rm(vfloat32m2_t vs2, vfloat16m1_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwadd_wf_f32m2_rm(vfloat32m2_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwadd_wf_f32m2_rm(vfloat32m2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_f32m4_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwadd_vf_f32m4_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwadd_vf_f32m4_rm(vfloat16m2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_f32m4_rm(vfloat32m4_t vs2, vfloat16m2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwadd_wf_f32m4_rm(vfloat32m4_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwadd_wf_f32m4_rm(vfloat32m4_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_f32m8_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwadd_vf_f32m8_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwadd_vf_f32m8_rm(vfloat16m4_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_f32m8_rm(vfloat32m8_t vs2, vfloat16m4_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwadd_wf_f32m8_rm(vfloat32m8_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwadd_wf_f32m8_rm(vfloat32m8_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_f64m1_rm(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                         unsigned int frm, size_t vl);
@@ -39269,43 +39251,43 @@ vfloat64m8_t __riscv_vfwadd_wf_f64m8_rm(vfloat64m8_t vs2, float32_t rs1,
                                         unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vv_f32mf2_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                           unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwsub_vf_f32mf2_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_vf_f32mf2_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_f32mf2_rm(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                           unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwsub_wf_f32mf2_rm(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_wf_f32mf2_rm(vfloat32mf2_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_f32m1_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwsub_vf_f32m1_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwsub_vf_f32m1_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_f32m1_rm(vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwsub_wf_f32m1_rm(vfloat32m1_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwsub_wf_f32m1_rm(vfloat32m1_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_f32m2_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwsub_vf_f32m2_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwsub_vf_f32m2_rm(vfloat16m1_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_f32m2_rm(vfloat32m2_t vs2, vfloat16m1_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwsub_wf_f32m2_rm(vfloat32m2_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwsub_wf_f32m2_rm(vfloat32m2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_f32m4_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwsub_vf_f32m4_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwsub_vf_f32m4_rm(vfloat16m2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_f32m4_rm(vfloat32m4_t vs2, vfloat16m2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwsub_wf_f32m4_rm(vfloat32m4_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwsub_wf_f32m4_rm(vfloat32m4_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_f32m8_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwsub_vf_f32m8_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwsub_vf_f32m8_rm(vfloat16m4_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_f32m8_rm(vfloat32m8_t vs2, vfloat16m4_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwsub_wf_f32m8_rm(vfloat32m8_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwsub_wf_f32m8_rm(vfloat32m8_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_f64m1_rm(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                         unsigned int frm, size_t vl);
@@ -39344,61 +39326,61 @@ vfloat32mf2_t __riscv_vfwadd_vv_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
                                             vfloat16mf4_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                             vfloat16mf4_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
                                           vfloat16mf2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2,
                                           vfloat16mf2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
                                           vfloat16m1_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
                                           vfloat16m1_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
                                           vfloat16m2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2,
                                           vfloat16m2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
                                           vfloat16m4_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2,
                                           vfloat16m4_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_f64m1_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                           vfloat32mf2_t vs1, unsigned int frm,
@@ -39452,61 +39434,61 @@ vfloat32mf2_t __riscv_vfwsub_vv_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
                                             vfloat16mf4_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                             vfloat16mf4_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
                                           vfloat16mf2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2,
                                           vfloat16mf2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
                                           vfloat16m1_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
                                           vfloat16m1_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
                                           vfloat16m2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2,
                                           vfloat16m2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
                                           vfloat16m4_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2,
                                           vfloat16m4_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_f64m1_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                           vfloat32mf2_t vs1, unsigned int frm,
@@ -39565,24 +39547,24 @@ vfloat64m8_t __riscv_vfwsub_wf_f64m8_rm_m(vbool8_t vm, vfloat64m8_t vs2,
 ----
 vfloat16mf4_t __riscv_vfmul_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vfloat16mf4_t __riscv_vfmul_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfmul_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16mf2_t __riscv_vfmul_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vfloat16mf2_t __riscv_vfmul_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfmul_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m1_t __riscv_vfmul_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                     size_t vl);
-vfloat16m1_t __riscv_vfmul_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfmul_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmul_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                     size_t vl);
-vfloat16m2_t __riscv_vfmul_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfmul_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmul_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                     size_t vl);
-vfloat16m4_t __riscv_vfmul_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfmul_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmul_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                     size_t vl);
-vfloat16m8_t __riscv_vfmul_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfmul_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmul_vv_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vfloat32mf2_t __riscv_vfmul_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
@@ -39613,24 +39595,24 @@ vfloat64m8_t __riscv_vfmul_vv_f64m8(vfloat64m8_t vs2, vfloat64m8_t vs1,
 vfloat64m8_t __riscv_vfmul_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfdiv_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vfloat16mf4_t __riscv_vfdiv_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfdiv_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vfloat16mf2_t __riscv_vfdiv_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfdiv_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m1_t __riscv_vfdiv_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                     size_t vl);
-vfloat16m1_t __riscv_vfdiv_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfdiv_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfdiv_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                     size_t vl);
-vfloat16m2_t __riscv_vfdiv_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfdiv_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfdiv_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                     size_t vl);
-vfloat16m4_t __riscv_vfdiv_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfdiv_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfdiv_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                     size_t vl);
-vfloat16m8_t __riscv_vfdiv_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfdiv_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vv_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
@@ -39659,18 +39641,14 @@ vfloat64m4_t __riscv_vfdiv_vf_f64m4(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfdiv_vv_f64m8(vfloat64m8_t vs2, vfloat64m8_t vs1,
                                     size_t vl);
 vfloat64m8_t __riscv_vfdiv_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
-vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl);
-vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl);
-vfloat16m1_t __riscv_vfrdiv_vf_f16m1(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
-vfloat16m2_t __riscv_vfrdiv_vf_f16m2(vfloat16m2_t vs2, float16_t rs1,
-                                     size_t vl);
-vfloat16m4_t __riscv_vfrdiv_vf_f16m4(vfloat16m4_t vs2, float16_t rs1,
-                                     size_t vl);
-vfloat16m8_t __riscv_vfrdiv_vf_f16m8(vfloat16m8_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat16m1_t __riscv_vfrdiv_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
+vfloat16m2_t __riscv_vfrdiv_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m4_t __riscv_vfrdiv_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
+vfloat16m8_t __riscv_vfrdiv_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
                                        size_t vl);
 vfloat32m1_t __riscv_vfrdiv_vf_f32m1(vfloat32m1_t vs2, float32_t rs1,
@@ -39693,27 +39671,27 @@ vfloat64m8_t __riscv_vfrdiv_vf_f64m8(vfloat64m8_t vs2, float64_t rs1,
 vfloat16mf4_t __riscv_vfmul_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfmul_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmul_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfmul_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmul_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
                                       vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfmul_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmul_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
                                       vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfmul_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmul_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
                                       vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfmul_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmul_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
                                       vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfmul_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmul_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmul_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -39753,27 +39731,27 @@ vfloat64m8_t __riscv_vfmul_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfdiv_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfdiv_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfdiv_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
                                       vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfdiv_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfdiv_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
                                       vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfdiv_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
                                       vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfdiv_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
                                       vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -39811,17 +39789,17 @@ vfloat64m8_t __riscv_vfdiv_vv_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfdiv_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
                                       float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfrdiv_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfrdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfrdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfrdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                          float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfrdiv_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
@@ -39842,27 +39820,27 @@ vfloat64m8_t __riscv_vfrdiv_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
                                        float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfmul_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmul_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfmul_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                          unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmul_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmul_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfmul_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                          unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmul_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmul_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfmul_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmul_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmul_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfmul_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmul_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmul_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfmul_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmul_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmul_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfmul_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmul_vv_f32mf2_rm(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                          unsigned int frm, size_t vl);
@@ -39902,27 +39880,27 @@ vfloat64m8_t __riscv_vfmul_vf_f64m8_rm(vfloat64m8_t vs2, float64_t rs1,
                                        unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfdiv_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                          unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                          unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfdiv_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfdiv_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfdiv_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfdiv_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfdiv_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfdiv_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfdiv_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfdiv_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfdiv_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfdiv_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfdiv_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfdiv_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vv_f32mf2_rm(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                          unsigned int frm, size_t vl);
@@ -39960,17 +39938,17 @@ vfloat64m8_t __riscv_vfdiv_vv_f64m8_rm(vfloat64m8_t vs2, vfloat64m8_t vs1,
                                        unsigned int frm, size_t vl);
 vfloat64m8_t __riscv_vfdiv_vf_f64m8_rm(vfloat64m8_t vs2, float64_t rs1,
                                        unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfrdiv_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfrdiv_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfrdiv_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfrdiv_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfrdiv_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfrdiv_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfrdiv_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfrdiv_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_vf_f32mf2_rm(vfloat32mf2_t vs2, float32_t rs1,
                                           unsigned int frm, size_t vl);
@@ -39995,37 +39973,37 @@ vfloat16mf4_t __riscv_vfmul_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
                                            vfloat16mf4_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfmul_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfmul_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
                                            vfloat16mf2_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfmul_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16m1_t __riscv_vfmul_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
                                          vfloat16m1_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmul_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfmul_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
                                          vfloat16m2_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfmul_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfmul_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
                                          vfloat16m4_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfmul_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfmul_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
                                          vfloat16m8_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfmul_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfmul_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                            vfloat32mf2_t vs1, unsigned int frm,
@@ -40085,37 +40063,37 @@ vfloat16mf4_t __riscv_vfdiv_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
                                            vfloat16mf4_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfdiv_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
                                            vfloat16mf2_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16m1_t __riscv_vfdiv_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
                                          vfloat16m1_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m1_t __riscv_vfdiv_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfdiv_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
                                          vfloat16m2_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfdiv_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfdiv_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
                                          vfloat16m4_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfdiv_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfdiv_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
                                          vfloat16m8_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfdiv_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                            vfloat32mf2_t vs1, unsigned int frm,
@@ -40172,22 +40150,22 @@ vfloat64m8_t __riscv_vfdiv_vf_f64m8_rm_m(vbool8_t vm, vfloat64m8_t vs2,
                                          float64_t rs1, unsigned int frm,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat16m1_t __riscv_vfrdiv_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m2_t __riscv_vfrdiv_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m4_t __riscv_vfrdiv_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m8_t __riscv_vfrdiv_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                             float32_t rs1, unsigned int frm,
@@ -40225,24 +40203,21 @@ vfloat64m8_t __riscv_vfrdiv_vf_f64m8_rm_m(vbool8_t vm, vfloat64m8_t vs2,
 ----
 vfloat32mf2_t __riscv_vfwmul_vv_f32mf2(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                        size_t vl);
-vfloat32mf2_t __riscv_vfwmul_vf_f32mf2(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwmul_vf_f32mf2(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat32m1_t __riscv_vfwmul_vv_f32m1(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                      size_t vl);
-vfloat32m1_t __riscv_vfwmul_vf_f32m1(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwmul_vf_f32m1(vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl);
 vfloat32m2_t __riscv_vfwmul_vv_f32m2(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vfloat32m2_t __riscv_vfwmul_vf_f32m2(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m2_t __riscv_vfwmul_vf_f32m2(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwmul_vv_f32m4(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                      size_t vl);
-vfloat32m4_t __riscv_vfwmul_vf_f32m4(vfloat16m2_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m4_t __riscv_vfwmul_vf_f32m4(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwmul_vv_f32m8(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                      size_t vl);
-vfloat32m8_t __riscv_vfwmul_vf_f32m8(vfloat16m4_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m8_t __riscv_vfwmul_vf_f32m8(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwmul_vv_f64m1(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                      size_t vl);
 vfloat64m1_t __riscv_vfwmul_vf_f64m1(vfloat32mf2_t vs2, float32_t rs1,
@@ -40263,23 +40238,23 @@ vfloat64m8_t __riscv_vfwmul_vf_f64m8(vfloat32m4_t vs2, float32_t rs1,
 vfloat32mf2_t __riscv_vfwmul_vv_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
                                          vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwmul_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwmul_vv_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
                                        vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwmul_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwmul_vv_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwmul_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwmul_vv_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
                                        vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwmul_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwmul_vv_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
                                        vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwmul_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwmul_vv_f64m1_m(vbool64_t vm, vfloat32mf2_t vs2,
                                        vfloat32mf2_t vs1, size_t vl);
 vfloat64m1_t __riscv_vfwmul_vf_f64m1_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -40298,23 +40273,23 @@ vfloat64m8_t __riscv_vfwmul_vf_f64m8_m(vbool8_t vm, vfloat32m4_t vs2,
                                        float32_t rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwmul_vv_f32mf2_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                           unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmul_vf_f32mf2_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwmul_vf_f32mf2_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmul_vv_f32m1_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmul_vf_f32m1_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwmul_vf_f32m1_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmul_vv_f32m2_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmul_vf_f32m2_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwmul_vf_f32m2_rm(vfloat16m1_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmul_vv_f32m4_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmul_vf_f32m4_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwmul_vf_f32m4_rm(vfloat16m2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmul_vv_f32m8_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmul_vf_f32m8_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwmul_vf_f32m8_rm(vfloat16m4_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmul_vv_f64m1_rm(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                         unsigned int frm, size_t vl);
@@ -40337,31 +40312,31 @@ vfloat32mf2_t __riscv_vfwmul_vv_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
                                             vfloat16mf4_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfwmul_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwmul_vv_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
                                           vfloat16mf2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwmul_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwmul_vv_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
                                           vfloat16m1_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwmul_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwmul_vv_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
                                           vfloat16m2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwmul_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwmul_vv_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
                                           vfloat16m4_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwmul_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat64m1_t __riscv_vfwmul_vv_f64m1_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                           vfloat32mf2_t vs1, unsigned int frm,
@@ -40396,27 +40371,27 @@ vfloat64m8_t __riscv_vfwmul_vf_f64m8_rm_m(vbool8_t vm, vfloat32m4_t vs2,
 ----
 vfloat16mf4_t __riscv_vfmacc_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                        vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmacc_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmacc_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                        vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmacc_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmacc_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmacc_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
                                      vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmacc_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmacc_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmacc_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
                                      vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmacc_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmacc_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmacc_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
                                      vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmacc_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmacc_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmacc_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
                                      vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmacc_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmacc_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmacc_vv_f32mf2(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                        vfloat32mf2_t vs2, size_t vl);
@@ -40456,27 +40431,27 @@ vfloat64m8_t __riscv_vfmacc_vf_f64m8(vfloat64m8_t vd, float64_t rs1,
                                      vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmacc_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                         vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                         vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
                                       vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmacc_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmacc_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
                                       vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmacc_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmacc_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
                                       vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmacc_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmacc_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
                                       vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmacc_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmacc_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_vv_f32mf2(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                         vfloat32mf2_t vs2, size_t vl);
@@ -40516,27 +40491,27 @@ vfloat64m8_t __riscv_vfnmacc_vf_f64m8(vfloat64m8_t vd, float64_t rs1,
                                       vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmsac_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                        vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmsac_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsac_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                        vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmsac_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsac_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmsac_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
                                      vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmsac_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsac_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmsac_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
                                      vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmsac_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsac_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmsac_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
                                      vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmsac_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsac_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmsac_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
                                      vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmsac_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsac_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmsac_vv_f32mf2(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                        vfloat32mf2_t vs2, size_t vl);
@@ -40576,27 +40551,27 @@ vfloat64m8_t __riscv_vfmsac_vf_f64m8(vfloat64m8_t vd, float64_t rs1,
                                      vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmsac_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                         vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                         vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
                                       vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsac_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsac_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
                                       vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsac_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsac_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
                                       vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsac_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsac_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
                                       vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsac_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsac_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_vv_f32mf2(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                         vfloat32mf2_t vs2, size_t vl);
@@ -40636,27 +40611,27 @@ vfloat64m8_t __riscv_vfnmsac_vf_f64m8(vfloat64m8_t vd, float64_t rs1,
                                       vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmadd_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                        vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmadd_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmadd_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                        vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmadd_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmadd_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmadd_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
                                      vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmadd_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmadd_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmadd_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
                                      vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmadd_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmadd_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmadd_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
                                      vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmadd_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmadd_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmadd_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
                                      vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmadd_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmadd_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmadd_vv_f32mf2(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                        vfloat32mf2_t vs2, size_t vl);
@@ -40696,27 +40671,27 @@ vfloat64m8_t __riscv_vfmadd_vf_f64m8(vfloat64m8_t vd, float64_t rs1,
                                      vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmadd_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                         vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                         vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
                                       vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmadd_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmadd_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
                                       vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmadd_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmadd_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
                                       vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmadd_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmadd_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
                                       vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmadd_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmadd_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_vv_f32mf2(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                         vfloat32mf2_t vs2, size_t vl);
@@ -40756,27 +40731,27 @@ vfloat64m8_t __riscv_vfnmadd_vf_f64m8(vfloat64m8_t vd, float64_t rs1,
                                       vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmsub_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                        vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmsub_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsub_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                        vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmsub_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsub_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmsub_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
                                      vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmsub_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsub_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmsub_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
                                      vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmsub_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsub_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmsub_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
                                      vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmsub_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsub_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmsub_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
                                      vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmsub_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsub_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmsub_vv_f32mf2(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                        vfloat32mf2_t vs2, size_t vl);
@@ -40816,27 +40791,27 @@ vfloat64m8_t __riscv_vfmsub_vf_f64m8(vfloat64m8_t vd, float64_t rs1,
                                      vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmsub_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                         vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                         vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
                                       vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsub_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsub_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
                                       vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsub_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsub_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
                                       vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsub_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsub_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
                                       vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsub_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsub_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_vv_f32mf2(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                         vfloat32mf2_t vs2, size_t vl);
@@ -40879,37 +40854,37 @@ vfloat16mf4_t __riscv_vfmacc_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
                                          vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfmacc_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
                                          vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmacc_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
                                        vfloat16m1_t vs1, vfloat16m1_t vs2,
                                        size_t vl);
 vfloat16m1_t __riscv_vfmacc_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmacc_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
                                        vfloat16m2_t vs1, vfloat16m2_t vs2,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmacc_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
                                        vfloat16m4_t vs1, vfloat16m4_t vs2,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmacc_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
                                        vfloat16m8_t vs1, vfloat16m8_t vs2,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfmacc_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                          vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -40969,37 +40944,37 @@ vfloat16mf4_t __riscv_vfnmacc_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
                                           vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
                                           vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
                                         vfloat16m1_t vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
                                         vfloat16m2_t vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
                                         vfloat16m4_t vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
                                         vfloat16m8_t vs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -41059,37 +41034,37 @@ vfloat16mf4_t __riscv_vfmsac_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
                                          vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfmsac_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
                                          vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmsac_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
                                        vfloat16m1_t vs1, vfloat16m1_t vs2,
                                        size_t vl);
 vfloat16m1_t __riscv_vfmsac_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmsac_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
                                        vfloat16m2_t vs1, vfloat16m2_t vs2,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmsac_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
                                        vfloat16m4_t vs1, vfloat16m4_t vs2,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmsac_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
                                        vfloat16m8_t vs1, vfloat16m8_t vs2,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfmsac_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                          vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -41149,37 +41124,37 @@ vfloat16mf4_t __riscv_vfnmsac_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
                                           vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
                                           vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
                                         vfloat16m1_t vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
                                         vfloat16m2_t vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
                                         vfloat16m4_t vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
                                         vfloat16m8_t vs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -41239,37 +41214,37 @@ vfloat16mf4_t __riscv_vfmadd_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
                                          vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfmadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
                                          vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmadd_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
                                        vfloat16m1_t vs1, vfloat16m1_t vs2,
                                        size_t vl);
 vfloat16m1_t __riscv_vfmadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmadd_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
                                        vfloat16m2_t vs1, vfloat16m2_t vs2,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmadd_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
                                        vfloat16m4_t vs1, vfloat16m4_t vs2,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmadd_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
                                        vfloat16m8_t vs1, vfloat16m8_t vs2,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfmadd_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                          vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -41329,37 +41304,37 @@ vfloat16mf4_t __riscv_vfnmadd_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
                                           vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
                                           vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
                                         vfloat16m1_t vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
                                         vfloat16m2_t vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
                                         vfloat16m4_t vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
                                         vfloat16m8_t vs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -41419,37 +41394,37 @@ vfloat16mf4_t __riscv_vfmsub_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
                                          vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfmsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
                                          vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmsub_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
                                        vfloat16m1_t vs1, vfloat16m1_t vs2,
                                        size_t vl);
 vfloat16m1_t __riscv_vfmsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmsub_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
                                        vfloat16m2_t vs1, vfloat16m2_t vs2,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmsub_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
                                        vfloat16m4_t vs1, vfloat16m4_t vs2,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmsub_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
                                        vfloat16m8_t vs1, vfloat16m8_t vs2,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfmsub_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                          vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -41509,37 +41484,37 @@ vfloat16mf4_t __riscv_vfnmsub_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
                                           vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
                                           vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
                                         vfloat16m1_t vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
                                         vfloat16m2_t vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
                                         vfloat16m4_t vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
                                         vfloat16m8_t vs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -41598,37 +41573,37 @@ vfloat64m8_t __riscv_vfnmsub_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vd,
 vfloat16mf4_t __riscv_vfmacc_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                           vfloat16mf4_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat16mf4_t __riscv_vfmacc_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmacc_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat16mf2_t __riscv_vfmacc_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmacc_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmacc_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
                                         vfloat16m1_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m1_t __riscv_vfmacc_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmacc_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmacc_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
                                         vfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m2_t __riscv_vfmacc_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmacc_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmacc_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
                                         vfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m4_t __riscv_vfmacc_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmacc_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmacc_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
                                         vfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m8_t __riscv_vfmacc_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmacc_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfmacc_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat32mf2_t vs1,
@@ -41688,37 +41663,37 @@ vfloat64m8_t __riscv_vfmacc_vf_f64m8_rm(vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmacc_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                            vfloat16mf2_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m1_t __riscv_vfnmacc_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmacc_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m2_t __riscv_vfnmacc_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmacc_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m4_t __riscv_vfnmacc_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmacc_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
                                          vfloat16m8_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m8_t __riscv_vfnmacc_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmacc_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat32mf2_t vs1,
@@ -41778,37 +41753,37 @@ vfloat64m8_t __riscv_vfnmacc_vf_f64m8_rm(vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmsac_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                           vfloat16mf4_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat16mf4_t __riscv_vfmsac_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsac_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat16mf2_t __riscv_vfmsac_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsac_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmsac_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
                                         vfloat16m1_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m1_t __riscv_vfmsac_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsac_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmsac_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
                                         vfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m2_t __riscv_vfmsac_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsac_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmsac_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
                                         vfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m4_t __riscv_vfmsac_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsac_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmsac_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
                                         vfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m8_t __riscv_vfmsac_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsac_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfmsac_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat32mf2_t vs1,
@@ -41868,37 +41843,37 @@ vfloat64m8_t __riscv_vfmsac_vf_f64m8_rm(vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmsac_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                            vfloat16mf2_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m1_t __riscv_vfnmsac_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsac_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m2_t __riscv_vfnmsac_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsac_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m4_t __riscv_vfnmsac_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsac_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
                                          vfloat16m8_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m8_t __riscv_vfnmsac_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsac_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat32mf2_t vs1,
@@ -41958,37 +41933,37 @@ vfloat64m8_t __riscv_vfnmsac_vf_f64m8_rm(vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmadd_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                           vfloat16mf4_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat16mf4_t __riscv_vfmadd_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmadd_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat16mf2_t __riscv_vfmadd_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmadd_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmadd_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
                                         vfloat16m1_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m1_t __riscv_vfmadd_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmadd_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmadd_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
                                         vfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m2_t __riscv_vfmadd_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmadd_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmadd_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
                                         vfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m4_t __riscv_vfmadd_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmadd_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmadd_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
                                         vfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m8_t __riscv_vfmadd_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmadd_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfmadd_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat32mf2_t vs1,
@@ -42048,37 +42023,37 @@ vfloat64m8_t __riscv_vfmadd_vf_f64m8_rm(vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmadd_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                            vfloat16mf2_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m1_t __riscv_vfnmadd_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmadd_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m2_t __riscv_vfnmadd_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmadd_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m4_t __riscv_vfnmadd_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmadd_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
                                          vfloat16m8_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m8_t __riscv_vfnmadd_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmadd_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat32mf2_t vs1,
@@ -42138,37 +42113,37 @@ vfloat64m8_t __riscv_vfnmadd_vf_f64m8_rm(vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmsub_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                           vfloat16mf4_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat16mf4_t __riscv_vfmsub_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsub_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat16mf2_t __riscv_vfmsub_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsub_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmsub_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
                                         vfloat16m1_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m1_t __riscv_vfmsub_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsub_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmsub_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
                                         vfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m2_t __riscv_vfmsub_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsub_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmsub_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
                                         vfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m4_t __riscv_vfmsub_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsub_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmsub_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
                                         vfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m8_t __riscv_vfmsub_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsub_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfmsub_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat32mf2_t vs1,
@@ -42228,37 +42203,37 @@ vfloat64m8_t __riscv_vfmsub_vf_f64m8_rm(vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmsub_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                            vfloat16mf2_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m1_t __riscv_vfnmsub_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsub_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m2_t __riscv_vfnmsub_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsub_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m4_t __riscv_vfnmsub_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsub_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
                                          vfloat16m8_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m8_t __riscv_vfnmsub_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsub_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat32mf2_t vs1,
@@ -42321,38 +42296,38 @@ vfloat16mf4_t __riscv_vfmacc_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16mf4_t __riscv_vfmacc_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmacc_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmacc_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmacc_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmacc_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmacc_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmacc_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmacc_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs1, vfloat16m8_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmacc_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmacc_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs1,
@@ -42414,38 +42389,38 @@ vfloat16mf4_t __riscv_vfnmacc_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs1,
@@ -42507,38 +42482,38 @@ vfloat16mf4_t __riscv_vfmsac_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16mf4_t __riscv_vfmsac_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsac_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsac_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsac_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsac_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsac_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsac_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsac_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs1, vfloat16m8_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsac_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsac_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs1,
@@ -42600,38 +42575,38 @@ vfloat16mf4_t __riscv_vfnmsac_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs1,
@@ -42693,38 +42668,38 @@ vfloat16mf4_t __riscv_vfmadd_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16mf4_t __riscv_vfmadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmadd_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmadd_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmadd_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmadd_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs1, vfloat16m8_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmadd_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs1,
@@ -42786,38 +42761,38 @@ vfloat16mf4_t __riscv_vfnmadd_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs1,
@@ -42879,38 +42854,38 @@ vfloat16mf4_t __riscv_vfmsub_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16mf4_t __riscv_vfmsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsub_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsub_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsub_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsub_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs1, vfloat16m8_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsub_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs1,
@@ -42972,38 +42947,38 @@ vfloat16mf4_t __riscv_vfnmsub_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs1,
@@ -43069,23 +43044,23 @@ vfloat64m8_t __riscv_vfnmsub_vf_f64m8_rm_m(vbool8_t vm, vfloat64m8_t vd,
 ----
 vfloat32mf2_t __riscv_vfwmacc_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                         vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1,
                                         vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                       vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwmacc_vf_f32m1(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmacc_vf_f32m1(vfloat32m1_t vd, _Float16 vs1,
                                       vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1,
                                       vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmacc_vf_f32m2(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmacc_vf_f32m2(vfloat32m2_t vd, _Float16 vs1,
                                       vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1,
                                       vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmacc_vf_f32m4(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmacc_vf_f32m4(vfloat32m4_t vd, _Float16 vs1,
                                       vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1,
                                       vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmacc_vf_f32m8(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmacc_vf_f32m8(vfloat32m8_t vd, _Float16 vs1,
                                       vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwmacc_vv_f64m1(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                       vfloat32mf2_t vs2, size_t vl);
@@ -43105,23 +43080,23 @@ vfloat64m8_t __riscv_vfwmacc_vf_f64m8(vfloat64m8_t vd, float32_t vs1,
                                       vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                          vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1,
                                          vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                        vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwnmacc_vf_f32m1(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmacc_vf_f32m1(vfloat32m1_t vd, _Float16 vs1,
                                        vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1,
                                        vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwnmacc_vf_f32m2(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmacc_vf_f32m2(vfloat32m2_t vd, _Float16 vs1,
                                        vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1,
                                        vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwnmacc_vf_f32m4(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmacc_vf_f32m4(vfloat32m4_t vd, _Float16 vs1,
                                        vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1,
                                        vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwnmacc_vf_f32m8(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmacc_vf_f32m8(vfloat32m8_t vd, _Float16 vs1,
                                        vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_vv_f64m1(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                        vfloat32mf2_t vs2, size_t vl);
@@ -43141,23 +43116,23 @@ vfloat64m8_t __riscv_vfwnmacc_vf_f64m8(vfloat64m8_t vd, float32_t vs1,
                                        vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwmsac_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                         vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1,
                                         vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                       vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwmsac_vf_f32m1(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmsac_vf_f32m1(vfloat32m1_t vd, _Float16 vs1,
                                       vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1,
                                       vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmsac_vf_f32m2(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmsac_vf_f32m2(vfloat32m2_t vd, _Float16 vs1,
                                       vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1,
                                       vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmsac_vf_f32m4(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmsac_vf_f32m4(vfloat32m4_t vd, _Float16 vs1,
                                       vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1,
                                       vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmsac_vf_f32m8(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmsac_vf_f32m8(vfloat32m8_t vd, _Float16 vs1,
                                       vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwmsac_vv_f64m1(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                       vfloat32mf2_t vs2, size_t vl);
@@ -43177,23 +43152,23 @@ vfloat64m8_t __riscv_vfwmsac_vf_f64m8(vfloat64m8_t vd, float32_t vs1,
                                       vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                          vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1,
                                          vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                        vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwnmsac_vf_f32m1(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmsac_vf_f32m1(vfloat32m1_t vd, _Float16 vs1,
                                        vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1,
                                        vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwnmsac_vf_f32m2(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmsac_vf_f32m2(vfloat32m2_t vd, _Float16 vs1,
                                        vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1,
                                        vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwnmsac_vf_f32m4(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmsac_vf_f32m4(vfloat32m4_t vd, _Float16 vs1,
                                        vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1,
                                        vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwnmsac_vf_f32m8(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmsac_vf_f32m8(vfloat32m8_t vd, _Float16 vs1,
                                        vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_vv_f64m1(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                        vfloat32mf2_t vs2, size_t vl);
@@ -43216,31 +43191,31 @@ vfloat32mf2_t __riscv_vfwmacc_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
-                                          float16_t vs1, vfloat16mf4_t vs2,
+                                          _Float16 vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
                                         vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                         size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
-                                        float16_t vs1, vfloat16mf2_t vs2,
+                                        _Float16 vs1, vfloat16mf2_t vs2,
                                         size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
                                         vfloat16m1_t vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
-                                        float16_t vs1, vfloat16m1_t vs2,
+                                        _Float16 vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
                                         vfloat16m2_t vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
-                                        float16_t vs1, vfloat16m2_t vs2,
+                                        _Float16 vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
                                         vfloat16m4_t vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
-                                        float16_t vs1, vfloat16m4_t vs2,
+                                        _Float16 vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat64m1_t __riscv_vfwmacc_vv_f64m1_m(vbool64_t vm, vfloat64m1_t vd,
                                         vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -43270,31 +43245,31 @@ vfloat32mf2_t __riscv_vfwnmacc_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
-                                           float16_t vs1, vfloat16mf4_t vs2,
+                                           _Float16 vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
                                          vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
-                                         float16_t vs1, vfloat16mf2_t vs2,
+                                         _Float16 vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
                                          vfloat16m1_t vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
-                                         float16_t vs1, vfloat16m1_t vs2,
+                                         _Float16 vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
                                          vfloat16m2_t vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
-                                         float16_t vs1, vfloat16m2_t vs2,
+                                         _Float16 vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
                                          vfloat16m4_t vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
-                                         float16_t vs1, vfloat16m4_t vs2,
+                                         _Float16 vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_vv_f64m1_m(vbool64_t vm, vfloat64m1_t vd,
                                          vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -43324,31 +43299,31 @@ vfloat32mf2_t __riscv_vfwmsac_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
-                                          float16_t vs1, vfloat16mf4_t vs2,
+                                          _Float16 vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
                                         vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                         size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
-                                        float16_t vs1, vfloat16mf2_t vs2,
+                                        _Float16 vs1, vfloat16mf2_t vs2,
                                         size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
                                         vfloat16m1_t vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
-                                        float16_t vs1, vfloat16m1_t vs2,
+                                        _Float16 vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
                                         vfloat16m2_t vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
-                                        float16_t vs1, vfloat16m2_t vs2,
+                                        _Float16 vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
                                         vfloat16m4_t vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
-                                        float16_t vs1, vfloat16m4_t vs2,
+                                        _Float16 vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat64m1_t __riscv_vfwmsac_vv_f64m1_m(vbool64_t vm, vfloat64m1_t vd,
                                         vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -43378,31 +43353,31 @@ vfloat32mf2_t __riscv_vfwnmsac_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
-                                           float16_t vs1, vfloat16mf4_t vs2,
+                                           _Float16 vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
                                          vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
-                                         float16_t vs1, vfloat16mf2_t vs2,
+                                         _Float16 vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
                                          vfloat16m1_t vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
-                                         float16_t vs1, vfloat16m1_t vs2,
+                                         _Float16 vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
                                          vfloat16m2_t vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
-                                         float16_t vs1, vfloat16m2_t vs2,
+                                         _Float16 vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
                                          vfloat16m4_t vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
-                                         float16_t vs1, vfloat16m4_t vs2,
+                                         _Float16 vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_vv_f64m1_m(vbool64_t vm, vfloat64m1_t vd,
                                          vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -43431,31 +43406,31 @@ vfloat64m8_t __riscv_vfwnmsac_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vd,
 vfloat32mf2_t __riscv_vfwmacc_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                          vfloat16mf2_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat32m1_t __riscv_vfwmacc_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmacc_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1,
                                          vfloat16mf2_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat32m2_t __riscv_vfwmacc_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmacc_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat32m4_t __riscv_vfwmacc_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmacc_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat32m8_t __riscv_vfwmacc_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmacc_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat64m1_t __riscv_vfwmacc_vv_f64m1_rm(vfloat64m1_t vd, vfloat32mf2_t vs1,
@@ -43485,31 +43460,31 @@ vfloat64m8_t __riscv_vfwmacc_vf_f64m8_rm(vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwnmacc_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                             vfloat16mf4_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1,
                                             vfloat16mf4_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat32m1_t __riscv_vfwnmacc_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmacc_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1,
                                           vfloat16m1_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat32m2_t __riscv_vfwnmacc_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmacc_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1,
                                           vfloat16m1_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1,
                                           vfloat16m2_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat32m4_t __riscv_vfwnmacc_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmacc_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1,
                                           vfloat16m2_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1,
                                           vfloat16m4_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat32m8_t __riscv_vfwnmacc_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmacc_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1,
                                           vfloat16m4_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_vv_f64m1_rm(vfloat64m1_t vd, vfloat32mf2_t vs1,
@@ -43539,31 +43514,31 @@ vfloat64m8_t __riscv_vfwnmacc_vf_f64m8_rm(vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwmsac_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                          vfloat16mf2_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat32m1_t __riscv_vfwmsac_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmsac_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1,
                                          vfloat16mf2_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat32m2_t __riscv_vfwmsac_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmsac_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat32m4_t __riscv_vfwmsac_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmsac_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat32m8_t __riscv_vfwmsac_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmsac_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat64m1_t __riscv_vfwmsac_vv_f64m1_rm(vfloat64m1_t vd, vfloat32mf2_t vs1,
@@ -43593,31 +43568,31 @@ vfloat64m8_t __riscv_vfwmsac_vf_f64m8_rm(vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwnmsac_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                             vfloat16mf4_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1,
                                             vfloat16mf4_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat32m1_t __riscv_vfwnmsac_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmsac_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1,
                                           vfloat16m1_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat32m2_t __riscv_vfwnmsac_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmsac_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1,
                                           vfloat16m1_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1,
                                           vfloat16m2_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat32m4_t __riscv_vfwnmsac_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmsac_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1,
                                           vfloat16m2_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1,
                                           vfloat16m4_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat32m8_t __riscv_vfwnmsac_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmsac_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1,
                                           vfloat16m4_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_vv_f64m1_rm(vfloat64m1_t vd, vfloat32mf2_t vs1,
@@ -43650,31 +43625,31 @@ vfloat32mf2_t __riscv_vfwmacc_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
-                                             float16_t vs1, vfloat16mf4_t vs2,
+                                             _Float16 vs1, vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
                                            vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
-                                           float16_t vs1, vfloat16mf2_t vs2,
+                                           _Float16 vs1, vfloat16mf2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
-                                           float16_t vs1, vfloat16m1_t vs2,
+                                           _Float16 vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
-                                           float16_t vs1, vfloat16m2_t vs2,
+                                           _Float16 vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
-                                           float16_t vs1, vfloat16m4_t vs2,
+                                           _Float16 vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmacc_vv_f64m1_rm_m(vbool64_t vm, vfloat64m1_t vd,
                                            vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -43705,32 +43680,32 @@ vfloat32mf2_t __riscv_vfwnmacc_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
-                                              float16_t vs1, vfloat16mf4_t vs2,
+                                              _Float16 vs1, vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
-                                            float16_t vs1, vfloat16mf2_t vs2,
+                                            _Float16 vs1, vfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
                                             vfloat16m1_t vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
-                                            float16_t vs1, vfloat16m1_t vs2,
+                                            _Float16 vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
                                             vfloat16m2_t vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
-                                            float16_t vs1, vfloat16m2_t vs2,
+                                            _Float16 vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
                                             vfloat16m4_t vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
-                                            float16_t vs1, vfloat16m4_t vs2,
+                                            _Float16 vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_vv_f64m1_rm_m(vbool64_t vm, vfloat64m1_t vd,
                                             vfloat32mf2_t vs1,
@@ -43762,31 +43737,31 @@ vfloat32mf2_t __riscv_vfwmsac_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
-                                             float16_t vs1, vfloat16mf4_t vs2,
+                                             _Float16 vs1, vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
                                            vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
-                                           float16_t vs1, vfloat16mf2_t vs2,
+                                           _Float16 vs1, vfloat16mf2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
-                                           float16_t vs1, vfloat16m1_t vs2,
+                                           _Float16 vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
-                                           float16_t vs1, vfloat16m2_t vs2,
+                                           _Float16 vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
-                                           float16_t vs1, vfloat16m4_t vs2,
+                                           _Float16 vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmsac_vv_f64m1_rm_m(vbool64_t vm, vfloat64m1_t vd,
                                            vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -43817,32 +43792,32 @@ vfloat32mf2_t __riscv_vfwnmsac_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
-                                              float16_t vs1, vfloat16mf4_t vs2,
+                                              _Float16 vs1, vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
-                                            float16_t vs1, vfloat16mf2_t vs2,
+                                            _Float16 vs1, vfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
                                             vfloat16m1_t vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
-                                            float16_t vs1, vfloat16m1_t vs2,
+                                            _Float16 vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
                                             vfloat16m2_t vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
-                                            float16_t vs1, vfloat16m2_t vs2,
+                                            _Float16 vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
                                             vfloat16m4_t vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
-                                            float16_t vs1, vfloat16m4_t vs2,
+                                            _Float16 vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_vv_f64m1_rm_m(vbool64_t vm, vfloat64m1_t vd,
                                             vfloat32mf2_t vs1,
@@ -44147,24 +44122,24 @@ vfloat64m8_t __riscv_vfrec7_v_f64m8_rm_m(vbool8_t vm, vfloat64m8_t vs2,
 ----
 vfloat16mf4_t __riscv_vfmin_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vfloat16mf4_t __riscv_vfmin_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfmin_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16mf2_t __riscv_vfmin_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vfloat16mf2_t __riscv_vfmin_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfmin_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m1_t __riscv_vfmin_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                     size_t vl);
-vfloat16m1_t __riscv_vfmin_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfmin_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmin_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                     size_t vl);
-vfloat16m2_t __riscv_vfmin_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfmin_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmin_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                     size_t vl);
-vfloat16m4_t __riscv_vfmin_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfmin_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmin_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                     size_t vl);
-vfloat16m8_t __riscv_vfmin_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfmin_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmin_vv_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vfloat32mf2_t __riscv_vfmin_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
@@ -44195,24 +44170,24 @@ vfloat64m8_t __riscv_vfmin_vv_f64m8(vfloat64m8_t vs2, vfloat64m8_t vs1,
 vfloat64m8_t __riscv_vfmin_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfmax_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vfloat16mf4_t __riscv_vfmax_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfmax_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16mf2_t __riscv_vfmax_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vfloat16mf2_t __riscv_vfmax_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfmax_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m1_t __riscv_vfmax_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                     size_t vl);
-vfloat16m1_t __riscv_vfmax_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfmax_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmax_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                     size_t vl);
-vfloat16m2_t __riscv_vfmax_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfmax_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmax_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                     size_t vl);
-vfloat16m4_t __riscv_vfmax_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfmax_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmax_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                     size_t vl);
-vfloat16m8_t __riscv_vfmax_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfmax_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmax_vv_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vfloat32mf2_t __riscv_vfmax_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
@@ -44245,27 +44220,27 @@ vfloat64m8_t __riscv_vfmax_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfmin_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfmin_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmin_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfmin_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmin_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
                                       vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfmin_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmin_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
                                       vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfmin_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmin_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
                                       vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfmin_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmin_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
                                       vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfmin_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmin_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmin_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -44305,27 +44280,27 @@ vfloat64m8_t __riscv_vfmin_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfmax_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfmax_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmax_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfmax_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmax_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
                                       vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfmax_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmax_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
                                       vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfmax_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmax_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
                                       vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfmax_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmax_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
                                       vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfmax_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmax_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmax_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -44371,28 +44346,24 @@ vfloat64m8_t __riscv_vfmax_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
 ----
 vfloat16mf4_t __riscv_vfsgnj_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                        size_t vl);
-vfloat16mf4_t __riscv_vfsgnj_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsgnj_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                        size_t vl);
-vfloat16mf2_t __riscv_vfsgnj_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsgnj_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m1_t __riscv_vfsgnj_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vfloat16m1_t __riscv_vfsgnj_vf_f16m1(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat16m1_t __riscv_vfsgnj_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnj_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                      size_t vl);
-vfloat16m2_t __riscv_vfsgnj_vf_f16m2(vfloat16m2_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat16m2_t __riscv_vfsgnj_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnj_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                      size_t vl);
-vfloat16m4_t __riscv_vfsgnj_vf_f16m4(vfloat16m4_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat16m4_t __riscv_vfsgnj_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnj_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                      size_t vl);
-vfloat16m8_t __riscv_vfsgnj_vf_f16m8(vfloat16m8_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat16m8_t __riscv_vfsgnj_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnj_vv_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfsgnj_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
@@ -44431,27 +44402,27 @@ vfloat64m8_t __riscv_vfsgnj_vf_f64m8(vfloat64m8_t vs2, float64_t rs1,
                                      size_t vl);
 vfloat16mf4_t __riscv_vfsgnjn_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                         size_t vl);
-vfloat16mf4_t __riscv_vfsgnjn_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsgnjn_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                         size_t vl);
-vfloat16mf2_t __riscv_vfsgnjn_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsgnjn_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                       size_t vl);
-vfloat16m1_t __riscv_vfsgnjn_vf_f16m1(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfsgnjn_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                       size_t vl);
-vfloat16m2_t __riscv_vfsgnjn_vf_f16m2(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfsgnjn_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                       size_t vl);
-vfloat16m4_t __riscv_vfsgnjn_vf_f16m4(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfsgnjn_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                       size_t vl);
-vfloat16m8_t __riscv_vfsgnjn_vf_f16m8(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfsgnjn_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn_vv_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                         size_t vl);
@@ -44491,27 +44462,27 @@ vfloat64m8_t __riscv_vfsgnjn_vf_f64m8(vfloat64m8_t vs2, float64_t rs1,
                                       size_t vl);
 vfloat16mf4_t __riscv_vfsgnjx_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                         size_t vl);
-vfloat16mf4_t __riscv_vfsgnjx_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsgnjx_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                         size_t vl);
-vfloat16mf2_t __riscv_vfsgnjx_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsgnjx_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                       size_t vl);
-vfloat16m1_t __riscv_vfsgnjx_vf_f16m1(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfsgnjx_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                       size_t vl);
-vfloat16m2_t __riscv_vfsgnjx_vf_f16m2(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfsgnjx_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                       size_t vl);
-vfloat16m4_t __riscv_vfsgnjx_vf_f16m4(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfsgnjx_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                       size_t vl);
-vfloat16m8_t __riscv_vfsgnjx_vf_f16m8(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfsgnjx_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx_vv_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                         size_t vl);
@@ -44553,27 +44524,27 @@ vfloat64m8_t __riscv_vfsgnjx_vf_f64m8(vfloat64m8_t vs2, float64_t rs1,
 vfloat16mf4_t __riscv_vfsgnj_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
                                          vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnj_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
                                          vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnj_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnj_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnj_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
                                        vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnj_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnj_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
                                        vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnj_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnj_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
                                        vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnj_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnj_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                          vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnj_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -44613,27 +44584,27 @@ vfloat64m8_t __riscv_vfsgnj_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfsgnjn_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
                                           vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnjn_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl);
+                                          _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
                                           vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                          float16_t rs1, size_t vl);
+                                          _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
                                         vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
                                         vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
                                         vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
                                         vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                           vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -44673,27 +44644,27 @@ vfloat64m8_t __riscv_vfsgnjn_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfsgnjx_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
                                           vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnjx_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl);
+                                          _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
                                           vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                          float16_t rs1, size_t vl);
+                                          _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
                                         vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
                                         vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
                                         vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
                                         vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                           vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -44780,25 +44751,24 @@ vfloat64m8_t __riscv_vfabs_v_f64m8_m(vbool8_t vm, vfloat64m8_t vs2, size_t vl);
 ----
 vbool64_t __riscv_vmfeq_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vbool64_t __riscv_vmfeq_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfeq_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool32_t __riscv_vmfeq_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vbool32_t __riscv_vmfeq_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfeq_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool16_t __riscv_vmfeq_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vbool16_t __riscv_vmfeq_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vbool16_t __riscv_vmfeq_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfeq_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                    size_t vl);
-vbool8_t __riscv_vmfeq_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfeq_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfeq_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                    size_t vl);
-vbool4_t __riscv_vmfeq_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfeq_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfeq_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                    size_t vl);
-vbool2_t __riscv_vmfeq_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfeq_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfeq_vv_f32mf2_b64(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vbool64_t __riscv_vmfeq_vf_f32mf2_b64(vfloat32mf2_t vs2, float32_t rs1,
@@ -44834,25 +44804,24 @@ vbool8_t __riscv_vmfeq_vv_f64m8_b8(vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmfeq_vf_f64m8_b8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfne_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vbool64_t __riscv_vmfne_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfne_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool32_t __riscv_vmfne_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vbool32_t __riscv_vmfne_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfne_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool16_t __riscv_vmfne_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vbool16_t __riscv_vmfne_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vbool16_t __riscv_vmfne_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfne_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                    size_t vl);
-vbool8_t __riscv_vmfne_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfne_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfne_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                    size_t vl);
-vbool4_t __riscv_vmfne_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfne_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfne_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                    size_t vl);
-vbool2_t __riscv_vmfne_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfne_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfne_vv_f32mf2_b64(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vbool64_t __riscv_vmfne_vf_f32mf2_b64(vfloat32mf2_t vs2, float32_t rs1,
@@ -44888,25 +44857,24 @@ vbool8_t __riscv_vmfne_vv_f64m8_b8(vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmfne_vf_f64m8_b8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmflt_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vbool64_t __riscv_vmflt_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmflt_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool32_t __riscv_vmflt_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vbool32_t __riscv_vmflt_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmflt_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool16_t __riscv_vmflt_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vbool16_t __riscv_vmflt_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vbool16_t __riscv_vmflt_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmflt_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                    size_t vl);
-vbool8_t __riscv_vmflt_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmflt_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmflt_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                    size_t vl);
-vbool4_t __riscv_vmflt_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmflt_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmflt_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                    size_t vl);
-vbool2_t __riscv_vmflt_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmflt_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmflt_vv_f32mf2_b64(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vbool64_t __riscv_vmflt_vf_f32mf2_b64(vfloat32mf2_t vs2, float32_t rs1,
@@ -44942,25 +44910,24 @@ vbool8_t __riscv_vmflt_vv_f64m8_b8(vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmflt_vf_f64m8_b8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfle_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vbool64_t __riscv_vmfle_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfle_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool32_t __riscv_vmfle_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vbool32_t __riscv_vmfle_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfle_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool16_t __riscv_vmfle_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vbool16_t __riscv_vmfle_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vbool16_t __riscv_vmfle_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfle_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                    size_t vl);
-vbool8_t __riscv_vmfle_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfle_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfle_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                    size_t vl);
-vbool4_t __riscv_vmfle_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfle_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfle_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                    size_t vl);
-vbool2_t __riscv_vmfle_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfle_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfle_vv_f32mf2_b64(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vbool64_t __riscv_vmfle_vf_f32mf2_b64(vfloat32mf2_t vs2, float32_t rs1,
@@ -44996,25 +44963,24 @@ vbool8_t __riscv_vmfle_vv_f64m8_b8(vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmfle_vf_f64m8_b8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfgt_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vbool64_t __riscv_vmfgt_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfgt_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool32_t __riscv_vmfgt_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vbool32_t __riscv_vmfgt_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfgt_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool16_t __riscv_vmfgt_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vbool16_t __riscv_vmfgt_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vbool16_t __riscv_vmfgt_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfgt_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                    size_t vl);
-vbool8_t __riscv_vmfgt_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfgt_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfgt_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                    size_t vl);
-vbool4_t __riscv_vmfgt_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfgt_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfgt_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                    size_t vl);
-vbool2_t __riscv_vmfgt_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfgt_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfgt_vv_f32mf2_b64(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vbool64_t __riscv_vmfgt_vf_f32mf2_b64(vfloat32mf2_t vs2, float32_t rs1,
@@ -45050,25 +45016,24 @@ vbool8_t __riscv_vmfgt_vv_f64m8_b8(vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmfgt_vf_f64m8_b8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfge_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vbool64_t __riscv_vmfge_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfge_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool32_t __riscv_vmfge_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vbool32_t __riscv_vmfge_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfge_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool16_t __riscv_vmfge_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vbool16_t __riscv_vmfge_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vbool16_t __riscv_vmfge_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfge_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                    size_t vl);
-vbool8_t __riscv_vmfge_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfge_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfge_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                    size_t vl);
-vbool4_t __riscv_vmfge_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfge_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfge_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                    size_t vl);
-vbool2_t __riscv_vmfge_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfge_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfge_vv_f32mf2_b64(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vbool64_t __riscv_vmfge_vf_f32mf2_b64(vfloat32mf2_t vs2, float32_t rs1,
@@ -45106,27 +45071,27 @@ vbool8_t __riscv_vmfge_vf_f64m8_b8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfeq_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vbool64_t __riscv_vmfeq_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfeq_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vbool32_t __riscv_vmfeq_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfeq_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vbool16_t __riscv_vmfeq_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfeq_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
                                      vfloat16m2_t vs1, size_t vl);
 vbool8_t __riscv_vmfeq_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfeq_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
                                      vfloat16m4_t vs1, size_t vl);
 vbool4_t __riscv_vmfeq_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfeq_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
                                      vfloat16m8_t vs1, size_t vl);
 vbool2_t __riscv_vmfeq_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfeq_vv_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfeq_vf_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -45166,27 +45131,27 @@ vbool8_t __riscv_vmfeq_vf_f64m8_b8_m(vbool8_t vm, vfloat64m8_t vs2,
 vbool64_t __riscv_vmfne_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vbool64_t __riscv_vmfne_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfne_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vbool32_t __riscv_vmfne_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfne_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vbool16_t __riscv_vmfne_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfne_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
                                      vfloat16m2_t vs1, size_t vl);
 vbool8_t __riscv_vmfne_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfne_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
                                      vfloat16m4_t vs1, size_t vl);
 vbool4_t __riscv_vmfne_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfne_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
                                      vfloat16m8_t vs1, size_t vl);
 vbool2_t __riscv_vmfne_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfne_vv_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfne_vf_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -45226,27 +45191,27 @@ vbool8_t __riscv_vmfne_vf_f64m8_b8_m(vbool8_t vm, vfloat64m8_t vs2,
 vbool64_t __riscv_vmflt_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vbool64_t __riscv_vmflt_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmflt_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vbool32_t __riscv_vmflt_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmflt_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vbool16_t __riscv_vmflt_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmflt_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
                                      vfloat16m2_t vs1, size_t vl);
 vbool8_t __riscv_vmflt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmflt_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
                                      vfloat16m4_t vs1, size_t vl);
 vbool4_t __riscv_vmflt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmflt_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
                                      vfloat16m8_t vs1, size_t vl);
 vbool2_t __riscv_vmflt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmflt_vv_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmflt_vf_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -45286,27 +45251,27 @@ vbool8_t __riscv_vmflt_vf_f64m8_b8_m(vbool8_t vm, vfloat64m8_t vs2,
 vbool64_t __riscv_vmfle_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vbool64_t __riscv_vmfle_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfle_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vbool32_t __riscv_vmfle_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfle_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vbool16_t __riscv_vmfle_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfle_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
                                      vfloat16m2_t vs1, size_t vl);
 vbool8_t __riscv_vmfle_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfle_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
                                      vfloat16m4_t vs1, size_t vl);
 vbool4_t __riscv_vmfle_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfle_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
                                      vfloat16m8_t vs1, size_t vl);
 vbool2_t __riscv_vmfle_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfle_vv_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfle_vf_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -45346,27 +45311,27 @@ vbool8_t __riscv_vmfle_vf_f64m8_b8_m(vbool8_t vm, vfloat64m8_t vs2,
 vbool64_t __riscv_vmfgt_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vbool64_t __riscv_vmfgt_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfgt_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vbool32_t __riscv_vmfgt_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfgt_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vbool16_t __riscv_vmfgt_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfgt_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
                                      vfloat16m2_t vs1, size_t vl);
 vbool8_t __riscv_vmfgt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfgt_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
                                      vfloat16m4_t vs1, size_t vl);
 vbool4_t __riscv_vmfgt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfgt_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
                                      vfloat16m8_t vs1, size_t vl);
 vbool2_t __riscv_vmfgt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfgt_vv_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfgt_vf_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -45406,27 +45371,27 @@ vbool8_t __riscv_vmfgt_vf_f64m8_b8_m(vbool8_t vm, vfloat64m8_t vs2,
 vbool64_t __riscv_vmfge_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vbool64_t __riscv_vmfge_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfge_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vbool32_t __riscv_vmfge_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfge_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vbool16_t __riscv_vmfge_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfge_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
                                      vfloat16m2_t vs1, size_t vl);
 vbool8_t __riscv_vmfge_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfge_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
                                      vfloat16m4_t vs1, size_t vl);
 vbool4_t __riscv_vmfge_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfge_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
                                      vfloat16m8_t vs1, size_t vl);
 vbool2_t __riscv_vmfge_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfge_vv_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfge_vf_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -45519,27 +45484,27 @@ vuint64m8_t __riscv_vfclass_v_u64m8_m(vbool8_t vm, vfloat64m8_t vs2, size_t vl);
 ----
 vfloat16mf4_t __riscv_vmerge_vvm_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                         vbool64_t v0, size_t vl);
-vfloat16mf4_t __riscv_vfmerge_vfm_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfmerge_vfm_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                          vbool64_t v0, size_t vl);
 vfloat16mf2_t __riscv_vmerge_vvm_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                         vbool32_t v0, size_t vl);
-vfloat16mf2_t __riscv_vfmerge_vfm_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfmerge_vfm_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                          vbool32_t v0, size_t vl);
 vfloat16m1_t __riscv_vmerge_vvm_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                       vbool16_t v0, size_t vl);
-vfloat16m1_t __riscv_vfmerge_vfm_f16m1(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfmerge_vfm_f16m1(vfloat16m1_t vs2, _Float16 rs1,
                                        vbool16_t v0, size_t vl);
 vfloat16m2_t __riscv_vmerge_vvm_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                       vbool8_t v0, size_t vl);
-vfloat16m2_t __riscv_vfmerge_vfm_f16m2(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfmerge_vfm_f16m2(vfloat16m2_t vs2, _Float16 rs1,
                                        vbool8_t v0, size_t vl);
 vfloat16m4_t __riscv_vmerge_vvm_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                       vbool4_t v0, size_t vl);
-vfloat16m4_t __riscv_vfmerge_vfm_f16m4(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfmerge_vfm_f16m4(vfloat16m4_t vs2, _Float16 rs1,
                                        vbool4_t v0, size_t vl);
 vfloat16m8_t __riscv_vmerge_vvm_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                       vbool2_t v0, size_t vl);
-vfloat16m8_t __riscv_vfmerge_vfm_f16m8(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfmerge_vfm_f16m8(vfloat16m8_t vs2, _Float16 rs1,
                                        vbool2_t v0, size_t vl);
 vfloat32mf2_t __riscv_vmerge_vvm_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                         vbool64_t v0, size_t vl);
@@ -45585,17 +45550,17 @@ vfloat64m8_t __riscv_vfmerge_vfm_f64m8(vfloat64m8_t vs2, float64_t rs1,
 [,c]
 ----
 vfloat16mf4_t __riscv_vmv_v_v_f16mf4(vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfmv_v_f_f16mf4(float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfmv_v_f_f16mf4(_Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vmv_v_v_f16mf2(vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfmv_v_f_f16mf2(float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfmv_v_f_f16mf2(_Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vmv_v_v_f16m1(vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfmv_v_f_f16m1(float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfmv_v_f_f16m1(_Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vmv_v_v_f16m2(vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfmv_v_f_f16m2(float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfmv_v_f_f16m2(_Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vmv_v_v_f16m4(vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfmv_v_f_f16m4(float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfmv_v_f_f16m4(_Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vmv_v_v_f16m8(vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfmv_v_f_f16m8(float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfmv_v_f_f16m8(_Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vmv_v_v_f32mf2(vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmv_v_f_f32mf2(float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vmv_v_v_f32m1(vfloat32m1_t vs1, size_t vl);
@@ -49221,18 +49186,18 @@ vuint64m8_t __riscv_vid_v_u64m8_m(vbool8_t vm, size_t vl);
 
 [,c]
 ----
-float16_t __riscv_vfmv_f_s_f16mf4_f16(vfloat16mf4_t vs1);
-vfloat16mf4_t __riscv_vfmv_s_f_f16mf4(float16_t rs1, size_t vl);
-float16_t __riscv_vfmv_f_s_f16mf2_f16(vfloat16mf2_t vs1);
-vfloat16mf2_t __riscv_vfmv_s_f_f16mf2(float16_t rs1, size_t vl);
-float16_t __riscv_vfmv_f_s_f16m1_f16(vfloat16m1_t vs1);
-vfloat16m1_t __riscv_vfmv_s_f_f16m1(float16_t rs1, size_t vl);
-float16_t __riscv_vfmv_f_s_f16m2_f16(vfloat16m2_t vs1);
-vfloat16m2_t __riscv_vfmv_s_f_f16m2(float16_t rs1, size_t vl);
-float16_t __riscv_vfmv_f_s_f16m4_f16(vfloat16m4_t vs1);
-vfloat16m4_t __riscv_vfmv_s_f_f16m4(float16_t rs1, size_t vl);
-float16_t __riscv_vfmv_f_s_f16m8_f16(vfloat16m8_t vs1);
-vfloat16m8_t __riscv_vfmv_s_f_f16m8(float16_t rs1, size_t vl);
+_Float16 __riscv_vfmv_f_s_f16mf4_f16(vfloat16mf4_t vs1);
+vfloat16mf4_t __riscv_vfmv_s_f_f16mf4(_Float16 rs1, size_t vl);
+_Float16 __riscv_vfmv_f_s_f16mf2_f16(vfloat16mf2_t vs1);
+vfloat16mf2_t __riscv_vfmv_s_f_f16mf2(_Float16 rs1, size_t vl);
+_Float16 __riscv_vfmv_f_s_f16m1_f16(vfloat16m1_t vs1);
+vfloat16m1_t __riscv_vfmv_s_f_f16m1(_Float16 rs1, size_t vl);
+_Float16 __riscv_vfmv_f_s_f16m2_f16(vfloat16m2_t vs1);
+vfloat16m2_t __riscv_vfmv_s_f_f16m2(_Float16 rs1, size_t vl);
+_Float16 __riscv_vfmv_f_s_f16m4_f16(vfloat16m4_t vs1);
+vfloat16m4_t __riscv_vfmv_s_f_f16m4(_Float16 rs1, size_t vl);
+_Float16 __riscv_vfmv_f_s_f16m8_f16(vfloat16m8_t vs1);
+vfloat16m8_t __riscv_vfmv_s_f_f16m8(_Float16 rs1, size_t vl);
 float32_t __riscv_vfmv_f_s_f32mf2_f32(vfloat32mf2_t vs1);
 vfloat32mf2_t __riscv_vfmv_s_f_f32mf2(float32_t rs1, size_t vl);
 float32_t __riscv_vfmv_f_s_f32m1_f32(vfloat32m1_t vs1);
@@ -49817,17 +49782,17 @@ vuint64m8_t __riscv_vslidedown_vx_u64m8_m(vbool8_t vm, vuint64m8_t vs2,
 
 [,c]
 ----
-vfloat16mf4_t __riscv_vfslide1up_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfslide1up_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl);
-vfloat16mf2_t __riscv_vfslide1up_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfslide1up_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl);
-vfloat16m1_t __riscv_vfslide1up_vf_f16m1(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfslide1up_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl);
-vfloat16m2_t __riscv_vfslide1up_vf_f16m2(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfslide1up_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl);
-vfloat16m4_t __riscv_vfslide1up_vf_f16m4(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfslide1up_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl);
-vfloat16m8_t __riscv_vfslide1up_vf_f16m8(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfslide1up_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfslide1up_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
                                            size_t vl);
@@ -49847,17 +49812,17 @@ vfloat64m4_t __riscv_vfslide1up_vf_f64m4(vfloat64m4_t vs2, float64_t rs1,
                                          size_t vl);
 vfloat64m8_t __riscv_vfslide1up_vf_f64m8(vfloat64m8_t vs2, float64_t rs1,
                                          size_t vl);
-vfloat16mf4_t __riscv_vfslide1down_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfslide1down_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                              size_t vl);
-vfloat16mf2_t __riscv_vfslide1down_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfslide1down_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                              size_t vl);
-vfloat16m1_t __riscv_vfslide1down_vf_f16m1(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfslide1down_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1,
                                            size_t vl);
-vfloat16m2_t __riscv_vfslide1down_vf_f16m2(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfslide1down_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1,
                                            size_t vl);
-vfloat16m4_t __riscv_vfslide1down_vf_f16m4(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfslide1down_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1,
                                            size_t vl);
-vfloat16m8_t __riscv_vfslide1down_vf_f16m8(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfslide1down_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfslide1down_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
                                              size_t vl);
@@ -50006,17 +49971,17 @@ vuint64m8_t __riscv_vslide1down_vx_u64m8(vuint64m8_t vs2, uint64_t rs1,
                                          size_t vl);
 // masked functions
 vfloat16mf4_t __riscv_vfslide1up_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                             float16_t rs1, size_t vl);
+                                             _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfslide1up_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                             float16_t rs1, size_t vl);
+                                             _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfslide1up_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                           float16_t rs1, size_t vl);
+                                           _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfslide1up_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                           float16_t rs1, size_t vl);
+                                           _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfslide1up_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                           float16_t rs1, size_t vl);
+                                           _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfslide1up_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                           float16_t rs1, size_t vl);
+                                           _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfslide1up_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                              float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfslide1up_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
@@ -50036,17 +50001,17 @@ vfloat64m4_t __riscv_vfslide1up_vf_f64m4_m(vbool16_t vm, vfloat64m4_t vs2,
 vfloat64m8_t __riscv_vfslide1up_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
                                            float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfslide1down_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                               float16_t rs1, size_t vl);
+                                               _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfslide1down_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                               float16_t rs1, size_t vl);
+                                               _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfslide1down_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                             float16_t rs1, size_t vl);
+                                             _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfslide1down_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                             float16_t rs1, size_t vl);
+                                             _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfslide1down_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                             float16_t rs1, size_t vl);
+                                             _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfslide1down_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                             float16_t rs1, size_t vl);
+                                             _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfslide1down_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                                float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfslide1down_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,

--- a/auto-generated/intrinsic_funcs/04_vector_floating-point_instructions.adoc
+++ b/auto-generated/intrinsic_funcs/04_vector_floating-point_instructions.adoc
@@ -8,24 +8,24 @@
 ----
 vfloat16mf4_t __riscv_vfadd_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vfloat16mf4_t __riscv_vfadd_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfadd_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16mf2_t __riscv_vfadd_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vfloat16mf2_t __riscv_vfadd_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfadd_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m1_t __riscv_vfadd_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                     size_t vl);
-vfloat16m1_t __riscv_vfadd_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfadd_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfadd_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                     size_t vl);
-vfloat16m2_t __riscv_vfadd_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfadd_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfadd_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                     size_t vl);
-vfloat16m4_t __riscv_vfadd_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfadd_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfadd_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                     size_t vl);
-vfloat16m8_t __riscv_vfadd_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfadd_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfadd_vv_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vfloat32mf2_t __riscv_vfadd_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
@@ -56,24 +56,24 @@ vfloat64m8_t __riscv_vfadd_vv_f64m8(vfloat64m8_t vs2, vfloat64m8_t vs1,
 vfloat64m8_t __riscv_vfadd_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfsub_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vfloat16mf4_t __riscv_vfsub_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsub_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16mf2_t __riscv_vfsub_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vfloat16mf2_t __riscv_vfsub_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsub_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m1_t __riscv_vfsub_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                     size_t vl);
-vfloat16m1_t __riscv_vfsub_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfsub_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsub_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                     size_t vl);
-vfloat16m2_t __riscv_vfsub_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfsub_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsub_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                     size_t vl);
-vfloat16m4_t __riscv_vfsub_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfsub_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsub_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                     size_t vl);
-vfloat16m8_t __riscv_vfsub_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfsub_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsub_vv_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vfloat32mf2_t __riscv_vfsub_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
@@ -102,18 +102,14 @@ vfloat64m4_t __riscv_vfsub_vf_f64m4(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfsub_vv_f64m8(vfloat64m8_t vs2, vfloat64m8_t vs1,
                                     size_t vl);
 vfloat64m8_t __riscv_vfsub_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
-vfloat16mf4_t __riscv_vfrsub_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfrsub_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl);
-vfloat16mf2_t __riscv_vfrsub_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfrsub_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl);
-vfloat16m1_t __riscv_vfrsub_vf_f16m1(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
-vfloat16m2_t __riscv_vfrsub_vf_f16m2(vfloat16m2_t vs2, float16_t rs1,
-                                     size_t vl);
-vfloat16m4_t __riscv_vfrsub_vf_f16m4(vfloat16m4_t vs2, float16_t rs1,
-                                     size_t vl);
-vfloat16m8_t __riscv_vfrsub_vf_f16m8(vfloat16m8_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat16m1_t __riscv_vfrsub_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
+vfloat16m2_t __riscv_vfrsub_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m4_t __riscv_vfrsub_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
+vfloat16m8_t __riscv_vfrsub_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrsub_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
                                        size_t vl);
 vfloat32m1_t __riscv_vfrsub_vf_f32m1(vfloat32m1_t vs2, float32_t rs1,
@@ -151,27 +147,27 @@ vfloat64m8_t __riscv_vfneg_v_f64m8(vfloat64m8_t vs, size_t vl);
 vfloat16mf4_t __riscv_vfadd_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfadd_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfadd_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
                                       vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfadd_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
                                       vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfadd_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
                                       vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfadd_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
                                       vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfadd_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfadd_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -211,27 +207,27 @@ vfloat64m8_t __riscv_vfadd_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfsub_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsub_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsub_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
                                       vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsub_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
                                       vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsub_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
                                       vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsub_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
                                       vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsub_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsub_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -269,17 +265,17 @@ vfloat64m8_t __riscv_vfsub_vv_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfsub_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
                                       float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfrsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfrsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfrsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfrsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfrsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfrsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrsub_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                          float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfrsub_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
@@ -318,27 +314,27 @@ vfloat64m4_t __riscv_vfneg_v_f64m4_m(vbool16_t vm, vfloat64m4_t vs, size_t vl);
 vfloat64m8_t __riscv_vfneg_v_f64m8_m(vbool8_t vm, vfloat64m8_t vs, size_t vl);
 vfloat16mf4_t __riscv_vfadd_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfadd_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfadd_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                          unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfadd_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfadd_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfadd_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                          unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfadd_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfadd_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfadd_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfadd_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfadd_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfadd_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfadd_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfadd_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfadd_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfadd_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfadd_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfadd_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfadd_vv_f32mf2_rm(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                          unsigned int frm, size_t vl);
@@ -378,27 +374,27 @@ vfloat64m8_t __riscv_vfadd_vf_f64m8_rm(vfloat64m8_t vs2, float64_t rs1,
                                        unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfsub_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfsub_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsub_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                          unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfsub_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfsub_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsub_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                          unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfsub_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfsub_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfsub_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfsub_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfsub_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfsub_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfsub_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfsub_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfsub_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfsub_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfsub_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfsub_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfsub_vv_f32mf2_rm(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                          unsigned int frm, size_t vl);
@@ -436,17 +432,17 @@ vfloat64m8_t __riscv_vfsub_vv_f64m8_rm(vfloat64m8_t vs2, vfloat64m8_t vs1,
                                        unsigned int frm, size_t vl);
 vfloat64m8_t __riscv_vfsub_vf_f64m8_rm(vfloat64m8_t vs2, float64_t rs1,
                                        unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfrsub_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfrsub_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfrsub_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfrsub_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfrsub_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfrsub_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfrsub_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfrsub_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfrsub_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfrsub_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfrsub_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfrsub_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrsub_vf_f32mf2_rm(vfloat32mf2_t vs2, float32_t rs1,
                                           unsigned int frm, size_t vl);
@@ -471,37 +467,37 @@ vfloat16mf4_t __riscv_vfadd_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
                                            vfloat16mf4_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfadd_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
                                            vfloat16mf2_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16m1_t __riscv_vfadd_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
                                          vfloat16m1_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m1_t __riscv_vfadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfadd_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
                                          vfloat16m2_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfadd_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
                                          vfloat16m4_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfadd_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
                                          vfloat16m8_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfadd_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                            vfloat32mf2_t vs1, unsigned int frm,
@@ -561,37 +557,37 @@ vfloat16mf4_t __riscv_vfsub_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
                                            vfloat16mf4_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfsub_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
                                            vfloat16mf2_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16m1_t __riscv_vfsub_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
                                          vfloat16m1_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m1_t __riscv_vfsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfsub_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
                                          vfloat16m2_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfsub_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
                                          vfloat16m4_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfsub_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
                                          vfloat16m8_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfsub_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                            vfloat32mf2_t vs1, unsigned int frm,
@@ -648,22 +644,22 @@ vfloat64m8_t __riscv_vfsub_vf_f64m8_rm_m(vbool8_t vm, vfloat64m8_t vs2,
                                          float64_t rs1, unsigned int frm,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfrsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfrsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat16m1_t __riscv_vfrsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m2_t __riscv_vfrsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m4_t __riscv_vfrsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m8_t __riscv_vfrsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfrsub_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                             float32_t rs1, unsigned int frm,
@@ -701,44 +697,37 @@ vfloat64m8_t __riscv_vfrsub_vf_f64m8_rm_m(vbool8_t vm, vfloat64m8_t vs2,
 ----
 vfloat32mf2_t __riscv_vfwadd_vv_f32mf2(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                        size_t vl);
-vfloat32mf2_t __riscv_vfwadd_vf_f32mf2(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_vf_f32mf2(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_f32mf2(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                        size_t vl);
-vfloat32mf2_t __riscv_vfwadd_wf_f32mf2(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_wf_f32mf2(vfloat32mf2_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_f32m1(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                      size_t vl);
-vfloat32m1_t __riscv_vfwadd_vf_f32m1(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwadd_vf_f32m1(vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_f32m1(vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                      size_t vl);
-vfloat32m1_t __riscv_vfwadd_wf_f32m1(vfloat32m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m1_t __riscv_vfwadd_wf_f32m1(vfloat32m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_f32m2(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vfloat32m2_t __riscv_vfwadd_vf_f32m2(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m2_t __riscv_vfwadd_vf_f32m2(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_f32m2(vfloat32m2_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vfloat32m2_t __riscv_vfwadd_wf_f32m2(vfloat32m2_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m2_t __riscv_vfwadd_wf_f32m2(vfloat32m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_f32m4(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                      size_t vl);
-vfloat32m4_t __riscv_vfwadd_vf_f32m4(vfloat16m2_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m4_t __riscv_vfwadd_vf_f32m4(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_f32m4(vfloat32m4_t vs2, vfloat16m2_t vs1,
                                      size_t vl);
-vfloat32m4_t __riscv_vfwadd_wf_f32m4(vfloat32m4_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m4_t __riscv_vfwadd_wf_f32m4(vfloat32m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_f32m8(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                      size_t vl);
-vfloat32m8_t __riscv_vfwadd_vf_f32m8(vfloat16m4_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m8_t __riscv_vfwadd_vf_f32m8(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_f32m8(vfloat32m8_t vs2, vfloat16m4_t vs1,
                                      size_t vl);
-vfloat32m8_t __riscv_vfwadd_wf_f32m8(vfloat32m8_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m8_t __riscv_vfwadd_wf_f32m8(vfloat32m8_t vs2, _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_f64m1(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                      size_t vl);
 vfloat64m1_t __riscv_vfwadd_vf_f64m1(vfloat32mf2_t vs2, float32_t rs1,
@@ -773,44 +762,37 @@ vfloat64m8_t __riscv_vfwadd_wf_f64m8(vfloat64m8_t vs2, float32_t rs1,
                                      size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vv_f32mf2(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                        size_t vl);
-vfloat32mf2_t __riscv_vfwsub_vf_f32mf2(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_vf_f32mf2(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_f32mf2(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                        size_t vl);
-vfloat32mf2_t __riscv_vfwsub_wf_f32mf2(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_wf_f32mf2(vfloat32mf2_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_f32m1(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                      size_t vl);
-vfloat32m1_t __riscv_vfwsub_vf_f32m1(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwsub_vf_f32m1(vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_f32m1(vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                      size_t vl);
-vfloat32m1_t __riscv_vfwsub_wf_f32m1(vfloat32m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m1_t __riscv_vfwsub_wf_f32m1(vfloat32m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_f32m2(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vfloat32m2_t __riscv_vfwsub_vf_f32m2(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m2_t __riscv_vfwsub_vf_f32m2(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_f32m2(vfloat32m2_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vfloat32m2_t __riscv_vfwsub_wf_f32m2(vfloat32m2_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m2_t __riscv_vfwsub_wf_f32m2(vfloat32m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_f32m4(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                      size_t vl);
-vfloat32m4_t __riscv_vfwsub_vf_f32m4(vfloat16m2_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m4_t __riscv_vfwsub_vf_f32m4(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_f32m4(vfloat32m4_t vs2, vfloat16m2_t vs1,
                                      size_t vl);
-vfloat32m4_t __riscv_vfwsub_wf_f32m4(vfloat32m4_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m4_t __riscv_vfwsub_wf_f32m4(vfloat32m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_f32m8(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                      size_t vl);
-vfloat32m8_t __riscv_vfwsub_vf_f32m8(vfloat16m4_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m8_t __riscv_vfwsub_vf_f32m8(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_f32m8(vfloat32m8_t vs2, vfloat16m4_t vs1,
                                      size_t vl);
-vfloat32m8_t __riscv_vfwsub_wf_f32m8(vfloat32m8_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m8_t __riscv_vfwsub_wf_f32m8(vfloat32m8_t vs2, _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_f64m1(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                      size_t vl);
 vfloat64m1_t __riscv_vfwsub_vf_f64m1(vfloat32mf2_t vs2, float32_t rs1,
@@ -847,43 +829,43 @@ vfloat64m8_t __riscv_vfwsub_wf_f64m8(vfloat64m8_t vs2, float32_t rs1,
 vfloat32mf2_t __riscv_vfwadd_vv_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
                                          vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                          vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
                                        vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
                                        vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_f32m2_m(vbool16_t vm, vfloat32m2_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_f32m2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
                                        vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_f32m4_m(vbool8_t vm, vfloat32m4_t vs2,
                                        vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
                                        vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_f32m8_m(vbool4_t vm, vfloat32m8_t vs2,
                                        vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_f64m1_m(vbool64_t vm, vfloat32mf2_t vs2,
                                        vfloat32mf2_t vs1, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vf_f64m1_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -919,43 +901,43 @@ vfloat64m8_t __riscv_vfwadd_wf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
 vfloat32mf2_t __riscv_vfwsub_vv_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
                                          vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                          vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
                                        vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
                                        vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_f32m2_m(vbool16_t vm, vfloat32m2_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_f32m2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
                                        vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_f32m4_m(vbool8_t vm, vfloat32m4_t vs2,
                                        vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
                                        vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_f32m8_m(vbool4_t vm, vfloat32m8_t vs2,
                                        vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_f64m1_m(vbool64_t vm, vfloat32mf2_t vs2,
                                        vfloat32mf2_t vs1, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vf_f64m1_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -990,43 +972,43 @@ vfloat64m8_t __riscv_vfwsub_wf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
                                        float32_t rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vv_f32mf2_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                           unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwadd_vf_f32mf2_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_vf_f32mf2_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_f32mf2_rm(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                           unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwadd_wf_f32mf2_rm(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_wf_f32mf2_rm(vfloat32mf2_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_f32m1_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwadd_vf_f32m1_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwadd_vf_f32m1_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_f32m1_rm(vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwadd_wf_f32m1_rm(vfloat32m1_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwadd_wf_f32m1_rm(vfloat32m1_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_f32m2_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwadd_vf_f32m2_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwadd_vf_f32m2_rm(vfloat16m1_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_f32m2_rm(vfloat32m2_t vs2, vfloat16m1_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwadd_wf_f32m2_rm(vfloat32m2_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwadd_wf_f32m2_rm(vfloat32m2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_f32m4_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwadd_vf_f32m4_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwadd_vf_f32m4_rm(vfloat16m2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_f32m4_rm(vfloat32m4_t vs2, vfloat16m2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwadd_wf_f32m4_rm(vfloat32m4_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwadd_wf_f32m4_rm(vfloat32m4_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_f32m8_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwadd_vf_f32m8_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwadd_vf_f32m8_rm(vfloat16m4_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_f32m8_rm(vfloat32m8_t vs2, vfloat16m4_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwadd_wf_f32m8_rm(vfloat32m8_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwadd_wf_f32m8_rm(vfloat32m8_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_f64m1_rm(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                         unsigned int frm, size_t vl);
@@ -1062,43 +1044,43 @@ vfloat64m8_t __riscv_vfwadd_wf_f64m8_rm(vfloat64m8_t vs2, float32_t rs1,
                                         unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vv_f32mf2_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                           unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwsub_vf_f32mf2_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_vf_f32mf2_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_f32mf2_rm(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                           unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwsub_wf_f32mf2_rm(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_wf_f32mf2_rm(vfloat32mf2_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_f32m1_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwsub_vf_f32m1_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwsub_vf_f32m1_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_f32m1_rm(vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwsub_wf_f32m1_rm(vfloat32m1_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwsub_wf_f32m1_rm(vfloat32m1_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_f32m2_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwsub_vf_f32m2_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwsub_vf_f32m2_rm(vfloat16m1_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_f32m2_rm(vfloat32m2_t vs2, vfloat16m1_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwsub_wf_f32m2_rm(vfloat32m2_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwsub_wf_f32m2_rm(vfloat32m2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_f32m4_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwsub_vf_f32m4_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwsub_vf_f32m4_rm(vfloat16m2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_f32m4_rm(vfloat32m4_t vs2, vfloat16m2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwsub_wf_f32m4_rm(vfloat32m4_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwsub_wf_f32m4_rm(vfloat32m4_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_f32m8_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwsub_vf_f32m8_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwsub_vf_f32m8_rm(vfloat16m4_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_f32m8_rm(vfloat32m8_t vs2, vfloat16m4_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwsub_wf_f32m8_rm(vfloat32m8_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwsub_wf_f32m8_rm(vfloat32m8_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_f64m1_rm(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                         unsigned int frm, size_t vl);
@@ -1137,61 +1119,61 @@ vfloat32mf2_t __riscv_vfwadd_vv_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
                                             vfloat16mf4_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                             vfloat16mf4_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
                                           vfloat16mf2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2,
                                           vfloat16mf2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
                                           vfloat16m1_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
                                           vfloat16m1_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
                                           vfloat16m2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2,
                                           vfloat16m2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
                                           vfloat16m4_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2,
                                           vfloat16m4_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_f64m1_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                           vfloat32mf2_t vs1, unsigned int frm,
@@ -1245,61 +1227,61 @@ vfloat32mf2_t __riscv_vfwsub_vv_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
                                             vfloat16mf4_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                             vfloat16mf4_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
                                           vfloat16mf2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2,
                                           vfloat16mf2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
                                           vfloat16m1_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
                                           vfloat16m1_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
                                           vfloat16m2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2,
                                           vfloat16m2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
                                           vfloat16m4_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2,
                                           vfloat16m4_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_f64m1_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                           vfloat32mf2_t vs1, unsigned int frm,
@@ -1358,24 +1340,24 @@ vfloat64m8_t __riscv_vfwsub_wf_f64m8_rm_m(vbool8_t vm, vfloat64m8_t vs2,
 ----
 vfloat16mf4_t __riscv_vfmul_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vfloat16mf4_t __riscv_vfmul_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfmul_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16mf2_t __riscv_vfmul_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vfloat16mf2_t __riscv_vfmul_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfmul_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m1_t __riscv_vfmul_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                     size_t vl);
-vfloat16m1_t __riscv_vfmul_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfmul_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmul_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                     size_t vl);
-vfloat16m2_t __riscv_vfmul_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfmul_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmul_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                     size_t vl);
-vfloat16m4_t __riscv_vfmul_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfmul_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmul_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                     size_t vl);
-vfloat16m8_t __riscv_vfmul_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfmul_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmul_vv_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vfloat32mf2_t __riscv_vfmul_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
@@ -1406,24 +1388,24 @@ vfloat64m8_t __riscv_vfmul_vv_f64m8(vfloat64m8_t vs2, vfloat64m8_t vs1,
 vfloat64m8_t __riscv_vfmul_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfdiv_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vfloat16mf4_t __riscv_vfdiv_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfdiv_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vfloat16mf2_t __riscv_vfdiv_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfdiv_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m1_t __riscv_vfdiv_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                     size_t vl);
-vfloat16m1_t __riscv_vfdiv_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfdiv_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfdiv_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                     size_t vl);
-vfloat16m2_t __riscv_vfdiv_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfdiv_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfdiv_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                     size_t vl);
-vfloat16m4_t __riscv_vfdiv_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfdiv_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfdiv_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                     size_t vl);
-vfloat16m8_t __riscv_vfdiv_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfdiv_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vv_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
@@ -1452,18 +1434,14 @@ vfloat64m4_t __riscv_vfdiv_vf_f64m4(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfdiv_vv_f64m8(vfloat64m8_t vs2, vfloat64m8_t vs1,
                                     size_t vl);
 vfloat64m8_t __riscv_vfdiv_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
-vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl);
-vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl);
-vfloat16m1_t __riscv_vfrdiv_vf_f16m1(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
-vfloat16m2_t __riscv_vfrdiv_vf_f16m2(vfloat16m2_t vs2, float16_t rs1,
-                                     size_t vl);
-vfloat16m4_t __riscv_vfrdiv_vf_f16m4(vfloat16m4_t vs2, float16_t rs1,
-                                     size_t vl);
-vfloat16m8_t __riscv_vfrdiv_vf_f16m8(vfloat16m8_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat16m1_t __riscv_vfrdiv_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
+vfloat16m2_t __riscv_vfrdiv_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m4_t __riscv_vfrdiv_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
+vfloat16m8_t __riscv_vfrdiv_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
                                        size_t vl);
 vfloat32m1_t __riscv_vfrdiv_vf_f32m1(vfloat32m1_t vs2, float32_t rs1,
@@ -1486,27 +1464,27 @@ vfloat64m8_t __riscv_vfrdiv_vf_f64m8(vfloat64m8_t vs2, float64_t rs1,
 vfloat16mf4_t __riscv_vfmul_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfmul_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmul_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfmul_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmul_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
                                       vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfmul_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmul_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
                                       vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfmul_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmul_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
                                       vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfmul_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmul_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
                                       vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfmul_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmul_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmul_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -1546,27 +1524,27 @@ vfloat64m8_t __riscv_vfmul_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfdiv_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfdiv_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfdiv_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
                                       vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfdiv_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfdiv_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
                                       vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfdiv_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
                                       vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfdiv_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
                                       vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -1604,17 +1582,17 @@ vfloat64m8_t __riscv_vfdiv_vv_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfdiv_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
                                       float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfrdiv_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfrdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfrdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfrdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                          float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfrdiv_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
@@ -1635,27 +1613,27 @@ vfloat64m8_t __riscv_vfrdiv_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
                                        float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfmul_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmul_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfmul_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                          unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmul_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmul_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfmul_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                          unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmul_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmul_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfmul_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmul_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmul_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfmul_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmul_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmul_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfmul_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmul_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmul_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfmul_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmul_vv_f32mf2_rm(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                          unsigned int frm, size_t vl);
@@ -1695,27 +1673,27 @@ vfloat64m8_t __riscv_vfmul_vf_f64m8_rm(vfloat64m8_t vs2, float64_t rs1,
                                        unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfdiv_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                          unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                          unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfdiv_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfdiv_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfdiv_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfdiv_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfdiv_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfdiv_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfdiv_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfdiv_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfdiv_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfdiv_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                        unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfdiv_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfdiv_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1,
                                        unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vv_f32mf2_rm(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                          unsigned int frm, size_t vl);
@@ -1753,17 +1731,17 @@ vfloat64m8_t __riscv_vfdiv_vv_f64m8_rm(vfloat64m8_t vs2, vfloat64m8_t vs1,
                                        unsigned int frm, size_t vl);
 vfloat64m8_t __riscv_vfdiv_vf_f64m8_rm(vfloat64m8_t vs2, float64_t rs1,
                                        unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfrdiv_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfrdiv_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfrdiv_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfrdiv_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfrdiv_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfrdiv_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfrdiv_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfrdiv_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_vf_f32mf2_rm(vfloat32mf2_t vs2, float32_t rs1,
                                           unsigned int frm, size_t vl);
@@ -1788,37 +1766,37 @@ vfloat16mf4_t __riscv_vfmul_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
                                            vfloat16mf4_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfmul_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfmul_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
                                            vfloat16mf2_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfmul_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16m1_t __riscv_vfmul_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
                                          vfloat16m1_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmul_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfmul_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
                                          vfloat16m2_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfmul_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfmul_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
                                          vfloat16m4_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfmul_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfmul_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
                                          vfloat16m8_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfmul_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfmul_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                            vfloat32mf2_t vs1, unsigned int frm,
@@ -1878,37 +1856,37 @@ vfloat16mf4_t __riscv_vfdiv_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
                                            vfloat16mf4_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfdiv_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
                                            vfloat16mf2_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16m1_t __riscv_vfdiv_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
                                          vfloat16m1_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m1_t __riscv_vfdiv_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfdiv_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
                                          vfloat16m2_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfdiv_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfdiv_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
                                          vfloat16m4_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfdiv_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfdiv_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
                                          vfloat16m8_t vs1, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfdiv_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                         float16_t rs1, unsigned int frm,
+                                         _Float16 rs1, unsigned int frm,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                            vfloat32mf2_t vs1, unsigned int frm,
@@ -1965,22 +1943,22 @@ vfloat64m8_t __riscv_vfdiv_vf_f64m8_rm_m(vbool8_t vm, vfloat64m8_t vs2,
                                          float64_t rs1, unsigned int frm,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat16m1_t __riscv_vfrdiv_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m2_t __riscv_vfrdiv_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m4_t __riscv_vfrdiv_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m8_t __riscv_vfrdiv_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                             float32_t rs1, unsigned int frm,
@@ -2018,24 +1996,21 @@ vfloat64m8_t __riscv_vfrdiv_vf_f64m8_rm_m(vbool8_t vm, vfloat64m8_t vs2,
 ----
 vfloat32mf2_t __riscv_vfwmul_vv_f32mf2(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                        size_t vl);
-vfloat32mf2_t __riscv_vfwmul_vf_f32mf2(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwmul_vf_f32mf2(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat32m1_t __riscv_vfwmul_vv_f32m1(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                      size_t vl);
-vfloat32m1_t __riscv_vfwmul_vf_f32m1(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwmul_vf_f32m1(vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl);
 vfloat32m2_t __riscv_vfwmul_vv_f32m2(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vfloat32m2_t __riscv_vfwmul_vf_f32m2(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m2_t __riscv_vfwmul_vf_f32m2(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwmul_vv_f32m4(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                      size_t vl);
-vfloat32m4_t __riscv_vfwmul_vf_f32m4(vfloat16m2_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m4_t __riscv_vfwmul_vf_f32m4(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwmul_vv_f32m8(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                      size_t vl);
-vfloat32m8_t __riscv_vfwmul_vf_f32m8(vfloat16m4_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat32m8_t __riscv_vfwmul_vf_f32m8(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwmul_vv_f64m1(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                      size_t vl);
 vfloat64m1_t __riscv_vfwmul_vf_f64m1(vfloat32mf2_t vs2, float32_t rs1,
@@ -2056,23 +2031,23 @@ vfloat64m8_t __riscv_vfwmul_vf_f64m8(vfloat32m4_t vs2, float32_t rs1,
 vfloat32mf2_t __riscv_vfwmul_vv_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
                                          vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwmul_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwmul_vv_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
                                        vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwmul_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwmul_vv_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwmul_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwmul_vv_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
                                        vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwmul_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwmul_vv_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
                                        vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwmul_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwmul_vv_f64m1_m(vbool64_t vm, vfloat32mf2_t vs2,
                                        vfloat32mf2_t vs1, size_t vl);
 vfloat64m1_t __riscv_vfwmul_vf_f64m1_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -2091,23 +2066,23 @@ vfloat64m8_t __riscv_vfwmul_vf_f64m8_m(vbool8_t vm, vfloat32m4_t vs2,
                                        float32_t rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwmul_vv_f32mf2_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                           unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmul_vf_f32mf2_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwmul_vf_f32mf2_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmul_vv_f32m1_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmul_vf_f32m1_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwmul_vf_f32m1_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmul_vv_f32m2_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmul_vf_f32m2_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwmul_vf_f32m2_rm(vfloat16m1_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmul_vv_f32m4_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmul_vf_f32m4_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwmul_vf_f32m4_rm(vfloat16m2_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmul_vv_f32m8_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                         unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmul_vf_f32m8_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwmul_vf_f32m8_rm(vfloat16m4_t vs2, _Float16 rs1,
                                         unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmul_vv_f64m1_rm(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                         unsigned int frm, size_t vl);
@@ -2130,31 +2105,31 @@ vfloat32mf2_t __riscv_vfwmul_vv_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
                                             vfloat16mf4_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfwmul_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwmul_vv_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
                                           vfloat16mf2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwmul_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwmul_vv_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
                                           vfloat16m1_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwmul_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwmul_vv_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
                                           vfloat16m2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwmul_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwmul_vv_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
                                           vfloat16m4_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwmul_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat64m1_t __riscv_vfwmul_vv_f64m1_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
                                           vfloat32mf2_t vs1, unsigned int frm,
@@ -2189,27 +2164,27 @@ vfloat64m8_t __riscv_vfwmul_vf_f64m8_rm_m(vbool8_t vm, vfloat32m4_t vs2,
 ----
 vfloat16mf4_t __riscv_vfmacc_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                        vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmacc_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmacc_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                        vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmacc_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmacc_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmacc_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
                                      vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmacc_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmacc_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmacc_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
                                      vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmacc_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmacc_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmacc_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
                                      vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmacc_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmacc_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmacc_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
                                      vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmacc_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmacc_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmacc_vv_f32mf2(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                        vfloat32mf2_t vs2, size_t vl);
@@ -2249,27 +2224,27 @@ vfloat64m8_t __riscv_vfmacc_vf_f64m8(vfloat64m8_t vd, float64_t rs1,
                                      vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmacc_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                         vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                         vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
                                       vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmacc_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmacc_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
                                       vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmacc_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmacc_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
                                       vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmacc_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmacc_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
                                       vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmacc_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmacc_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_vv_f32mf2(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                         vfloat32mf2_t vs2, size_t vl);
@@ -2309,27 +2284,27 @@ vfloat64m8_t __riscv_vfnmacc_vf_f64m8(vfloat64m8_t vd, float64_t rs1,
                                       vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmsac_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                        vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmsac_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsac_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                        vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmsac_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsac_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmsac_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
                                      vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmsac_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsac_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmsac_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
                                      vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmsac_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsac_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmsac_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
                                      vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmsac_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsac_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmsac_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
                                      vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmsac_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsac_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmsac_vv_f32mf2(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                        vfloat32mf2_t vs2, size_t vl);
@@ -2369,27 +2344,27 @@ vfloat64m8_t __riscv_vfmsac_vf_f64m8(vfloat64m8_t vd, float64_t rs1,
                                      vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmsac_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                         vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                         vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
                                       vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsac_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsac_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
                                       vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsac_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsac_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
                                       vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsac_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsac_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
                                       vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsac_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsac_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_vv_f32mf2(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                         vfloat32mf2_t vs2, size_t vl);
@@ -2429,27 +2404,27 @@ vfloat64m8_t __riscv_vfnmsac_vf_f64m8(vfloat64m8_t vd, float64_t rs1,
                                       vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmadd_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                        vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmadd_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmadd_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                        vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmadd_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmadd_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmadd_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
                                      vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmadd_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmadd_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmadd_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
                                      vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmadd_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmadd_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmadd_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
                                      vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmadd_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmadd_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmadd_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
                                      vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmadd_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmadd_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmadd_vv_f32mf2(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                        vfloat32mf2_t vs2, size_t vl);
@@ -2489,27 +2464,27 @@ vfloat64m8_t __riscv_vfmadd_vf_f64m8(vfloat64m8_t vd, float64_t rs1,
                                      vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmadd_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                         vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                         vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
                                       vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmadd_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmadd_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
                                       vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmadd_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmadd_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
                                       vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmadd_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmadd_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
                                       vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmadd_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmadd_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_vv_f32mf2(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                         vfloat32mf2_t vs2, size_t vl);
@@ -2549,27 +2524,27 @@ vfloat64m8_t __riscv_vfnmadd_vf_f64m8(vfloat64m8_t vd, float64_t rs1,
                                       vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmsub_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                        vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmsub_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsub_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                        vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmsub_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsub_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmsub_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
                                      vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmsub_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsub_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmsub_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
                                      vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmsub_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsub_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmsub_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
                                      vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmsub_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsub_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmsub_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
                                      vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmsub_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsub_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmsub_vv_f32mf2(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                        vfloat32mf2_t vs2, size_t vl);
@@ -2609,27 +2584,27 @@ vfloat64m8_t __riscv_vfmsub_vf_f64m8(vfloat64m8_t vd, float64_t rs1,
                                      vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmsub_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                         vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                         vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
                                       vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsub_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsub_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
                                       vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsub_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsub_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
                                       vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsub_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsub_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
                                       vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsub_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsub_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_vv_f32mf2(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                         vfloat32mf2_t vs2, size_t vl);
@@ -2672,37 +2647,37 @@ vfloat16mf4_t __riscv_vfmacc_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
                                          vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfmacc_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
                                          vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmacc_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
                                        vfloat16m1_t vs1, vfloat16m1_t vs2,
                                        size_t vl);
 vfloat16m1_t __riscv_vfmacc_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmacc_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
                                        vfloat16m2_t vs1, vfloat16m2_t vs2,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmacc_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
                                        vfloat16m4_t vs1, vfloat16m4_t vs2,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmacc_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
                                        vfloat16m8_t vs1, vfloat16m8_t vs2,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfmacc_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                          vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -2762,37 +2737,37 @@ vfloat16mf4_t __riscv_vfnmacc_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
                                           vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
                                           vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
                                         vfloat16m1_t vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
                                         vfloat16m2_t vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
                                         vfloat16m4_t vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
                                         vfloat16m8_t vs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -2852,37 +2827,37 @@ vfloat16mf4_t __riscv_vfmsac_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
                                          vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfmsac_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
                                          vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmsac_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
                                        vfloat16m1_t vs1, vfloat16m1_t vs2,
                                        size_t vl);
 vfloat16m1_t __riscv_vfmsac_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmsac_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
                                        vfloat16m2_t vs1, vfloat16m2_t vs2,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmsac_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
                                        vfloat16m4_t vs1, vfloat16m4_t vs2,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmsac_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
                                        vfloat16m8_t vs1, vfloat16m8_t vs2,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfmsac_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                          vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -2942,37 +2917,37 @@ vfloat16mf4_t __riscv_vfnmsac_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
                                           vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
                                           vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
                                         vfloat16m1_t vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
                                         vfloat16m2_t vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
                                         vfloat16m4_t vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
                                         vfloat16m8_t vs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -3032,37 +3007,37 @@ vfloat16mf4_t __riscv_vfmadd_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
                                          vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfmadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
                                          vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmadd_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
                                        vfloat16m1_t vs1, vfloat16m1_t vs2,
                                        size_t vl);
 vfloat16m1_t __riscv_vfmadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmadd_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
                                        vfloat16m2_t vs1, vfloat16m2_t vs2,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmadd_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
                                        vfloat16m4_t vs1, vfloat16m4_t vs2,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmadd_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
                                        vfloat16m8_t vs1, vfloat16m8_t vs2,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfmadd_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                          vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -3122,37 +3097,37 @@ vfloat16mf4_t __riscv_vfnmadd_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
                                           vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
                                           vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
                                         vfloat16m1_t vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
                                         vfloat16m2_t vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
                                         vfloat16m4_t vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
                                         vfloat16m8_t vs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -3212,37 +3187,37 @@ vfloat16mf4_t __riscv_vfmsub_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
                                          vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfmsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
                                          vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmsub_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
                                        vfloat16m1_t vs1, vfloat16m1_t vs2,
                                        size_t vl);
 vfloat16m1_t __riscv_vfmsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmsub_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
                                        vfloat16m2_t vs1, vfloat16m2_t vs2,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmsub_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
                                        vfloat16m4_t vs1, vfloat16m4_t vs2,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmsub_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
                                        vfloat16m8_t vs1, vfloat16m8_t vs2,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfmsub_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                          vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -3302,37 +3277,37 @@ vfloat16mf4_t __riscv_vfnmsub_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
                                           vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
                                           vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
                                         vfloat16m1_t vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
                                         vfloat16m2_t vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
                                         vfloat16m4_t vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
                                         vfloat16m8_t vs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -3391,37 +3366,37 @@ vfloat64m8_t __riscv_vfnmsub_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vd,
 vfloat16mf4_t __riscv_vfmacc_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                           vfloat16mf4_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat16mf4_t __riscv_vfmacc_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmacc_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat16mf2_t __riscv_vfmacc_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmacc_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmacc_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
                                         vfloat16m1_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m1_t __riscv_vfmacc_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmacc_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmacc_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
                                         vfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m2_t __riscv_vfmacc_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmacc_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmacc_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
                                         vfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m4_t __riscv_vfmacc_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmacc_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmacc_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
                                         vfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m8_t __riscv_vfmacc_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmacc_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfmacc_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat32mf2_t vs1,
@@ -3481,37 +3456,37 @@ vfloat64m8_t __riscv_vfmacc_vf_f64m8_rm(vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmacc_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                            vfloat16mf2_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m1_t __riscv_vfnmacc_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmacc_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m2_t __riscv_vfnmacc_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmacc_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m4_t __riscv_vfnmacc_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmacc_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
                                          vfloat16m8_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m8_t __riscv_vfnmacc_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmacc_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat32mf2_t vs1,
@@ -3571,37 +3546,37 @@ vfloat64m8_t __riscv_vfnmacc_vf_f64m8_rm(vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmsac_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                           vfloat16mf4_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat16mf4_t __riscv_vfmsac_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsac_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat16mf2_t __riscv_vfmsac_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsac_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmsac_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
                                         vfloat16m1_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m1_t __riscv_vfmsac_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsac_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmsac_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
                                         vfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m2_t __riscv_vfmsac_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsac_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmsac_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
                                         vfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m4_t __riscv_vfmsac_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsac_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmsac_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
                                         vfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m8_t __riscv_vfmsac_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsac_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfmsac_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat32mf2_t vs1,
@@ -3661,37 +3636,37 @@ vfloat64m8_t __riscv_vfmsac_vf_f64m8_rm(vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmsac_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                            vfloat16mf2_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m1_t __riscv_vfnmsac_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsac_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m2_t __riscv_vfnmsac_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsac_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m4_t __riscv_vfnmsac_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsac_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
                                          vfloat16m8_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m8_t __riscv_vfnmsac_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsac_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat32mf2_t vs1,
@@ -3751,37 +3726,37 @@ vfloat64m8_t __riscv_vfnmsac_vf_f64m8_rm(vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmadd_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                           vfloat16mf4_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat16mf4_t __riscv_vfmadd_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmadd_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat16mf2_t __riscv_vfmadd_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmadd_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmadd_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
                                         vfloat16m1_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m1_t __riscv_vfmadd_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmadd_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmadd_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
                                         vfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m2_t __riscv_vfmadd_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmadd_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmadd_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
                                         vfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m4_t __riscv_vfmadd_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmadd_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmadd_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
                                         vfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m8_t __riscv_vfmadd_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmadd_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfmadd_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat32mf2_t vs1,
@@ -3841,37 +3816,37 @@ vfloat64m8_t __riscv_vfmadd_vf_f64m8_rm(vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmadd_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                            vfloat16mf2_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m1_t __riscv_vfnmadd_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmadd_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m2_t __riscv_vfnmadd_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmadd_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m4_t __riscv_vfnmadd_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmadd_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
                                          vfloat16m8_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m8_t __riscv_vfnmadd_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmadd_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat32mf2_t vs1,
@@ -3931,37 +3906,37 @@ vfloat64m8_t __riscv_vfnmadd_vf_f64m8_rm(vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmsub_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                           vfloat16mf4_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat16mf4_t __riscv_vfmsub_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsub_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat16mf2_t __riscv_vfmsub_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsub_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmsub_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
                                         vfloat16m1_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m1_t __riscv_vfmsub_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsub_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmsub_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
                                         vfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m2_t __riscv_vfmsub_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsub_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmsub_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
                                         vfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m4_t __riscv_vfmsub_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsub_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmsub_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
                                         vfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
-vfloat16m8_t __riscv_vfmsub_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsub_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfmsub_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat32mf2_t vs1,
@@ -4021,37 +3996,37 @@ vfloat64m8_t __riscv_vfmsub_vf_f64m8_rm(vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmsub_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                            vfloat16mf2_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m1_t __riscv_vfnmsub_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsub_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m2_t __riscv_vfnmsub_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsub_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m4_t __riscv_vfnmsub_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsub_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
                                          vfloat16m8_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat16m8_t __riscv_vfnmsub_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsub_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat32mf2_t vs1,
@@ -4114,38 +4089,38 @@ vfloat16mf4_t __riscv_vfmacc_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16mf4_t __riscv_vfmacc_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmacc_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmacc_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmacc_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmacc_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmacc_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmacc_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmacc_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs1, vfloat16m8_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmacc_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmacc_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs1,
@@ -4207,38 +4182,38 @@ vfloat16mf4_t __riscv_vfnmacc_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs1,
@@ -4300,38 +4275,38 @@ vfloat16mf4_t __riscv_vfmsac_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16mf4_t __riscv_vfmsac_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsac_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsac_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsac_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsac_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsac_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsac_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsac_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs1, vfloat16m8_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsac_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsac_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs1,
@@ -4393,38 +4368,38 @@ vfloat16mf4_t __riscv_vfnmsac_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs1,
@@ -4486,38 +4461,38 @@ vfloat16mf4_t __riscv_vfmadd_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16mf4_t __riscv_vfmadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmadd_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmadd_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmadd_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmadd_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs1, vfloat16m8_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmadd_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs1,
@@ -4579,38 +4554,38 @@ vfloat16mf4_t __riscv_vfnmadd_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs1,
@@ -4672,38 +4647,38 @@ vfloat16mf4_t __riscv_vfmsub_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16mf4_t __riscv_vfmsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsub_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsub_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsub_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsub_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs1, vfloat16m8_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsub_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs1,
@@ -4765,38 +4740,38 @@ vfloat16mf4_t __riscv_vfnmsub_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs1,
@@ -4862,23 +4837,23 @@ vfloat64m8_t __riscv_vfnmsub_vf_f64m8_rm_m(vbool8_t vm, vfloat64m8_t vd,
 ----
 vfloat32mf2_t __riscv_vfwmacc_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                         vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1,
                                         vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                       vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwmacc_vf_f32m1(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmacc_vf_f32m1(vfloat32m1_t vd, _Float16 vs1,
                                       vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1,
                                       vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmacc_vf_f32m2(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmacc_vf_f32m2(vfloat32m2_t vd, _Float16 vs1,
                                       vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1,
                                       vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmacc_vf_f32m4(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmacc_vf_f32m4(vfloat32m4_t vd, _Float16 vs1,
                                       vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1,
                                       vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmacc_vf_f32m8(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmacc_vf_f32m8(vfloat32m8_t vd, _Float16 vs1,
                                       vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwmacc_vv_f64m1(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                       vfloat32mf2_t vs2, size_t vl);
@@ -4898,23 +4873,23 @@ vfloat64m8_t __riscv_vfwmacc_vf_f64m8(vfloat64m8_t vd, float32_t vs1,
                                       vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                          vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1,
                                          vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                        vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwnmacc_vf_f32m1(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmacc_vf_f32m1(vfloat32m1_t vd, _Float16 vs1,
                                        vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1,
                                        vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwnmacc_vf_f32m2(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmacc_vf_f32m2(vfloat32m2_t vd, _Float16 vs1,
                                        vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1,
                                        vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwnmacc_vf_f32m4(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmacc_vf_f32m4(vfloat32m4_t vd, _Float16 vs1,
                                        vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1,
                                        vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwnmacc_vf_f32m8(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmacc_vf_f32m8(vfloat32m8_t vd, _Float16 vs1,
                                        vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_vv_f64m1(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                        vfloat32mf2_t vs2, size_t vl);
@@ -4934,23 +4909,23 @@ vfloat64m8_t __riscv_vfwnmacc_vf_f64m8(vfloat64m8_t vd, float32_t vs1,
                                        vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwmsac_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                         vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1,
                                         vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                       vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwmsac_vf_f32m1(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmsac_vf_f32m1(vfloat32m1_t vd, _Float16 vs1,
                                       vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1,
                                       vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmsac_vf_f32m2(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmsac_vf_f32m2(vfloat32m2_t vd, _Float16 vs1,
                                       vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1,
                                       vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmsac_vf_f32m4(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmsac_vf_f32m4(vfloat32m4_t vd, _Float16 vs1,
                                       vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1,
                                       vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmsac_vf_f32m8(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmsac_vf_f32m8(vfloat32m8_t vd, _Float16 vs1,
                                       vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwmsac_vv_f64m1(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                       vfloat32mf2_t vs2, size_t vl);
@@ -4970,23 +4945,23 @@ vfloat64m8_t __riscv_vfwmsac_vf_f64m8(vfloat64m8_t vd, float32_t vs1,
                                       vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                          vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1,
                                          vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                        vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwnmsac_vf_f32m1(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmsac_vf_f32m1(vfloat32m1_t vd, _Float16 vs1,
                                        vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1,
                                        vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwnmsac_vf_f32m2(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmsac_vf_f32m2(vfloat32m2_t vd, _Float16 vs1,
                                        vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1,
                                        vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwnmsac_vf_f32m4(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmsac_vf_f32m4(vfloat32m4_t vd, _Float16 vs1,
                                        vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1,
                                        vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwnmsac_vf_f32m8(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmsac_vf_f32m8(vfloat32m8_t vd, _Float16 vs1,
                                        vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_vv_f64m1(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                        vfloat32mf2_t vs2, size_t vl);
@@ -5009,31 +4984,31 @@ vfloat32mf2_t __riscv_vfwmacc_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
-                                          float16_t vs1, vfloat16mf4_t vs2,
+                                          _Float16 vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
                                         vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                         size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
-                                        float16_t vs1, vfloat16mf2_t vs2,
+                                        _Float16 vs1, vfloat16mf2_t vs2,
                                         size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
                                         vfloat16m1_t vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
-                                        float16_t vs1, vfloat16m1_t vs2,
+                                        _Float16 vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
                                         vfloat16m2_t vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
-                                        float16_t vs1, vfloat16m2_t vs2,
+                                        _Float16 vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
                                         vfloat16m4_t vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
-                                        float16_t vs1, vfloat16m4_t vs2,
+                                        _Float16 vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat64m1_t __riscv_vfwmacc_vv_f64m1_m(vbool64_t vm, vfloat64m1_t vd,
                                         vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5063,31 +5038,31 @@ vfloat32mf2_t __riscv_vfwnmacc_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
-                                           float16_t vs1, vfloat16mf4_t vs2,
+                                           _Float16 vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
                                          vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
-                                         float16_t vs1, vfloat16mf2_t vs2,
+                                         _Float16 vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
                                          vfloat16m1_t vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
-                                         float16_t vs1, vfloat16m1_t vs2,
+                                         _Float16 vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
                                          vfloat16m2_t vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
-                                         float16_t vs1, vfloat16m2_t vs2,
+                                         _Float16 vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
                                          vfloat16m4_t vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
-                                         float16_t vs1, vfloat16m4_t vs2,
+                                         _Float16 vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_vv_f64m1_m(vbool64_t vm, vfloat64m1_t vd,
                                          vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5117,31 +5092,31 @@ vfloat32mf2_t __riscv_vfwmsac_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
-                                          float16_t vs1, vfloat16mf4_t vs2,
+                                          _Float16 vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
                                         vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                         size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
-                                        float16_t vs1, vfloat16mf2_t vs2,
+                                        _Float16 vs1, vfloat16mf2_t vs2,
                                         size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
                                         vfloat16m1_t vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
-                                        float16_t vs1, vfloat16m1_t vs2,
+                                        _Float16 vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
                                         vfloat16m2_t vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
-                                        float16_t vs1, vfloat16m2_t vs2,
+                                        _Float16 vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
                                         vfloat16m4_t vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
-                                        float16_t vs1, vfloat16m4_t vs2,
+                                        _Float16 vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat64m1_t __riscv_vfwmsac_vv_f64m1_m(vbool64_t vm, vfloat64m1_t vd,
                                         vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5171,31 +5146,31 @@ vfloat32mf2_t __riscv_vfwnmsac_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
-                                           float16_t vs1, vfloat16mf4_t vs2,
+                                           _Float16 vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
                                          vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
-                                         float16_t vs1, vfloat16mf2_t vs2,
+                                         _Float16 vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
                                          vfloat16m1_t vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
-                                         float16_t vs1, vfloat16m1_t vs2,
+                                         _Float16 vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
                                          vfloat16m2_t vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
-                                         float16_t vs1, vfloat16m2_t vs2,
+                                         _Float16 vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
                                          vfloat16m4_t vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
-                                         float16_t vs1, vfloat16m4_t vs2,
+                                         _Float16 vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_vv_f64m1_m(vbool64_t vm, vfloat64m1_t vd,
                                          vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5224,31 +5199,31 @@ vfloat64m8_t __riscv_vfwnmsac_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vd,
 vfloat32mf2_t __riscv_vfwmacc_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                          vfloat16mf2_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat32m1_t __riscv_vfwmacc_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmacc_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1,
                                          vfloat16mf2_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat32m2_t __riscv_vfwmacc_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmacc_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat32m4_t __riscv_vfwmacc_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmacc_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat32m8_t __riscv_vfwmacc_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmacc_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat64m1_t __riscv_vfwmacc_vv_f64m1_rm(vfloat64m1_t vd, vfloat32mf2_t vs1,
@@ -5278,31 +5253,31 @@ vfloat64m8_t __riscv_vfwmacc_vf_f64m8_rm(vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwnmacc_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                             vfloat16mf4_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1,
                                             vfloat16mf4_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat32m1_t __riscv_vfwnmacc_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmacc_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1,
                                           vfloat16m1_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat32m2_t __riscv_vfwnmacc_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmacc_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1,
                                           vfloat16m1_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1,
                                           vfloat16m2_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat32m4_t __riscv_vfwnmacc_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmacc_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1,
                                           vfloat16m2_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1,
                                           vfloat16m4_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat32m8_t __riscv_vfwnmacc_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmacc_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1,
                                           vfloat16m4_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_vv_f64m1_rm(vfloat64m1_t vd, vfloat32mf2_t vs1,
@@ -5332,31 +5307,31 @@ vfloat64m8_t __riscv_vfwnmacc_vf_f64m8_rm(vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwmsac_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1,
                                            vfloat16mf4_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                          vfloat16mf2_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat32m1_t __riscv_vfwmsac_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmsac_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1,
                                          vfloat16mf2_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat32m2_t __riscv_vfwmsac_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmsac_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1,
                                          vfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat32m4_t __riscv_vfwmsac_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmsac_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1,
                                          vfloat16m2_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
-vfloat32m8_t __riscv_vfwmsac_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmsac_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1,
                                          vfloat16m4_t vs2, unsigned int frm,
                                          size_t vl);
 vfloat64m1_t __riscv_vfwmsac_vv_f64m1_rm(vfloat64m1_t vd, vfloat32mf2_t vs1,
@@ -5386,31 +5361,31 @@ vfloat64m8_t __riscv_vfwmsac_vf_f64m8_rm(vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwnmsac_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                             vfloat16mf4_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1,
                                             vfloat16mf4_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat32m1_t __riscv_vfwnmsac_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmsac_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1,
                                           vfloat16mf2_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1,
                                           vfloat16m1_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat32m2_t __riscv_vfwnmsac_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmsac_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1,
                                           vfloat16m1_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1,
                                           vfloat16m2_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat32m4_t __riscv_vfwnmsac_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmsac_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1,
                                           vfloat16m2_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1,
                                           vfloat16m4_t vs2, unsigned int frm,
                                           size_t vl);
-vfloat32m8_t __riscv_vfwnmsac_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmsac_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1,
                                           vfloat16m4_t vs2, unsigned int frm,
                                           size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_vv_f64m1_rm(vfloat64m1_t vd, vfloat32mf2_t vs1,
@@ -5443,31 +5418,31 @@ vfloat32mf2_t __riscv_vfwmacc_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
-                                             float16_t vs1, vfloat16mf4_t vs2,
+                                             _Float16 vs1, vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
                                            vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
-                                           float16_t vs1, vfloat16mf2_t vs2,
+                                           _Float16 vs1, vfloat16mf2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
-                                           float16_t vs1, vfloat16m1_t vs2,
+                                           _Float16 vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
-                                           float16_t vs1, vfloat16m2_t vs2,
+                                           _Float16 vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
-                                           float16_t vs1, vfloat16m4_t vs2,
+                                           _Float16 vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmacc_vv_f64m1_rm_m(vbool64_t vm, vfloat64m1_t vd,
                                            vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5498,32 +5473,32 @@ vfloat32mf2_t __riscv_vfwnmacc_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
-                                              float16_t vs1, vfloat16mf4_t vs2,
+                                              _Float16 vs1, vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
-                                            float16_t vs1, vfloat16mf2_t vs2,
+                                            _Float16 vs1, vfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
                                             vfloat16m1_t vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
-                                            float16_t vs1, vfloat16m1_t vs2,
+                                            _Float16 vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
                                             vfloat16m2_t vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
-                                            float16_t vs1, vfloat16m2_t vs2,
+                                            _Float16 vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
                                             vfloat16m4_t vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
-                                            float16_t vs1, vfloat16m4_t vs2,
+                                            _Float16 vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_vv_f64m1_rm_m(vbool64_t vm, vfloat64m1_t vd,
                                             vfloat32mf2_t vs1,
@@ -5555,31 +5530,31 @@ vfloat32mf2_t __riscv_vfwmsac_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
-                                             float16_t vs1, vfloat16mf4_t vs2,
+                                             _Float16 vs1, vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
                                            vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
-                                           float16_t vs1, vfloat16mf2_t vs2,
+                                           _Float16 vs1, vfloat16mf2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
-                                           float16_t vs1, vfloat16m1_t vs2,
+                                           _Float16 vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
-                                           float16_t vs1, vfloat16m2_t vs2,
+                                           _Float16 vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
-                                           float16_t vs1, vfloat16m4_t vs2,
+                                           _Float16 vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmsac_vv_f64m1_rm_m(vbool64_t vm, vfloat64m1_t vd,
                                            vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5610,32 +5585,32 @@ vfloat32mf2_t __riscv_vfwnmsac_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
-                                              float16_t vs1, vfloat16mf4_t vs2,
+                                              _Float16 vs1, vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
-                                            float16_t vs1, vfloat16mf2_t vs2,
+                                            _Float16 vs1, vfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
                                             vfloat16m1_t vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
-                                            float16_t vs1, vfloat16m1_t vs2,
+                                            _Float16 vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
                                             vfloat16m2_t vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
-                                            float16_t vs1, vfloat16m2_t vs2,
+                                            _Float16 vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
                                             vfloat16m4_t vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
-                                            float16_t vs1, vfloat16m4_t vs2,
+                                            _Float16 vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_vv_f64m1_rm_m(vbool64_t vm, vfloat64m1_t vd,
                                             vfloat32mf2_t vs1,
@@ -5940,24 +5915,24 @@ vfloat64m8_t __riscv_vfrec7_v_f64m8_rm_m(vbool8_t vm, vfloat64m8_t vs2,
 ----
 vfloat16mf4_t __riscv_vfmin_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vfloat16mf4_t __riscv_vfmin_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfmin_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16mf2_t __riscv_vfmin_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vfloat16mf2_t __riscv_vfmin_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfmin_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m1_t __riscv_vfmin_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                     size_t vl);
-vfloat16m1_t __riscv_vfmin_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfmin_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmin_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                     size_t vl);
-vfloat16m2_t __riscv_vfmin_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfmin_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmin_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                     size_t vl);
-vfloat16m4_t __riscv_vfmin_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfmin_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmin_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                     size_t vl);
-vfloat16m8_t __riscv_vfmin_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfmin_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmin_vv_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vfloat32mf2_t __riscv_vfmin_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
@@ -5988,24 +5963,24 @@ vfloat64m8_t __riscv_vfmin_vv_f64m8(vfloat64m8_t vs2, vfloat64m8_t vs1,
 vfloat64m8_t __riscv_vfmin_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfmax_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vfloat16mf4_t __riscv_vfmax_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfmax_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16mf2_t __riscv_vfmax_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vfloat16mf2_t __riscv_vfmax_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfmax_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m1_t __riscv_vfmax_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                     size_t vl);
-vfloat16m1_t __riscv_vfmax_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfmax_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmax_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                     size_t vl);
-vfloat16m2_t __riscv_vfmax_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfmax_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmax_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                     size_t vl);
-vfloat16m4_t __riscv_vfmax_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfmax_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmax_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                     size_t vl);
-vfloat16m8_t __riscv_vfmax_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfmax_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmax_vv_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vfloat32mf2_t __riscv_vfmax_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
@@ -6038,27 +6013,27 @@ vfloat64m8_t __riscv_vfmax_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfmin_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfmin_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmin_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfmin_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmin_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
                                       vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfmin_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmin_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
                                       vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfmin_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmin_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
                                       vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfmin_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmin_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
                                       vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfmin_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmin_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmin_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -6098,27 +6073,27 @@ vfloat64m8_t __riscv_vfmin_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfmax_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfmax_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmax_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfmax_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmax_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
                                       vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfmax_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmax_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
                                       vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfmax_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmax_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
                                       vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfmax_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmax_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
                                       vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfmax_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmax_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmax_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -6164,28 +6139,24 @@ vfloat64m8_t __riscv_vfmax_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
 ----
 vfloat16mf4_t __riscv_vfsgnj_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                        size_t vl);
-vfloat16mf4_t __riscv_vfsgnj_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsgnj_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                        size_t vl);
-vfloat16mf2_t __riscv_vfsgnj_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsgnj_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m1_t __riscv_vfsgnj_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vfloat16m1_t __riscv_vfsgnj_vf_f16m1(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat16m1_t __riscv_vfsgnj_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnj_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                      size_t vl);
-vfloat16m2_t __riscv_vfsgnj_vf_f16m2(vfloat16m2_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat16m2_t __riscv_vfsgnj_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnj_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                      size_t vl);
-vfloat16m4_t __riscv_vfsgnj_vf_f16m4(vfloat16m4_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat16m4_t __riscv_vfsgnj_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnj_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                      size_t vl);
-vfloat16m8_t __riscv_vfsgnj_vf_f16m8(vfloat16m8_t vs2, float16_t rs1,
-                                     size_t vl);
+vfloat16m8_t __riscv_vfsgnj_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnj_vv_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfsgnj_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
@@ -6224,27 +6195,27 @@ vfloat64m8_t __riscv_vfsgnj_vf_f64m8(vfloat64m8_t vs2, float64_t rs1,
                                      size_t vl);
 vfloat16mf4_t __riscv_vfsgnjn_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                         size_t vl);
-vfloat16mf4_t __riscv_vfsgnjn_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsgnjn_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                         size_t vl);
-vfloat16mf2_t __riscv_vfsgnjn_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsgnjn_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                       size_t vl);
-vfloat16m1_t __riscv_vfsgnjn_vf_f16m1(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfsgnjn_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                       size_t vl);
-vfloat16m2_t __riscv_vfsgnjn_vf_f16m2(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfsgnjn_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                       size_t vl);
-vfloat16m4_t __riscv_vfsgnjn_vf_f16m4(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfsgnjn_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                       size_t vl);
-vfloat16m8_t __riscv_vfsgnjn_vf_f16m8(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfsgnjn_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn_vv_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                         size_t vl);
@@ -6284,27 +6255,27 @@ vfloat64m8_t __riscv_vfsgnjn_vf_f64m8(vfloat64m8_t vs2, float64_t rs1,
                                       size_t vl);
 vfloat16mf4_t __riscv_vfsgnjx_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                         size_t vl);
-vfloat16mf4_t __riscv_vfsgnjx_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsgnjx_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                         size_t vl);
-vfloat16mf2_t __riscv_vfsgnjx_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsgnjx_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                       size_t vl);
-vfloat16m1_t __riscv_vfsgnjx_vf_f16m1(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfsgnjx_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                       size_t vl);
-vfloat16m2_t __riscv_vfsgnjx_vf_f16m2(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfsgnjx_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                       size_t vl);
-vfloat16m4_t __riscv_vfsgnjx_vf_f16m4(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfsgnjx_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                       size_t vl);
-vfloat16m8_t __riscv_vfsgnjx_vf_f16m8(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfsgnjx_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx_vv_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                         size_t vl);
@@ -6346,27 +6317,27 @@ vfloat64m8_t __riscv_vfsgnjx_vf_f64m8(vfloat64m8_t vs2, float64_t rs1,
 vfloat16mf4_t __riscv_vfsgnj_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
                                          vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnj_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
                                          vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnj_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnj_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnj_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
                                        vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnj_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnj_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
                                        vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnj_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnj_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
                                        vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnj_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnj_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                          vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnj_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -6406,27 +6377,27 @@ vfloat64m8_t __riscv_vfsgnj_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfsgnjn_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
                                           vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnjn_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl);
+                                          _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
                                           vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                          float16_t rs1, size_t vl);
+                                          _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
                                         vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
                                         vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
                                         vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
                                         vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                           vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -6466,27 +6437,27 @@ vfloat64m8_t __riscv_vfsgnjn_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfsgnjx_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
                                           vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnjx_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl);
+                                          _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
                                           vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                          float16_t rs1, size_t vl);
+                                          _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
                                         vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
                                         vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
                                         vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
                                         vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                           vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -6573,25 +6544,24 @@ vfloat64m8_t __riscv_vfabs_v_f64m8_m(vbool8_t vm, vfloat64m8_t vs2, size_t vl);
 ----
 vbool64_t __riscv_vmfeq_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vbool64_t __riscv_vmfeq_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfeq_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool32_t __riscv_vmfeq_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vbool32_t __riscv_vmfeq_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfeq_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool16_t __riscv_vmfeq_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vbool16_t __riscv_vmfeq_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vbool16_t __riscv_vmfeq_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfeq_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                    size_t vl);
-vbool8_t __riscv_vmfeq_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfeq_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfeq_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                    size_t vl);
-vbool4_t __riscv_vmfeq_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfeq_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfeq_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                    size_t vl);
-vbool2_t __riscv_vmfeq_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfeq_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfeq_vv_f32mf2_b64(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vbool64_t __riscv_vmfeq_vf_f32mf2_b64(vfloat32mf2_t vs2, float32_t rs1,
@@ -6627,25 +6597,24 @@ vbool8_t __riscv_vmfeq_vv_f64m8_b8(vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmfeq_vf_f64m8_b8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfne_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vbool64_t __riscv_vmfne_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfne_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool32_t __riscv_vmfne_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vbool32_t __riscv_vmfne_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfne_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool16_t __riscv_vmfne_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vbool16_t __riscv_vmfne_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vbool16_t __riscv_vmfne_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfne_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                    size_t vl);
-vbool8_t __riscv_vmfne_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfne_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfne_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                    size_t vl);
-vbool4_t __riscv_vmfne_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfne_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfne_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                    size_t vl);
-vbool2_t __riscv_vmfne_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfne_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfne_vv_f32mf2_b64(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vbool64_t __riscv_vmfne_vf_f32mf2_b64(vfloat32mf2_t vs2, float32_t rs1,
@@ -6681,25 +6650,24 @@ vbool8_t __riscv_vmfne_vv_f64m8_b8(vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmfne_vf_f64m8_b8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmflt_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vbool64_t __riscv_vmflt_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmflt_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool32_t __riscv_vmflt_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vbool32_t __riscv_vmflt_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmflt_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool16_t __riscv_vmflt_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vbool16_t __riscv_vmflt_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vbool16_t __riscv_vmflt_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmflt_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                    size_t vl);
-vbool8_t __riscv_vmflt_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmflt_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmflt_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                    size_t vl);
-vbool4_t __riscv_vmflt_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmflt_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmflt_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                    size_t vl);
-vbool2_t __riscv_vmflt_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmflt_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmflt_vv_f32mf2_b64(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vbool64_t __riscv_vmflt_vf_f32mf2_b64(vfloat32mf2_t vs2, float32_t rs1,
@@ -6735,25 +6703,24 @@ vbool8_t __riscv_vmflt_vv_f64m8_b8(vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmflt_vf_f64m8_b8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfle_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vbool64_t __riscv_vmfle_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfle_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool32_t __riscv_vmfle_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vbool32_t __riscv_vmfle_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfle_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool16_t __riscv_vmfle_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vbool16_t __riscv_vmfle_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vbool16_t __riscv_vmfle_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfle_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                    size_t vl);
-vbool8_t __riscv_vmfle_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfle_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfle_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                    size_t vl);
-vbool4_t __riscv_vmfle_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfle_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfle_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                    size_t vl);
-vbool2_t __riscv_vmfle_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfle_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfle_vv_f32mf2_b64(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vbool64_t __riscv_vmfle_vf_f32mf2_b64(vfloat32mf2_t vs2, float32_t rs1,
@@ -6789,25 +6756,24 @@ vbool8_t __riscv_vmfle_vv_f64m8_b8(vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmfle_vf_f64m8_b8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfgt_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vbool64_t __riscv_vmfgt_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfgt_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool32_t __riscv_vmfgt_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vbool32_t __riscv_vmfgt_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfgt_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool16_t __riscv_vmfgt_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vbool16_t __riscv_vmfgt_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vbool16_t __riscv_vmfgt_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfgt_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                    size_t vl);
-vbool8_t __riscv_vmfgt_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfgt_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfgt_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                    size_t vl);
-vbool4_t __riscv_vmfgt_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfgt_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfgt_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                    size_t vl);
-vbool2_t __riscv_vmfgt_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfgt_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfgt_vv_f32mf2_b64(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vbool64_t __riscv_vmfgt_vf_f32mf2_b64(vfloat32mf2_t vs2, float32_t rs1,
@@ -6843,25 +6809,24 @@ vbool8_t __riscv_vmfgt_vv_f64m8_b8(vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmfgt_vf_f64m8_b8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfge_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                       size_t vl);
-vbool64_t __riscv_vmfge_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfge_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool32_t __riscv_vmfge_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                       size_t vl);
-vbool32_t __riscv_vmfge_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfge_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool16_t __riscv_vmfge_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                      size_t vl);
-vbool16_t __riscv_vmfge_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+vbool16_t __riscv_vmfge_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfge_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                    size_t vl);
-vbool8_t __riscv_vmfge_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfge_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfge_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                    size_t vl);
-vbool4_t __riscv_vmfge_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfge_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfge_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                    size_t vl);
-vbool2_t __riscv_vmfge_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfge_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfge_vv_f32mf2_b64(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                       size_t vl);
 vbool64_t __riscv_vmfge_vf_f32mf2_b64(vfloat32mf2_t vs2, float32_t rs1,
@@ -6899,27 +6864,27 @@ vbool8_t __riscv_vmfge_vf_f64m8_b8(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfeq_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vbool64_t __riscv_vmfeq_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfeq_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vbool32_t __riscv_vmfeq_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfeq_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vbool16_t __riscv_vmfeq_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfeq_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
                                      vfloat16m2_t vs1, size_t vl);
 vbool8_t __riscv_vmfeq_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfeq_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
                                      vfloat16m4_t vs1, size_t vl);
 vbool4_t __riscv_vmfeq_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfeq_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
                                      vfloat16m8_t vs1, size_t vl);
 vbool2_t __riscv_vmfeq_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfeq_vv_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfeq_vf_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -6959,27 +6924,27 @@ vbool8_t __riscv_vmfeq_vf_f64m8_b8_m(vbool8_t vm, vfloat64m8_t vs2,
 vbool64_t __riscv_vmfne_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vbool64_t __riscv_vmfne_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfne_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vbool32_t __riscv_vmfne_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfne_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vbool16_t __riscv_vmfne_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfne_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
                                      vfloat16m2_t vs1, size_t vl);
 vbool8_t __riscv_vmfne_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfne_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
                                      vfloat16m4_t vs1, size_t vl);
 vbool4_t __riscv_vmfne_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfne_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
                                      vfloat16m8_t vs1, size_t vl);
 vbool2_t __riscv_vmfne_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfne_vv_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfne_vf_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -7019,27 +6984,27 @@ vbool8_t __riscv_vmfne_vf_f64m8_b8_m(vbool8_t vm, vfloat64m8_t vs2,
 vbool64_t __riscv_vmflt_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vbool64_t __riscv_vmflt_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmflt_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vbool32_t __riscv_vmflt_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmflt_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vbool16_t __riscv_vmflt_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmflt_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
                                      vfloat16m2_t vs1, size_t vl);
 vbool8_t __riscv_vmflt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmflt_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
                                      vfloat16m4_t vs1, size_t vl);
 vbool4_t __riscv_vmflt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmflt_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
                                      vfloat16m8_t vs1, size_t vl);
 vbool2_t __riscv_vmflt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmflt_vv_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmflt_vf_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -7079,27 +7044,27 @@ vbool8_t __riscv_vmflt_vf_f64m8_b8_m(vbool8_t vm, vfloat64m8_t vs2,
 vbool64_t __riscv_vmfle_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vbool64_t __riscv_vmfle_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfle_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vbool32_t __riscv_vmfle_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfle_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vbool16_t __riscv_vmfle_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfle_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
                                      vfloat16m2_t vs1, size_t vl);
 vbool8_t __riscv_vmfle_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfle_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
                                      vfloat16m4_t vs1, size_t vl);
 vbool4_t __riscv_vmfle_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfle_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
                                      vfloat16m8_t vs1, size_t vl);
 vbool2_t __riscv_vmfle_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfle_vv_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfle_vf_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -7139,27 +7104,27 @@ vbool8_t __riscv_vmfle_vf_f64m8_b8_m(vbool8_t vm, vfloat64m8_t vs2,
 vbool64_t __riscv_vmfgt_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vbool64_t __riscv_vmfgt_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfgt_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vbool32_t __riscv_vmfgt_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfgt_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vbool16_t __riscv_vmfgt_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfgt_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
                                      vfloat16m2_t vs1, size_t vl);
 vbool8_t __riscv_vmfgt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfgt_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
                                      vfloat16m4_t vs1, size_t vl);
 vbool4_t __riscv_vmfgt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfgt_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
                                      vfloat16m8_t vs1, size_t vl);
 vbool2_t __riscv_vmfgt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfgt_vv_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfgt_vf_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -7199,27 +7164,27 @@ vbool8_t __riscv_vmfgt_vf_f64m8_b8_m(vbool8_t vm, vfloat64m8_t vs2,
 vbool64_t __riscv_vmfge_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
                                         vfloat16mf4_t vs1, size_t vl);
 vbool64_t __riscv_vmfge_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfge_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vbool32_t __riscv_vmfge_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfge_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vbool16_t __riscv_vmfge_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfge_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
                                      vfloat16m2_t vs1, size_t vl);
 vbool8_t __riscv_vmfge_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfge_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
                                      vfloat16m4_t vs1, size_t vl);
 vbool4_t __riscv_vmfge_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfge_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
                                      vfloat16m8_t vs1, size_t vl);
 vbool2_t __riscv_vmfge_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfge_vv_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfge_vf_f32mf2_b64_m(vbool64_t vm, vfloat32mf2_t vs2,
@@ -7312,27 +7277,27 @@ vuint64m8_t __riscv_vfclass_v_u64m8_m(vbool8_t vm, vfloat64m8_t vs2, size_t vl);
 ----
 vfloat16mf4_t __riscv_vmerge_vvm_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                         vbool64_t v0, size_t vl);
-vfloat16mf4_t __riscv_vfmerge_vfm_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfmerge_vfm_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                          vbool64_t v0, size_t vl);
 vfloat16mf2_t __riscv_vmerge_vvm_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                         vbool32_t v0, size_t vl);
-vfloat16mf2_t __riscv_vfmerge_vfm_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfmerge_vfm_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                          vbool32_t v0, size_t vl);
 vfloat16m1_t __riscv_vmerge_vvm_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                       vbool16_t v0, size_t vl);
-vfloat16m1_t __riscv_vfmerge_vfm_f16m1(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfmerge_vfm_f16m1(vfloat16m1_t vs2, _Float16 rs1,
                                        vbool16_t v0, size_t vl);
 vfloat16m2_t __riscv_vmerge_vvm_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                       vbool8_t v0, size_t vl);
-vfloat16m2_t __riscv_vfmerge_vfm_f16m2(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfmerge_vfm_f16m2(vfloat16m2_t vs2, _Float16 rs1,
                                        vbool8_t v0, size_t vl);
 vfloat16m4_t __riscv_vmerge_vvm_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                       vbool4_t v0, size_t vl);
-vfloat16m4_t __riscv_vfmerge_vfm_f16m4(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfmerge_vfm_f16m4(vfloat16m4_t vs2, _Float16 rs1,
                                        vbool4_t v0, size_t vl);
 vfloat16m8_t __riscv_vmerge_vvm_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
                                       vbool2_t v0, size_t vl);
-vfloat16m8_t __riscv_vfmerge_vfm_f16m8(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfmerge_vfm_f16m8(vfloat16m8_t vs2, _Float16 rs1,
                                        vbool2_t v0, size_t vl);
 vfloat32mf2_t __riscv_vmerge_vvm_f32mf2(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                         vbool64_t v0, size_t vl);
@@ -7378,17 +7343,17 @@ vfloat64m8_t __riscv_vfmerge_vfm_f64m8(vfloat64m8_t vs2, float64_t rs1,
 [,c]
 ----
 vfloat16mf4_t __riscv_vmv_v_v_f16mf4(vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfmv_v_f_f16mf4(float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfmv_v_f_f16mf4(_Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vmv_v_v_f16mf2(vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfmv_v_f_f16mf2(float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfmv_v_f_f16mf2(_Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vmv_v_v_f16m1(vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfmv_v_f_f16m1(float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfmv_v_f_f16m1(_Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vmv_v_v_f16m2(vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfmv_v_f_f16m2(float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfmv_v_f_f16m2(_Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vmv_v_v_f16m4(vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfmv_v_f_f16m4(float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfmv_v_f_f16m4(_Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vmv_v_v_f16m8(vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfmv_v_f_f16m8(float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfmv_v_f_f16m8(_Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vmv_v_v_f32mf2(vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmv_v_f_f32mf2(float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vmv_v_v_f32m1(vfloat32m1_t vs1, size_t vl);

--- a/auto-generated/intrinsic_funcs/06_vector_mask_instructions.adoc
+++ b/auto-generated/intrinsic_funcs/06_vector_mask_instructions.adoc
@@ -97,21 +97,21 @@ vbool64_t __riscv_vmnot_m_b64(vbool64_t vs, size_t vl);
 
 [,c]
 ----
-unsigned long __riscv_vcpop_m_b1(vbool1_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b2(vbool2_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b4(vbool4_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b8(vbool8_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b16(vbool16_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b32(vbool32_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b64(vbool64_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b1(vbool1_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b2(vbool2_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b4(vbool4_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b8(vbool8_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b16(vbool16_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b32(vbool32_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b64(vbool64_t vs2, size_t vl);
 // masked functions
-unsigned long __riscv_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl);
-unsigned long __riscv_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl);
+unsigned int __riscv_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
 ----
 
 [[vfirst-find-first-set-mask-bit]]
@@ -119,21 +119,21 @@ unsigned long __riscv_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
 
 [,c]
 ----
-long __riscv_vfirst_m_b1(vbool1_t vs2, size_t vl);
-long __riscv_vfirst_m_b2(vbool2_t vs2, size_t vl);
-long __riscv_vfirst_m_b4(vbool4_t vs2, size_t vl);
-long __riscv_vfirst_m_b8(vbool8_t vs2, size_t vl);
-long __riscv_vfirst_m_b16(vbool16_t vs2, size_t vl);
-long __riscv_vfirst_m_b32(vbool32_t vs2, size_t vl);
-long __riscv_vfirst_m_b64(vbool64_t vs2, size_t vl);
+int __riscv_vfirst_m_b1(vbool1_t vs2, size_t vl);
+int __riscv_vfirst_m_b2(vbool2_t vs2, size_t vl);
+int __riscv_vfirst_m_b4(vbool4_t vs2, size_t vl);
+int __riscv_vfirst_m_b8(vbool8_t vs2, size_t vl);
+int __riscv_vfirst_m_b16(vbool16_t vs2, size_t vl);
+int __riscv_vfirst_m_b32(vbool32_t vs2, size_t vl);
+int __riscv_vfirst_m_b64(vbool64_t vs2, size_t vl);
 // masked functions
-long __riscv_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl);
-long __riscv_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl);
-long __riscv_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl);
-long __riscv_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl);
-long __riscv_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl);
-long __riscv_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl);
-long __riscv_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
+int __riscv_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl);
+int __riscv_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl);
+int __riscv_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl);
+int __riscv_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl);
+int __riscv_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl);
+int __riscv_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl);
+int __riscv_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
 ----
 
 [[vmsbfm-set-before-first-mask-bit]]

--- a/auto-generated/intrinsic_funcs/07_vector_permutation_instructions.adoc
+++ b/auto-generated/intrinsic_funcs/07_vector_permutation_instructions.adoc
@@ -6,18 +6,18 @@
 
 [,c]
 ----
-float16_t __riscv_vfmv_f_s_f16mf4_f16(vfloat16mf4_t vs1);
-vfloat16mf4_t __riscv_vfmv_s_f_f16mf4(float16_t rs1, size_t vl);
-float16_t __riscv_vfmv_f_s_f16mf2_f16(vfloat16mf2_t vs1);
-vfloat16mf2_t __riscv_vfmv_s_f_f16mf2(float16_t rs1, size_t vl);
-float16_t __riscv_vfmv_f_s_f16m1_f16(vfloat16m1_t vs1);
-vfloat16m1_t __riscv_vfmv_s_f_f16m1(float16_t rs1, size_t vl);
-float16_t __riscv_vfmv_f_s_f16m2_f16(vfloat16m2_t vs1);
-vfloat16m2_t __riscv_vfmv_s_f_f16m2(float16_t rs1, size_t vl);
-float16_t __riscv_vfmv_f_s_f16m4_f16(vfloat16m4_t vs1);
-vfloat16m4_t __riscv_vfmv_s_f_f16m4(float16_t rs1, size_t vl);
-float16_t __riscv_vfmv_f_s_f16m8_f16(vfloat16m8_t vs1);
-vfloat16m8_t __riscv_vfmv_s_f_f16m8(float16_t rs1, size_t vl);
+_Float16 __riscv_vfmv_f_s_f16mf4_f16(vfloat16mf4_t vs1);
+vfloat16mf4_t __riscv_vfmv_s_f_f16mf4(_Float16 rs1, size_t vl);
+_Float16 __riscv_vfmv_f_s_f16mf2_f16(vfloat16mf2_t vs1);
+vfloat16mf2_t __riscv_vfmv_s_f_f16mf2(_Float16 rs1, size_t vl);
+_Float16 __riscv_vfmv_f_s_f16m1_f16(vfloat16m1_t vs1);
+vfloat16m1_t __riscv_vfmv_s_f_f16m1(_Float16 rs1, size_t vl);
+_Float16 __riscv_vfmv_f_s_f16m2_f16(vfloat16m2_t vs1);
+vfloat16m2_t __riscv_vfmv_s_f_f16m2(_Float16 rs1, size_t vl);
+_Float16 __riscv_vfmv_f_s_f16m4_f16(vfloat16m4_t vs1);
+vfloat16m4_t __riscv_vfmv_s_f_f16m4(_Float16 rs1, size_t vl);
+_Float16 __riscv_vfmv_f_s_f16m8_f16(vfloat16m8_t vs1);
+vfloat16m8_t __riscv_vfmv_s_f_f16m8(_Float16 rs1, size_t vl);
 float32_t __riscv_vfmv_f_s_f32mf2_f32(vfloat32mf2_t vs1);
 vfloat32mf2_t __riscv_vfmv_s_f_f32mf2(float32_t rs1, size_t vl);
 float32_t __riscv_vfmv_f_s_f32m1_f32(vfloat32m1_t vs1);
@@ -602,17 +602,17 @@ vuint64m8_t __riscv_vslidedown_vx_u64m8_m(vbool8_t vm, vuint64m8_t vs2,
 
 [,c]
 ----
-vfloat16mf4_t __riscv_vfslide1up_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfslide1up_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl);
-vfloat16mf2_t __riscv_vfslide1up_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfslide1up_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl);
-vfloat16m1_t __riscv_vfslide1up_vf_f16m1(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfslide1up_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl);
-vfloat16m2_t __riscv_vfslide1up_vf_f16m2(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfslide1up_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl);
-vfloat16m4_t __riscv_vfslide1up_vf_f16m4(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfslide1up_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl);
-vfloat16m8_t __riscv_vfslide1up_vf_f16m8(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfslide1up_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfslide1up_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
                                            size_t vl);
@@ -632,17 +632,17 @@ vfloat64m4_t __riscv_vfslide1up_vf_f64m4(vfloat64m4_t vs2, float64_t rs1,
                                          size_t vl);
 vfloat64m8_t __riscv_vfslide1up_vf_f64m8(vfloat64m8_t vs2, float64_t rs1,
                                          size_t vl);
-vfloat16mf4_t __riscv_vfslide1down_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfslide1down_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                              size_t vl);
-vfloat16mf2_t __riscv_vfslide1down_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfslide1down_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                              size_t vl);
-vfloat16m1_t __riscv_vfslide1down_vf_f16m1(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfslide1down_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1,
                                            size_t vl);
-vfloat16m2_t __riscv_vfslide1down_vf_f16m2(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfslide1down_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1,
                                            size_t vl);
-vfloat16m4_t __riscv_vfslide1down_vf_f16m4(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfslide1down_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1,
                                            size_t vl);
-vfloat16m8_t __riscv_vfslide1down_vf_f16m8(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfslide1down_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfslide1down_vf_f32mf2(vfloat32mf2_t vs2, float32_t rs1,
                                              size_t vl);
@@ -791,17 +791,17 @@ vuint64m8_t __riscv_vslide1down_vx_u64m8(vuint64m8_t vs2, uint64_t rs1,
                                          size_t vl);
 // masked functions
 vfloat16mf4_t __riscv_vfslide1up_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                             float16_t rs1, size_t vl);
+                                             _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfslide1up_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                             float16_t rs1, size_t vl);
+                                             _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfslide1up_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                           float16_t rs1, size_t vl);
+                                           _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfslide1up_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                           float16_t rs1, size_t vl);
+                                           _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfslide1up_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                           float16_t rs1, size_t vl);
+                                           _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfslide1up_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                           float16_t rs1, size_t vl);
+                                           _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfslide1up_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                              float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfslide1up_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
@@ -821,17 +821,17 @@ vfloat64m4_t __riscv_vfslide1up_vf_f64m4_m(vbool16_t vm, vfloat64m4_t vs2,
 vfloat64m8_t __riscv_vfslide1up_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
                                            float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfslide1down_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                               float16_t rs1, size_t vl);
+                                               _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfslide1down_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                               float16_t rs1, size_t vl);
+                                               _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfslide1down_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                             float16_t rs1, size_t vl);
+                                             _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfslide1down_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                             float16_t rs1, size_t vl);
+                                             _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfslide1down_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                             float16_t rs1, size_t vl);
+                                             _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfslide1down_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                             float16_t rs1, size_t vl);
+                                             _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfslide1down_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
                                                float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfslide1down_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,

--- a/auto-generated/llvm-api-tests/vcpop.c
+++ b/auto-generated/llvm-api-tests/vcpop.c
@@ -6,58 +6,58 @@
 
 #include <riscv_vector.h>
 
-unsigned long test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vcpop_m_b1(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vcpop_m_b2(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vcpop_m_b4(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vcpop_m_b8(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vcpop_m_b16(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vcpop_m_b32(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vcpop_m_b64(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vcpop_m_b1_m(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vcpop_m_b2_m(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vcpop_m_b4_m(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vcpop_m_b8_m(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vcpop_m_b16_m(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vcpop_m_b32_m(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vcpop_m_b64_m(vm, vs2, vl);
 }

--- a/auto-generated/llvm-api-tests/vfirst.c
+++ b/auto-generated/llvm-api-tests/vfirst.c
@@ -5,58 +5,58 @@
 
 #include <riscv_vector.h>
 
-long test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
+int test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vfirst_m_b1(vs2, vl);
 }
 
-long test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
+int test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vfirst_m_b2(vs2, vl);
 }
 
-long test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
+int test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vfirst_m_b4(vs2, vl);
 }
 
-long test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
+int test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vfirst_m_b8(vs2, vl);
 }
 
-long test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
+int test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vfirst_m_b16(vs2, vl);
 }
 
-long test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
+int test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vfirst_m_b32(vs2, vl);
 }
 
-long test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
+int test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vfirst_m_b64(vs2, vl);
 }
 
-long test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+int test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vfirst_m_b1_m(vm, vs2, vl);
 }
 
-long test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+int test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vfirst_m_b2_m(vm, vs2, vl);
 }
 
-long test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+int test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vfirst_m_b4_m(vm, vs2, vl);
 }
 
-long test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+int test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vfirst_m_b8_m(vm, vs2, vl);
 }
 
-long test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+int test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vfirst_m_b16_m(vm, vs2, vl);
 }
 
-long test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+int test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vfirst_m_b32_m(vm, vs2, vl);
 }
 
-long test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+int test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vfirst_m_b64_m(vm, vs2, vl);
 }

--- a/auto-generated/llvm-overloaded-tests/vcpop.c
+++ b/auto-generated/llvm-overloaded-tests/vcpop.c
@@ -6,58 +6,58 @@
 
 #include <riscv_vector.h>
 
-unsigned long test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }

--- a/auto-generated/llvm-overloaded-tests/vfirst.c
+++ b/auto-generated/llvm-overloaded-tests/vfirst.c
@@ -5,58 +5,58 @@
 
 #include <riscv_vector.h>
 
-long test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
+int test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
+int test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
+int test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
+int test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
+int test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
+int test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
+int test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+int test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-long test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+int test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-long test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+int test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-long test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+int test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-long test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+int test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-long test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+int test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-long test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+int test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }

--- a/auto-generated/overloaded-api-testing/vcpop.c
+++ b/auto-generated/overloaded-api-testing/vcpop.c
@@ -5,58 +5,58 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-unsigned long test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned long test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned long test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+unsigned int test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfadd.c
+++ b/auto-generated/overloaded-api-testing/vfadd.c
@@ -10,8 +10,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfadd(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfadd(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vfloat16m1_t test_vfadd_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfadd(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, vl);
 }
 
@@ -39,7 +37,7 @@ vfloat16m2_t test_vfadd_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfadd(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, vl);
 }
 
@@ -48,7 +46,7 @@ vfloat16m4_t test_vfadd_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfadd(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, vl);
 }
 
@@ -57,7 +55,7 @@ vfloat16m8_t test_vfadd_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfadd(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, vl);
 }
 
@@ -149,7 +147,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, vl);
 }
 
@@ -159,7 +157,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, vl);
 }
 
@@ -168,8 +166,8 @@ vfloat16m1_t test_vfadd_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
   return __riscv_vfadd(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                   float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
+                                   size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, vl);
 }
 
@@ -178,7 +176,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfadd(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, vl);
 }
@@ -188,7 +186,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfadd(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, vl);
 }
@@ -198,7 +196,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vfadd(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, vl);
 }
@@ -298,7 +296,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfadd(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfadd_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfadd(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -308,7 +306,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfadd(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfadd_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfadd(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -318,8 +316,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfadd(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -328,8 +325,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfadd(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -338,8 +334,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfadd(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -348,8 +343,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfadd(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -449,7 +443,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +453,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -469,7 +463,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -479,7 +473,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -489,7 +483,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +493,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfadd(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/overloaded-api-testing/vfdiv.c
+++ b/auto-generated/overloaded-api-testing/vfdiv.c
@@ -10,8 +10,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfdiv(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfdiv(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfdiv(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, vl);
 }
 
@@ -39,7 +37,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfdiv(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, vl);
 }
 
@@ -48,7 +46,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfdiv(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, vl);
 }
 
@@ -57,7 +55,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfdiv(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, vl);
 }
 
@@ -149,7 +147,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, vl);
 }
 
@@ -159,7 +157,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, vl);
 }
 
@@ -168,8 +166,8 @@ vfloat16m1_t test_vfdiv_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
   return __riscv_vfdiv(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                   float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
+                                   size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, vl);
 }
 
@@ -178,7 +176,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfdiv(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, vl);
 }
@@ -188,7 +186,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfdiv(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, vl);
 }
@@ -198,7 +196,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vfdiv(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, vl);
 }
@@ -298,7 +296,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfdiv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -308,7 +306,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfdiv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -318,8 +316,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfdiv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -328,8 +325,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfdiv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -338,8 +334,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfdiv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -348,8 +343,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfdiv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -449,7 +443,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +453,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -469,7 +463,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfdiv_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -479,7 +473,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfdiv_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -489,7 +483,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfdiv_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +493,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfdiv_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/overloaded-api-testing/vfirst.c
+++ b/auto-generated/overloaded-api-testing/vfirst.c
@@ -5,58 +5,58 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-long test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
+int test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
+int test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
+int test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
+int test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
+int test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
+int test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
+int test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-long test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+int test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-long test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+int test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-long test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+int test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-long test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+int test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-long test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+int test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-long test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+int test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-long test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+int test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfmacc.c
+++ b/auto-generated/overloaded-api-testing/vfmacc.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmacc_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                     vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmacc_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                     vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmacc_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                   vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmacc_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                   vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmacc_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                   vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmacc_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                   vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmacc_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                      float16_t rs1, vfloat16mf4_t vs2,
+                                      _Float16 rs1, vfloat16mf4_t vs2,
                                       size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmacc_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                      float16_t rs1, vfloat16mf2_t vs2,
+                                      _Float16 rs1, vfloat16mf2_t vs2,
                                       size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, vl);
 }
@@ -185,9 +185,8 @@ vfloat16m1_t test_vfmacc_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
   return __riscv_vfmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                    float16_t rs1, vfloat16m1_t vs2,
-                                    size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
+                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, vl);
 }
 
@@ -197,7 +196,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, vl);
 }
@@ -208,7 +207,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, vl);
 }
@@ -219,7 +218,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, vl);
 }
@@ -334,7 +333,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmacc_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -344,7 +343,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmacc_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -354,7 +353,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmacc_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -364,7 +363,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmacc_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -374,7 +373,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmacc_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -384,7 +383,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmacc_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -486,7 +485,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -498,7 +497,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -510,7 +509,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmacc_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -522,7 +521,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmacc_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -534,7 +533,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmacc_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -546,7 +545,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmacc_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfmadd.c
+++ b/auto-generated/overloaded-api-testing/vfmadd.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmadd_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                     vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmadd_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                     vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmadd_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                   vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmadd_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                   vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmadd_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                   vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmadd_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                   vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                      float16_t rs1, vfloat16mf4_t vs2,
+                                      _Float16 rs1, vfloat16mf4_t vs2,
                                       size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                      float16_t rs1, vfloat16mf2_t vs2,
+                                      _Float16 rs1, vfloat16mf2_t vs2,
                                       size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, vl);
 }
@@ -185,9 +185,8 @@ vfloat16m1_t test_vfmadd_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
   return __riscv_vfmadd(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                    float16_t rs1, vfloat16m1_t vs2,
-                                    size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
+                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, vl);
 }
 
@@ -197,7 +196,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfmadd(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, vl);
 }
@@ -208,7 +207,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfmadd(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, vl);
 }
@@ -219,7 +218,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfmadd(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, vl);
 }
@@ -334,7 +333,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmadd_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -344,7 +343,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmadd_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -354,7 +353,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmadd_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -364,7 +363,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmadd_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -374,7 +373,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmadd_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -384,7 +383,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmadd_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -486,7 +485,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -498,7 +497,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -510,7 +509,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -522,7 +521,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -534,7 +533,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -546,7 +545,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfmax.c
+++ b/auto-generated/overloaded-api-testing/vfmax.c
@@ -10,8 +10,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfmax(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmax_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf4_t test_vfmax_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfmax(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmax_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf2_t test_vfmax_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vfloat16m1_t test_vfmax_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfmax(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmax_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmax_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vs2, rs1, vl);
 }
 
@@ -39,7 +37,7 @@ vfloat16m2_t test_vfmax_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfmax(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmax_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmax_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vs2, rs1, vl);
 }
 
@@ -48,7 +46,7 @@ vfloat16m4_t test_vfmax_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfmax(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmax_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmax_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vs2, rs1, vl);
 }
 
@@ -57,7 +55,7 @@ vfloat16m8_t test_vfmax_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfmax(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmax_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmax_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vs2, rs1, vl);
 }
 
@@ -149,7 +147,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfmax_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vm, vs2, rs1, vl);
 }
 
@@ -159,7 +157,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfmax_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfmax(vm, vs2, rs1, vl);
 }
 
@@ -168,8 +166,8 @@ vfloat16m1_t test_vfmax_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
   return __riscv_vfmax(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmax_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                   float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmax_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
+                                   size_t vl) {
   return __riscv_vfmax(vm, vs2, rs1, vl);
 }
 
@@ -178,7 +176,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfmax(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmax_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfmax_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfmax(vm, vs2, rs1, vl);
 }
@@ -188,7 +186,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfmax(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmax_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfmax_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfmax(vm, vs2, rs1, vl);
 }
@@ -198,7 +196,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vfmax(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmax_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfmax_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfmax(vm, vs2, rs1, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfmerge.c
+++ b/auto-generated/overloaded-api-testing/vfmerge.c
@@ -5,33 +5,33 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfmerge_vfm_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfmerge_vfm_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                       vbool64_t v0, size_t vl) {
   return __riscv_vfmerge(vs2, rs1, v0, vl);
 }
 
-vfloat16mf2_t test_vfmerge_vfm_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfmerge_vfm_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                       vbool32_t v0, size_t vl) {
   return __riscv_vfmerge(vs2, rs1, v0, vl);
 }
 
-vfloat16m1_t test_vfmerge_vfm_f16m1(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t test_vfmerge_vfm_f16m1(vfloat16m1_t vs2, _Float16 rs1,
                                     vbool16_t v0, size_t vl) {
   return __riscv_vfmerge(vs2, rs1, v0, vl);
 }
 
-vfloat16m2_t test_vfmerge_vfm_f16m2(vfloat16m2_t vs2, float16_t rs1,
-                                    vbool8_t v0, size_t vl) {
+vfloat16m2_t test_vfmerge_vfm_f16m2(vfloat16m2_t vs2, _Float16 rs1, vbool8_t v0,
+                                    size_t vl) {
   return __riscv_vfmerge(vs2, rs1, v0, vl);
 }
 
-vfloat16m4_t test_vfmerge_vfm_f16m4(vfloat16m4_t vs2, float16_t rs1,
-                                    vbool4_t v0, size_t vl) {
+vfloat16m4_t test_vfmerge_vfm_f16m4(vfloat16m4_t vs2, _Float16 rs1, vbool4_t v0,
+                                    size_t vl) {
   return __riscv_vfmerge(vs2, rs1, v0, vl);
 }
 
-vfloat16m8_t test_vfmerge_vfm_f16m8(vfloat16m8_t vs2, float16_t rs1,
-                                    vbool2_t v0, size_t vl) {
+vfloat16m8_t test_vfmerge_vfm_f16m8(vfloat16m8_t vs2, _Float16 rs1, vbool2_t v0,
+                                    size_t vl) {
   return __riscv_vfmerge(vs2, rs1, v0, vl);
 }
 

--- a/auto-generated/overloaded-api-testing/vfmin.c
+++ b/auto-generated/overloaded-api-testing/vfmin.c
@@ -10,8 +10,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfmin(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmin_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf4_t test_vfmin_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfmin(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmin_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf2_t test_vfmin_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vfloat16m1_t test_vfmin_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfmin(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmin_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmin_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vs2, rs1, vl);
 }
 
@@ -39,7 +37,7 @@ vfloat16m2_t test_vfmin_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfmin(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmin_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmin_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vs2, rs1, vl);
 }
 
@@ -48,7 +46,7 @@ vfloat16m4_t test_vfmin_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfmin(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmin_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmin_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vs2, rs1, vl);
 }
 
@@ -57,7 +55,7 @@ vfloat16m8_t test_vfmin_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfmin(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmin_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmin_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vs2, rs1, vl);
 }
 
@@ -149,7 +147,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfmin_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vm, vs2, rs1, vl);
 }
 
@@ -159,7 +157,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfmin_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfmin(vm, vs2, rs1, vl);
 }
 
@@ -168,8 +166,8 @@ vfloat16m1_t test_vfmin_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
   return __riscv_vfmin(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmin_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                   float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmin_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
+                                   size_t vl) {
   return __riscv_vfmin(vm, vs2, rs1, vl);
 }
 
@@ -178,7 +176,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfmin(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmin_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfmin_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfmin(vm, vs2, rs1, vl);
 }
@@ -188,7 +186,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfmin(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmin_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfmin_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfmin(vm, vs2, rs1, vl);
 }
@@ -198,7 +196,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vfmin(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmin_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfmin_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfmin(vm, vs2, rs1, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfmsac.c
+++ b/auto-generated/overloaded-api-testing/vfmsac.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmsac_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                     vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmsac_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                     vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmsac_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                   vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsac_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                   vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsac_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                   vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsac_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                   vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsac_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                      float16_t rs1, vfloat16mf4_t vs2,
+                                      _Float16 rs1, vfloat16mf4_t vs2,
                                       size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsac_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                      float16_t rs1, vfloat16mf2_t vs2,
+                                      _Float16 rs1, vfloat16mf2_t vs2,
                                       size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, vl);
 }
@@ -185,9 +185,8 @@ vfloat16m1_t test_vfmsac_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
   return __riscv_vfmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                    float16_t rs1, vfloat16m1_t vs2,
-                                    size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
+                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, vl);
 }
 
@@ -197,7 +196,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, vl);
 }
@@ -208,7 +207,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, vl);
 }
@@ -219,7 +218,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, vl);
 }
@@ -334,7 +333,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmsac_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -344,7 +343,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmsac_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -354,7 +353,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmsac_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -364,7 +363,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsac_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -374,7 +373,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsac_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -384,7 +383,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsac_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -486,7 +485,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -498,7 +497,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -510,7 +509,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsac_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -522,7 +521,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsac_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -534,7 +533,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsac_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -546,7 +545,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsac_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfmsub.c
+++ b/auto-generated/overloaded-api-testing/vfmsub.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmsub_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                     vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmsub_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                     vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmsub_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                   vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsub_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                   vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsub_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                   vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsub_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                   vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                      float16_t rs1, vfloat16mf4_t vs2,
+                                      _Float16 rs1, vfloat16mf4_t vs2,
                                       size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                      float16_t rs1, vfloat16mf2_t vs2,
+                                      _Float16 rs1, vfloat16mf2_t vs2,
                                       size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, vl);
 }
@@ -185,9 +185,8 @@ vfloat16m1_t test_vfmsub_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
   return __riscv_vfmsub(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                    float16_t rs1, vfloat16m1_t vs2,
-                                    size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
+                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, vl);
 }
 
@@ -197,7 +196,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfmsub(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, vl);
 }
@@ -208,7 +207,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfmsub(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, vl);
 }
@@ -219,7 +218,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfmsub(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, vl);
 }
@@ -334,7 +333,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmsub_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -344,7 +343,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmsub_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -354,7 +353,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmsub_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -364,7 +363,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsub_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -374,7 +373,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsub_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -384,7 +383,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsub_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -486,7 +485,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -498,7 +497,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -510,7 +509,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -522,7 +521,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -534,7 +533,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -546,7 +545,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfmul.c
+++ b/auto-generated/overloaded-api-testing/vfmul.c
@@ -10,8 +10,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfmul(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfmul(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vfloat16m1_t test_vfmul_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfmul(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, vl);
 }
 
@@ -39,7 +37,7 @@ vfloat16m2_t test_vfmul_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfmul(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, vl);
 }
 
@@ -48,7 +46,7 @@ vfloat16m4_t test_vfmul_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfmul(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, vl);
 }
 
@@ -57,7 +55,7 @@ vfloat16m8_t test_vfmul_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfmul(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, vl);
 }
 
@@ -149,7 +147,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, vl);
 }
 
@@ -159,7 +157,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, vl);
 }
 
@@ -168,8 +166,8 @@ vfloat16m1_t test_vfmul_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
   return __riscv_vfmul(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                   float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
+                                   size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, vl);
 }
 
@@ -178,7 +176,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfmul(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfmul_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, vl);
 }
@@ -188,7 +186,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfmul(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfmul_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, vl);
 }
@@ -198,7 +196,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vfmul(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfmul_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, vl);
 }
@@ -298,7 +296,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfmul_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -308,7 +306,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfmul_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -318,8 +316,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -328,8 +325,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -338,8 +334,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -348,8 +343,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -449,7 +443,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +453,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -469,7 +463,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfmul_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -479,7 +473,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfmul_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -489,7 +483,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfmul_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +493,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfmul_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/overloaded-api-testing/vfmv.c
+++ b/auto-generated/overloaded-api-testing/vfmv.c
@@ -5,27 +5,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-float16_t test_vfmv_f_s_f16mf4_f16(vfloat16mf4_t vs1) {
+_Float16 test_vfmv_f_s_f16mf4_f16(vfloat16mf4_t vs1) {
   return __riscv_vfmv_f(vs1);
 }
 
-float16_t test_vfmv_f_s_f16mf2_f16(vfloat16mf2_t vs1) {
+_Float16 test_vfmv_f_s_f16mf2_f16(vfloat16mf2_t vs1) {
   return __riscv_vfmv_f(vs1);
 }
 
-float16_t test_vfmv_f_s_f16m1_f16(vfloat16m1_t vs1) {
+_Float16 test_vfmv_f_s_f16m1_f16(vfloat16m1_t vs1) {
   return __riscv_vfmv_f(vs1);
 }
 
-float16_t test_vfmv_f_s_f16m2_f16(vfloat16m2_t vs1) {
+_Float16 test_vfmv_f_s_f16m2_f16(vfloat16m2_t vs1) {
   return __riscv_vfmv_f(vs1);
 }
 
-float16_t test_vfmv_f_s_f16m4_f16(vfloat16m4_t vs1) {
+_Float16 test_vfmv_f_s_f16m4_f16(vfloat16m4_t vs1) {
   return __riscv_vfmv_f(vs1);
 }
 
-float16_t test_vfmv_f_s_f16m8_f16(vfloat16m8_t vs1) {
+_Float16 test_vfmv_f_s_f16m8_f16(vfloat16m8_t vs1) {
   return __riscv_vfmv_f(vs1);
 }
 

--- a/auto-generated/overloaded-api-testing/vfnmacc.c
+++ b/auto-generated/overloaded-api-testing/vfnmacc.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmacc_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                      vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmacc_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                      vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmacc_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmacc_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                    vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmacc_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                    vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmacc_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                    vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmacc_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                       float16_t rs1, vfloat16mf4_t vs2,
+                                       _Float16 rs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmacc_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                       float16_t rs1, vfloat16mf2_t vs2,
+                                       _Float16 rs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmacc_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                     float16_t rs1, vfloat16m1_t vs2,
+                                     _Float16 rs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, vl);
 }
@@ -197,9 +197,8 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfnmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                     float16_t rs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, vl);
 }
 
@@ -209,9 +208,8 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfnmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                     float16_t rs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, vl);
 }
 
@@ -221,9 +219,8 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfnmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                     float16_t rs1, vfloat16m8_t vs2,
-                                     size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
+                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, vl);
 }
 
@@ -340,7 +337,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -350,7 +347,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -360,7 +357,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmacc_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -370,7 +367,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmacc_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -380,7 +377,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmacc_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -390,7 +387,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmacc_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -492,7 +489,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -504,7 +501,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -516,7 +513,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmacc_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -528,7 +525,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmacc_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -540,7 +537,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmacc_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -552,7 +549,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmacc_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfnmadd.c
+++ b/auto-generated/overloaded-api-testing/vfnmadd.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmadd_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                      vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmadd_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                      vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmadd_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmadd_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                    vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmadd_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                    vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmadd(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmadd_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                    vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmadd_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                       float16_t rs1, vfloat16mf4_t vs2,
+                                       _Float16 rs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmadd_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                       float16_t rs1, vfloat16mf2_t vs2,
+                                       _Float16 rs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmadd_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                     float16_t rs1, vfloat16m1_t vs2,
+                                     _Float16 rs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, vl);
 }
@@ -197,9 +197,8 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfnmadd(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                     float16_t rs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, vl);
 }
 
@@ -209,9 +208,8 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfnmadd(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                     float16_t rs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, vl);
 }
 
@@ -221,9 +219,8 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfnmadd(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                     float16_t rs1, vfloat16m8_t vs2,
-                                     size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
+                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, vl);
 }
 
@@ -340,7 +337,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -350,7 +347,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -360,7 +357,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmadd_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -370,7 +367,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmadd_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -380,7 +377,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmadd_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -390,7 +387,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmadd(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmadd_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -492,7 +489,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -504,7 +501,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -516,7 +513,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmadd_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -528,7 +525,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmadd_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -540,7 +537,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmadd_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -552,7 +549,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmadd_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfnmsac.c
+++ b/auto-generated/overloaded-api-testing/vfnmsac.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmsac_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                      vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmsac_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                      vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmsac_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmsac_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                    vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmsac_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                    vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmsac_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                    vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsac_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                       float16_t rs1, vfloat16mf4_t vs2,
+                                       _Float16 rs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsac_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                       float16_t rs1, vfloat16mf2_t vs2,
+                                       _Float16 rs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsac_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                     float16_t rs1, vfloat16m1_t vs2,
+                                     _Float16 rs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, vl);
 }
@@ -197,9 +197,8 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfnmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                     float16_t rs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, vl);
 }
 
@@ -209,9 +208,8 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfnmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                     float16_t rs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, vl);
 }
 
@@ -221,9 +219,8 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfnmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                     float16_t rs1, vfloat16m8_t vs2,
-                                     size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
+                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, vl);
 }
 
@@ -340,7 +337,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -350,7 +347,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -360,7 +357,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmsac_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -370,7 +367,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmsac_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -380,7 +377,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmsac_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -390,7 +387,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmsac_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -492,7 +489,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -504,7 +501,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -516,7 +513,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsac_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -528,7 +525,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsac_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -540,7 +537,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsac_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -552,7 +549,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsac_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfnmsub.c
+++ b/auto-generated/overloaded-api-testing/vfnmsub.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmsub_vf_f16mf4(vfloat16mf4_t vd, _Float16 rs1,
                                      vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmsub_vf_f16mf2(vfloat16mf2_t vd, _Float16 rs1,
                                      vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmsub_vf_f16m1(vfloat16m1_t vd, _Float16 rs1,
                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmsub_vf_f16m2(vfloat16m2_t vd, _Float16 rs1,
                                    vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmsub_vf_f16m4(vfloat16m4_t vd, _Float16 rs1,
                                    vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmsub(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmsub_vf_f16m8(vfloat16m8_t vd, _Float16 rs1,
                                    vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vd,
-                                       float16_t rs1, vfloat16mf4_t vs2,
+                                       _Float16 rs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vd,
-                                       float16_t rs1, vfloat16mf2_t vs2,
+                                       _Float16 rs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vd,
-                                     float16_t rs1, vfloat16m1_t vs2,
+                                     _Float16 rs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, vl);
 }
@@ -197,9 +197,8 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfnmsub(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd,
-                                     float16_t rs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, vl);
 }
 
@@ -209,9 +208,8 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfnmsub(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd,
-                                     float16_t rs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, vl);
 }
 
@@ -221,9 +219,8 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfnmsub(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd,
-                                     float16_t rs1, vfloat16m8_t vs2,
-                                     size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
+                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, vl);
 }
 
@@ -340,7 +337,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -350,7 +347,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -360,7 +357,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_rm(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmsub_vf_f16m1_rm(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -370,7 +367,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_rm(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmsub_vf_f16m2_rm(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -380,7 +377,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_rm(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmsub_vf_f16m4_rm(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -390,7 +387,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmsub(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_rm(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmsub_vf_f16m8_rm(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -492,7 +489,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -504,7 +501,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -516,7 +513,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -528,7 +525,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -540,7 +537,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -552,7 +549,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfrdiv.c
+++ b/auto-generated/overloaded-api-testing/vfrdiv.c
@@ -5,29 +5,29 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfrdiv_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfrdiv_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, vl);
 }
 
@@ -69,32 +69,32 @@ vfloat64m8_t test_vfrdiv_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl) {
 }
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, vl);
 }
 
@@ -143,32 +143,32 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
   return __riscv_vfrdiv(vm, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t test_vfrdiv_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfrdiv_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfrdiv_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfrdiv_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrdiv(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -219,32 +219,32 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_rm(vfloat64m8_t vs2, float64_t rs1,
 }
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrdiv_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrdiv_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrdiv_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/overloaded-api-testing/vfrsub.c
+++ b/auto-generated/overloaded-api-testing/vfrsub.c
@@ -5,29 +5,29 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfrsub_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfrsub(vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfrsub_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfrsub(vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vs2, rs1, vl);
 }
 
@@ -69,32 +69,32 @@ vfloat64m8_t test_vfrsub_vf_f64m8(vfloat64m8_t vs2, float64_t rs1, size_t vl) {
 }
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, vl);
 }
 
@@ -143,32 +143,32 @@ vfloat64m8_t test_vfrsub_vf_f64m8_m(vbool8_t vm, vfloat64m8_t vs2,
   return __riscv_vfrsub(vm, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfrsub_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfrsub_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t test_vfrsub_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfrsub_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfrsub_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfrsub_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -219,32 +219,32 @@ vfloat64m8_t test_vfrsub_vf_f64m8_rm(vfloat64m8_t vs2, float64_t rs1,
 }
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/overloaded-api-testing/vfsgnj.c
+++ b/auto-generated/overloaded-api-testing/vfsgnj.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfsgnj(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnj_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfsgnj_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfsgnj(vs2, rs1, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfsgnj(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnj_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfsgnj_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfsgnj(vs2, rs1, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfsgnj(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnj_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnj_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj(vs2, rs1, vl);
 }
 
@@ -39,7 +39,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfsgnj(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnj_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnj_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj(vs2, rs1, vl);
 }
 
@@ -48,7 +48,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfsgnj(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnj_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnj_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj(vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfsgnj(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnj_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnj_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj(vs2, rs1, vl);
 }
 
@@ -149,7 +149,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsgnj_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj(vm, vs2, rs1, vl);
 }
 
@@ -159,7 +159,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsgnj_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj(vm, vs2, rs1, vl);
 }
 
@@ -169,7 +169,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfsgnj_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj(vm, vs2, rs1, vl);
 }
 
@@ -178,8 +178,8 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfsgnj(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnj_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnj_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfsgnj(vm, vs2, rs1, vl);
 }
 
@@ -188,8 +188,8 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfsgnj(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnj_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnj_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfsgnj(vm, vs2, rs1, vl);
 }
 
@@ -198,8 +198,8 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vfsgnj(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnj_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnj_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfsgnj(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/overloaded-api-testing/vfsgnjn.c
+++ b/auto-generated/overloaded-api-testing/vfsgnjn.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfsgnjn(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjn_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfsgnjn_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsgnjn(vs2, rs1, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfsgnjn(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjn_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfsgnjn_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsgnjn(vs2, rs1, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfsgnjn(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjn_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjn_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vs2, rs1, vl);
 }
 
@@ -39,7 +39,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfsgnjn(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjn_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjn_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vs2, rs1, vl);
 }
 
@@ -48,7 +48,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfsgnjn(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjn_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjn_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfsgnjn(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjn_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjn_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vs2, rs1, vl);
 }
 
@@ -149,7 +149,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsgnjn_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vm, vs2, rs1, vl);
 }
 
@@ -159,7 +159,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsgnjn_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vm, vs2, rs1, vl);
 }
 
@@ -169,7 +169,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfsgnjn_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vm, vs2, rs1, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfsgnjn_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vm, vs2, rs1, vl);
 }
 
@@ -189,7 +189,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfsgnjn_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vm, vs2, rs1, vl);
 }
 
@@ -199,7 +199,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfsgnjn_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/overloaded-api-testing/vfsgnjx.c
+++ b/auto-generated/overloaded-api-testing/vfsgnjx.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfsgnjx(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjx_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfsgnjx_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsgnjx(vs2, rs1, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfsgnjx(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjx_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfsgnjx_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsgnjx(vs2, rs1, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfsgnjx(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjx_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjx_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vs2, rs1, vl);
 }
 
@@ -39,7 +39,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfsgnjx(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjx_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjx_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vs2, rs1, vl);
 }
 
@@ -48,7 +48,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfsgnjx(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjx_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjx_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfsgnjx(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjx_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjx_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vs2, rs1, vl);
 }
 
@@ -149,7 +149,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsgnjx_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vm, vs2, rs1, vl);
 }
 
@@ -159,7 +159,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsgnjx_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vm, vs2, rs1, vl);
 }
 
@@ -169,7 +169,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfsgnjx_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vm, vs2, rs1, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfsgnjx_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vm, vs2, rs1, vl);
 }
 
@@ -189,7 +189,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfsgnjx_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vm, vs2, rs1, vl);
 }
 
@@ -199,7 +199,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfsgnjx_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/overloaded-api-testing/vfslide1down.c
+++ b/auto-generated/overloaded-api-testing/vfslide1down.c
@@ -5,32 +5,32 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfslide1down_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfslide1down_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfslide1down(vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1down_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfslide1down_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfslide1down(vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1down_vf_f16m1(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t test_vfslide1down_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfslide1down(vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1down_vf_f16m2(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfslide1down_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfslide1down(vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1down_vf_f16m4(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfslide1down_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfslide1down(vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1down_vf_f16m8(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfslide1down_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfslide1down(vs2, rs1, vl);
 }
@@ -81,32 +81,32 @@ vfloat64m8_t test_vfslide1down_vf_f64m8(vfloat64m8_t vs2, float64_t rs1,
 }
 
 vfloat16mf4_t test_vfslide1down_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                            float16_t rs1, size_t vl) {
+                                            _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down(vm, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1down_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                            float16_t rs1, size_t vl) {
+                                            _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down(vm, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1down_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down(vm, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1down_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down(vm, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1down_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down(vm, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1down_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/overloaded-api-testing/vfslide1up.c
+++ b/auto-generated/overloaded-api-testing/vfslide1up.c
@@ -5,32 +5,32 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfslide1up_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfslide1up_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfslide1up(vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1up_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfslide1up_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfslide1up(vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1up_vf_f16m1(vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t test_vfslide1up_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfslide1up(vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1up_vf_f16m2(vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfslide1up_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfslide1up(vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1up_vf_f16m4(vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfslide1up_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfslide1up(vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1up_vf_f16m8(vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfslide1up_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfslide1up(vs2, rs1, vl);
 }
@@ -81,32 +81,32 @@ vfloat64m8_t test_vfslide1up_vf_f64m8(vfloat64m8_t vs2, float64_t rs1,
 }
 
 vfloat16mf4_t test_vfslide1up_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up(vm, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1up_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up(vm, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1up_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up(vm, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1up_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up(vm, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1up_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up(vm, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1up_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up(vm, vs2, rs1, vl);
 }
 

--- a/auto-generated/overloaded-api-testing/vfsub.c
+++ b/auto-generated/overloaded-api-testing/vfsub.c
@@ -10,8 +10,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfsub(vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfsub(vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vfloat16m1_t test_vfsub_vv_f16m1(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfsub(vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, vl);
 }
 
@@ -39,7 +37,7 @@ vfloat16m2_t test_vfsub_vv_f16m2(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfsub(vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, vl);
 }
 
@@ -48,7 +46,7 @@ vfloat16m4_t test_vfsub_vv_f16m4(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfsub(vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, vl);
 }
 
@@ -57,7 +55,7 @@ vfloat16m8_t test_vfsub_vv_f16m8(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfsub(vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, vl);
 }
 
@@ -149,7 +147,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, vl);
 }
 
@@ -159,7 +157,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, vl);
 }
 
@@ -168,8 +166,8 @@ vfloat16m1_t test_vfsub_vv_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
   return __riscv_vfsub(vm, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2,
-                                   float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_m(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
+                                   size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, vl);
 }
 
@@ -178,7 +176,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfsub(vm, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t test_vfsub_vf_f16m2_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, vl);
 }
@@ -188,7 +186,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfsub(vm, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t test_vfsub_vf_f16m4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, vl);
 }
@@ -198,7 +196,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vfsub(vm, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t test_vfsub_vf_f16m8_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                    size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, vl);
 }
@@ -298,7 +296,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfsub(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t test_vfsub_vf_f16mf4_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -308,7 +306,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfsub(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t test_vfsub_vf_f16mf2_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -318,8 +316,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfsub(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_rm(vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_rm(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -328,8 +325,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfsub(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_rm(vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_rm(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -338,8 +334,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfsub(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_rm(vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_rm(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -348,8 +343,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm(vfloat16m8_t vs2, vfloat16m8_t vs1,
   return __riscv_vfsub(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_rm(vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_rm(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -449,7 +443,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +453,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -469,7 +463,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfsub_vf_f16m1_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -479,7 +473,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfsub_vf_f16m2_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -489,7 +483,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfsub_vf_f16m4_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +493,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfsub_vf_f16m8_rm_m(vbool2_t vm, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsub(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/overloaded-api-testing/vfwadd.c
+++ b/auto-generated/overloaded-api-testing/vfwadd.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwadd_vv(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwadd_vf_f32mf2(vfloat16mf4_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, vl);
 }
@@ -20,7 +20,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwadd_wv(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwadd_wf_f32mf2(vfloat32mf2_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwadd_vv(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, vl);
 }
 
@@ -39,7 +39,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1(vfloat32m1_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwadd_wv(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1(vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1(vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, vl);
 }
 
@@ -48,7 +48,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwadd_vv(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2(vfloat32m2_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwadd_wv(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2(vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2(vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, vl);
 }
 
@@ -66,7 +66,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwadd_vv(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, vl);
 }
 
@@ -75,7 +75,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4(vfloat32m4_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwadd_wv(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4(vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4(vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, vl);
 }
 
@@ -84,7 +84,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwadd_vv(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, vl);
 }
 
@@ -93,7 +93,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8(vfloat32m8_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwadd_wv(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8(vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8(vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, vl);
 }
 
@@ -175,7 +175,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, vl);
 }
 
@@ -185,7 +185,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, vl);
 }
 
@@ -195,7 +195,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, vl);
 }
 
@@ -205,7 +205,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, vl);
 }
 
@@ -215,7 +215,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, vl);
 }
 
@@ -225,7 +225,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_m(vbool16_t vm, vfloat32m2_t vs2,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, vl);
 }
 
@@ -234,8 +234,8 @@ vfloat32m4_t test_vfwadd_vv_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfwadd_vv(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, vl);
 }
 
@@ -244,8 +244,8 @@ vfloat32m4_t test_vfwadd_wv_f32m4_m(vbool8_t vm, vfloat32m4_t vs2,
   return __riscv_vfwadd_wv(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, vl);
 }
 
@@ -254,8 +254,8 @@ vfloat32m8_t test_vfwadd_vv_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfwadd_vv(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, vl);
 }
 
@@ -264,8 +264,8 @@ vfloat32m8_t test_vfwadd_wv_f32m8_m(vbool4_t vm, vfloat32m8_t vs2,
   return __riscv_vfwadd_wv(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, vl);
 }
 
@@ -354,7 +354,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwadd_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwadd_vf_f32mf2_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -364,7 +364,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwadd_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_rm(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwadd_wf_f32mf2_rm(vfloat32mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -374,7 +374,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwadd_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t test_vfwadd_vf_f32m1_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -384,7 +384,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm(vfloat32m1_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwadd_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_rm(vfloat32m1_t vs2, float16_t rs1,
+vfloat32m1_t test_vfwadd_wf_f32m1_rm(vfloat32m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -394,7 +394,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwadd_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t test_vfwadd_vf_f32m2_rm(vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -404,7 +404,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm(vfloat32m2_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwadd_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_rm(vfloat32m2_t vs2, float16_t rs1,
+vfloat32m2_t test_vfwadd_wf_f32m2_rm(vfloat32m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -414,7 +414,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwadd_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t test_vfwadd_vf_f32m4_rm(vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -424,7 +424,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm(vfloat32m4_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwadd_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_rm(vfloat32m4_t vs2, float16_t rs1,
+vfloat32m4_t test_vfwadd_wf_f32m4_rm(vfloat32m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -434,7 +434,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwadd_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t test_vfwadd_vf_f32m8_rm(vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -444,7 +444,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm(vfloat32m8_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwadd_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_rm(vfloat32m8_t vs2, float16_t rs1,
+vfloat32m8_t test_vfwadd_wf_f32m8_rm(vfloat32m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -535,7 +535,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -545,7 +545,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -555,7 +555,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -565,7 +565,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -575,7 +575,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -585,7 +585,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -595,7 +595,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
 }
 
 vfloat32m4_t test_vfwadd_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -605,7 +605,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2,
 }
 
 vfloat32m4_t test_vfwadd_wf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -615,7 +615,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
 }
 
 vfloat32m8_t test_vfwadd_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -625,7 +625,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2,
 }
 
 vfloat32m8_t test_vfwadd_wf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/overloaded-api-testing/vfwmacc.c
+++ b/auto-generated/overloaded-api-testing/vfwmacc.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwmacc_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1,
                                      vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwmacc_vf_f32m1(vfloat32m1_t vd, _Float16 vs1,
                                    vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwmacc_vf_f32m2(vfloat32m2_t vd, _Float16 vs1,
                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwmacc_vf_f32m4(vfloat32m4_t vd, _Float16 vs1,
                                    vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwmacc_vf_f32m8(vfloat32m8_t vd, _Float16 vs1,
                                    vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, vl);
 }
@@ -102,7 +102,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmacc_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
-                                       float16_t vs1, vfloat16mf4_t vs2,
+                                       _Float16 vs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, vl);
 }
@@ -114,7 +114,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmacc_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
-                                     float16_t vs1, vfloat16mf2_t vs2,
+                                     _Float16 vs1, vfloat16mf2_t vs2,
                                      size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, vl);
 }
@@ -126,7 +126,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmacc_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
-                                     float16_t vs1, vfloat16m1_t vs2,
+                                     _Float16 vs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, vl);
 }
@@ -137,9 +137,8 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
   return __riscv_vfwmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
-                                     float16_t vs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, vl);
 }
 
@@ -149,9 +148,8 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
   return __riscv_vfwmacc(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
-                                     float16_t vs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, vl);
 }
 
@@ -208,7 +206,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -218,7 +216,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwmacc_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1,
                                       vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -228,7 +226,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwmacc_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -238,7 +236,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwmacc_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -248,7 +246,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwmacc_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -300,7 +298,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
-                                          float16_t vs1, vfloat16mf4_t vs2,
+                                          _Float16 vs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -312,7 +310,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmacc_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
-                                        float16_t vs1, vfloat16mf2_t vs2,
+                                        _Float16 vs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -324,7 +322,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmacc_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
-                                        float16_t vs1, vfloat16m1_t vs2,
+                                        _Float16 vs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -336,7 +334,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmacc_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
-                                        float16_t vs1, vfloat16m2_t vs2,
+                                        _Float16 vs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -348,7 +346,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmacc_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
-                                        float16_t vs1, vfloat16m4_t vs2,
+                                        _Float16 vs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfwmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfwmsac.c
+++ b/auto-generated/overloaded-api-testing/vfwmsac.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwmsac_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1,
                                      vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwmsac_vf_f32m1(vfloat32m1_t vd, _Float16 vs1,
                                    vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwmsac_vf_f32m2(vfloat32m2_t vd, _Float16 vs1,
                                    vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwmsac_vf_f32m4(vfloat32m4_t vd, _Float16 vs1,
                                    vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwmsac_vf_f32m8(vfloat32m8_t vd, _Float16 vs1,
                                    vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, vl);
 }
@@ -102,7 +102,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmsac_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
-                                       float16_t vs1, vfloat16mf4_t vs2,
+                                       _Float16 vs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, vl);
 }
@@ -114,7 +114,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmsac_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
-                                     float16_t vs1, vfloat16mf2_t vs2,
+                                     _Float16 vs1, vfloat16mf2_t vs2,
                                      size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, vl);
 }
@@ -126,7 +126,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmsac_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
-                                     float16_t vs1, vfloat16m1_t vs2,
+                                     _Float16 vs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, vl);
 }
@@ -137,9 +137,8 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
   return __riscv_vfwmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
-                                     float16_t vs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, vl);
 }
 
@@ -149,9 +148,8 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
   return __riscv_vfwmsac(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
-                                     float16_t vs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, vl);
 }
 
@@ -208,7 +206,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -218,7 +216,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwmsac_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1,
                                       vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -228,7 +226,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwmsac_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -238,7 +236,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwmsac_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -248,7 +246,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwmsac_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -300,7 +298,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
-                                          float16_t vs1, vfloat16mf4_t vs2,
+                                          _Float16 vs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -312,7 +310,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmsac_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
-                                        float16_t vs1, vfloat16mf2_t vs2,
+                                        _Float16 vs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -324,7 +322,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmsac_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
-                                        float16_t vs1, vfloat16m1_t vs2,
+                                        _Float16 vs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -336,7 +334,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmsac_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
-                                        float16_t vs1, vfloat16m2_t vs2,
+                                        _Float16 vs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -348,7 +346,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmsac_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
-                                        float16_t vs1, vfloat16m4_t vs2,
+                                        _Float16 vs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfwmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfwmul.c
+++ b/auto-generated/overloaded-api-testing/vfwmul.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwmul(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwmul_vf_f32mf2(vfloat16mf4_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfwmul(vs2, rs1, vl);
 }
@@ -20,7 +20,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwmul(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vs2, rs1, vl);
 }
 
@@ -29,7 +29,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwmul(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vs2, rs1, vl);
 }
 
@@ -38,7 +38,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwmul(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vs2, rs1, vl);
 }
 
@@ -47,7 +47,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwmul(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vs2, rs1, vl);
 }
 
@@ -93,7 +93,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, vl);
 }
 
@@ -103,7 +103,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, vl);
 }
 
@@ -113,7 +113,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, vl);
 }
 
@@ -122,8 +122,8 @@ vfloat32m4_t test_vfwmul_vv_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfwmul(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, vl);
 }
 
@@ -132,8 +132,8 @@ vfloat32m8_t test_vfwmul_vv_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfwmul(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, vl);
 }
 
@@ -182,7 +182,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwmul_vf_f32mf2_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -192,7 +192,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t test_vfwmul_vf_f32m1_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -202,7 +202,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t test_vfwmul_vf_f32m2_rm(vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -212,7 +212,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t test_vfwmul_vf_f32m4_rm(vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -222,7 +222,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwmul(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t test_vfwmul_vf_f32m8_rm(vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwmul(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -273,7 +273,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -293,7 +293,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -303,7 +303,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
 }
 
 vfloat32m4_t test_vfwmul_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -313,7 +313,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
 }
 
 vfloat32m8_t test_vfwmul_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwmul(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/overloaded-api-testing/vfwnmacc.c
+++ b/auto-generated/overloaded-api-testing/vfwnmacc.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1,
                                       vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwnmacc_vf_f32m1(vfloat32m1_t vd, _Float16 vs1,
                                     vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwnmacc_vf_f32m2(vfloat32m2_t vd, _Float16 vs1,
                                     vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwnmacc_vf_f32m4(vfloat32m4_t vd, _Float16 vs1,
                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwnmacc_vf_f32m8(vfloat32m8_t vd, _Float16 vs1,
                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, vl);
 }
@@ -102,7 +102,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmacc_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
-                                        float16_t vs1, vfloat16mf4_t vs2,
+                                        _Float16 vs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, vl);
 }
@@ -114,7 +114,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmacc_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
-                                      float16_t vs1, vfloat16mf2_t vs2,
+                                      _Float16 vs1, vfloat16mf2_t vs2,
                                       size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, vl);
 }
@@ -126,7 +126,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmacc_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
-                                      float16_t vs1, vfloat16m1_t vs2,
+                                      _Float16 vs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, vl);
 }
@@ -138,7 +138,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmacc_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
-                                      float16_t vs1, vfloat16m2_t vs2,
+                                      _Float16 vs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, vl);
 }
@@ -150,7 +150,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmacc_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
-                                      float16_t vs1, vfloat16m4_t vs2,
+                                      _Float16 vs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, vl);
 }
@@ -208,7 +208,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1,
                                          vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -218,7 +218,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwnmacc_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -228,7 +228,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwnmacc_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1,
                                        vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -238,7 +238,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwnmacc_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1,
                                        vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -248,7 +248,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwnmacc_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1,
                                        vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -300,7 +300,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
-                                           float16_t vs1, vfloat16mf4_t vs2,
+                                           _Float16 vs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -312,7 +312,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
-                                         float16_t vs1, vfloat16mf2_t vs2,
+                                         _Float16 vs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -324,7 +324,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
-                                         float16_t vs1, vfloat16m1_t vs2,
+                                         _Float16 vs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -336,7 +336,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
-                                         float16_t vs1, vfloat16m2_t vs2,
+                                         _Float16 vs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -348,7 +348,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
-                                         float16_t vs1, vfloat16m4_t vs2,
+                                         _Float16 vs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmacc(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfwnmsac.c
+++ b/auto-generated/overloaded-api-testing/vfwnmsac.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2(vfloat32mf2_t vd, _Float16 vs1,
                                       vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwnmsac_vf_f32m1(vfloat32m1_t vd, _Float16 vs1,
                                     vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwnmsac_vf_f32m2(vfloat32m2_t vd, _Float16 vs1,
                                     vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwnmsac_vf_f32m4(vfloat32m4_t vd, _Float16 vs1,
                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwnmsac_vf_f32m8(vfloat32m8_t vd, _Float16 vs1,
                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, vl);
 }
@@ -102,7 +102,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmsac_vf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vd,
-                                        float16_t vs1, vfloat16mf4_t vs2,
+                                        _Float16 vs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, vl);
 }
@@ -114,7 +114,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmsac_vf_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
-                                      float16_t vs1, vfloat16mf2_t vs2,
+                                      _Float16 vs1, vfloat16mf2_t vs2,
                                       size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, vl);
 }
@@ -126,7 +126,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmsac_vf_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
-                                      float16_t vs1, vfloat16m1_t vs2,
+                                      _Float16 vs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, vl);
 }
@@ -138,7 +138,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmsac_vf_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
-                                      float16_t vs1, vfloat16m2_t vs2,
+                                      _Float16 vs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, vl);
 }
@@ -150,7 +150,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmsac_vf_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
-                                      float16_t vs1, vfloat16m4_t vs2,
+                                      _Float16 vs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, vl);
 }
@@ -208,7 +208,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm(vfloat32mf2_t vd, _Float16 vs1,
                                          vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -218,7 +218,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_rm(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwnmsac_vf_f32m1_rm(vfloat32m1_t vd, _Float16 vs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -228,7 +228,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_rm(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwnmsac_vf_f32m2_rm(vfloat32m2_t vd, _Float16 vs1,
                                        vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -238,7 +238,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_rm(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwnmsac_vf_f32m4_rm(vfloat32m4_t vd, _Float16 vs1,
                                        vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -248,7 +248,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_rm(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwnmsac_vf_f32m8_rm(vfloat32m8_t vd, _Float16 vs1,
                                        vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -300,7 +300,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vd,
-                                           float16_t vs1, vfloat16mf4_t vs2,
+                                           _Float16 vs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -312,7 +312,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
-                                         float16_t vs1, vfloat16mf2_t vs2,
+                                         _Float16 vs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -324,7 +324,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
-                                         float16_t vs1, vfloat16m1_t vs2,
+                                         _Float16 vs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -336,7 +336,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
-                                         float16_t vs1, vfloat16m2_t vs2,
+                                         _Float16 vs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -348,7 +348,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
-                                         float16_t vs1, vfloat16m4_t vs2,
+                                         _Float16 vs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmsac(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfwsub.c
+++ b/auto-generated/overloaded-api-testing/vfwsub.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwsub_vv(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwsub_vf_f32mf2(vfloat16mf4_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, vl);
 }
@@ -20,7 +20,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwsub_wv(vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwsub_wf_f32mf2(vfloat32mf2_t vs2, _Float16 rs1,
                                     size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwsub_vv(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1(vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, vl);
 }
 
@@ -39,7 +39,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1(vfloat32m1_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwsub_wv(vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1(vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1(vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, vl);
 }
 
@@ -48,7 +48,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwsub_vv(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2(vfloat32m2_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwsub_wv(vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2(vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2(vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, vl);
 }
 
@@ -66,7 +66,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwsub_vv(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, vl);
 }
 
@@ -75,7 +75,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4(vfloat32m4_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwsub_wv(vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4(vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4(vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, vl);
 }
 
@@ -84,7 +84,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwsub_vv(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, vl);
 }
 
@@ -93,7 +93,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8(vfloat32m8_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwsub_wv(vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8(vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8(vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, vl);
 }
 
@@ -175,7 +175,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, vl);
 }
 
@@ -185,7 +185,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, vl);
 }
 
@@ -195,7 +195,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, vl);
 }
 
@@ -205,7 +205,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_m(vbool32_t vm, vfloat32m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, vl);
 }
 
@@ -215,7 +215,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, vl);
 }
 
@@ -225,7 +225,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_m(vbool16_t vm, vfloat32m2_t vs2,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, vl);
 }
 
@@ -234,8 +234,8 @@ vfloat32m4_t test_vfwsub_vv_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vfwsub_vv(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, vl);
 }
 
@@ -244,8 +244,8 @@ vfloat32m4_t test_vfwsub_wv_f32m4_m(vbool8_t vm, vfloat32m4_t vs2,
   return __riscv_vfwsub_wv(vm, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_m(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, vl);
 }
 
@@ -254,8 +254,8 @@ vfloat32m8_t test_vfwsub_vv_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vfwsub_vv(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, vl);
 }
 
@@ -264,8 +264,8 @@ vfloat32m8_t test_vfwsub_wv_f32m8_m(vbool4_t vm, vfloat32m8_t vs2,
   return __riscv_vfwsub_wv(vm, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_m(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1,
+                                    size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, vl);
 }
 
@@ -354,7 +354,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwsub_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_rm(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwsub_vf_f32mf2_rm(vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -364,7 +364,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
   return __riscv_vfwsub_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_rm(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t test_vfwsub_wf_f32mf2_rm(vfloat32mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -374,7 +374,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwsub_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_rm(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t test_vfwsub_vf_f32m1_rm(vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -384,7 +384,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm(vfloat32m1_t vs2, vfloat16mf2_t vs1,
   return __riscv_vfwsub_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_rm(vfloat32m1_t vs2, float16_t rs1,
+vfloat32m1_t test_vfwsub_wf_f32m1_rm(vfloat32m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -394,7 +394,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwsub_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_rm(vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t test_vfwsub_vf_f32m2_rm(vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -404,7 +404,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm(vfloat32m2_t vs2, vfloat16m1_t vs1,
   return __riscv_vfwsub_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_rm(vfloat32m2_t vs2, float16_t rs1,
+vfloat32m2_t test_vfwsub_wf_f32m2_rm(vfloat32m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -414,7 +414,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm(vfloat16m2_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwsub_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_rm(vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t test_vfwsub_vf_f32m4_rm(vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -424,7 +424,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm(vfloat32m4_t vs2, vfloat16m2_t vs1,
   return __riscv_vfwsub_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_rm(vfloat32m4_t vs2, float16_t rs1,
+vfloat32m4_t test_vfwsub_wf_f32m4_rm(vfloat32m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -434,7 +434,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm(vfloat16m4_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwsub_vv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_rm(vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t test_vfwsub_vf_f32m8_rm(vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_vf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -444,7 +444,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm(vfloat32m8_t vs2, vfloat16m4_t vs1,
   return __riscv_vfwsub_wv(vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_rm(vfloat32m8_t vs2, float16_t rs1,
+vfloat32m8_t test_vfwsub_wf_f32m8_rm(vfloat32m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_wf(vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -535,7 +535,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -545,7 +545,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -555,7 +555,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_rm_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -565,7 +565,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -575,7 +575,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_rm_m(vbool16_t vm, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -585,7 +585,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -595,7 +595,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
 }
 
 vfloat32m4_t test_vfwsub_vf_f32m4_rm_m(vbool8_t vm, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -605,7 +605,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2,
 }
 
 vfloat32m4_t test_vfwsub_wf_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -615,7 +615,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
 }
 
 vfloat32m8_t test_vfwsub_vf_f32m8_rm_m(vbool4_t vm, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -625,7 +625,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2,
 }
 
 vfloat32m8_t test_vfwsub_wf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf(vm, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/overloaded-api-testing/vmfeq.c
+++ b/auto-generated/overloaded-api-testing/vmfeq.c
@@ -10,8 +10,7 @@ vbool64_t test_vmfeq_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vmfeq(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfeq_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool64_t test_vmfeq_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vbool32_t test_vmfeq_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vmfeq(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfeq_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool32_t test_vmfeq_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vbool16_t test_vmfeq_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vmfeq(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfeq_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfeq_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vs2, rs1, vl);
 }
 
@@ -38,7 +36,7 @@ vbool8_t test_vmfeq_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfeq(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfeq_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfeq_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vs2, rs1, vl);
 }
 
@@ -46,7 +44,7 @@ vbool4_t test_vmfeq_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfeq(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfeq_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfeq_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vs2, rs1, vl);
 }
 
@@ -54,7 +52,7 @@ vbool2_t test_vmfeq_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfeq(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfeq_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfeq_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vs2, rs1, vl);
 }
 
@@ -143,7 +141,7 @@ vbool64_t test_vmfeq_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vbool64_t test_vmfeq_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vm, vs2, rs1, vl);
 }
 
@@ -153,7 +151,7 @@ vbool32_t test_vmfeq_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vbool32_t test_vmfeq_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +161,7 @@ vbool16_t test_vmfeq_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vbool16_t test_vmfeq_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vmfeq(vm, vs2, rs1, vl);
 }
 
@@ -172,7 +170,7 @@ vbool8_t test_vmfeq_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vmfeq(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfeq_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vbool8_t test_vmfeq_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfeq(vm, vs2, rs1, vl);
 }
@@ -182,7 +180,7 @@ vbool4_t test_vmfeq_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vmfeq(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfeq_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vbool4_t test_vmfeq_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfeq(vm, vs2, rs1, vl);
 }
@@ -192,7 +190,7 @@ vbool2_t test_vmfeq_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vmfeq(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfeq_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vbool2_t test_vmfeq_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfeq(vm, vs2, rs1, vl);
 }

--- a/auto-generated/overloaded-api-testing/vmfge.c
+++ b/auto-generated/overloaded-api-testing/vmfge.c
@@ -10,8 +10,7 @@ vbool64_t test_vmfge_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vmfge(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfge_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool64_t test_vmfge_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vbool32_t test_vmfge_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vmfge(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfge_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool32_t test_vmfge_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vbool16_t test_vmfge_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vmfge(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfge_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfge_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vs2, rs1, vl);
 }
 
@@ -38,7 +36,7 @@ vbool8_t test_vmfge_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfge(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfge_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfge_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vs2, rs1, vl);
 }
 
@@ -46,7 +44,7 @@ vbool4_t test_vmfge_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfge(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfge_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfge_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vs2, rs1, vl);
 }
 
@@ -54,7 +52,7 @@ vbool2_t test_vmfge_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfge(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfge_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfge_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vs2, rs1, vl);
 }
 
@@ -143,7 +141,7 @@ vbool64_t test_vmfge_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vbool64_t test_vmfge_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vm, vs2, rs1, vl);
 }
 
@@ -153,7 +151,7 @@ vbool32_t test_vmfge_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vbool32_t test_vmfge_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +161,7 @@ vbool16_t test_vmfge_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vbool16_t test_vmfge_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vmfge(vm, vs2, rs1, vl);
 }
 
@@ -172,7 +170,7 @@ vbool8_t test_vmfge_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vmfge(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfge_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vbool8_t test_vmfge_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfge(vm, vs2, rs1, vl);
 }
@@ -182,7 +180,7 @@ vbool4_t test_vmfge_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vmfge(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfge_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vbool4_t test_vmfge_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfge(vm, vs2, rs1, vl);
 }
@@ -192,7 +190,7 @@ vbool2_t test_vmfge_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vmfge(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfge_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vbool2_t test_vmfge_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfge(vm, vs2, rs1, vl);
 }

--- a/auto-generated/overloaded-api-testing/vmfgt.c
+++ b/auto-generated/overloaded-api-testing/vmfgt.c
@@ -10,8 +10,7 @@ vbool64_t test_vmfgt_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vmfgt(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfgt_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool64_t test_vmfgt_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vbool32_t test_vmfgt_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vmfgt(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfgt_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool32_t test_vmfgt_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vbool16_t test_vmfgt_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vmfgt(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfgt_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfgt_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vs2, rs1, vl);
 }
 
@@ -38,7 +36,7 @@ vbool8_t test_vmfgt_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfgt(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfgt_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfgt_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vs2, rs1, vl);
 }
 
@@ -46,7 +44,7 @@ vbool4_t test_vmfgt_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfgt(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfgt_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfgt_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vs2, rs1, vl);
 }
 
@@ -54,7 +52,7 @@ vbool2_t test_vmfgt_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfgt(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfgt_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfgt_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vs2, rs1, vl);
 }
 
@@ -143,7 +141,7 @@ vbool64_t test_vmfgt_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vbool64_t test_vmfgt_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vm, vs2, rs1, vl);
 }
 
@@ -153,7 +151,7 @@ vbool32_t test_vmfgt_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vbool32_t test_vmfgt_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +161,7 @@ vbool16_t test_vmfgt_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vbool16_t test_vmfgt_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vmfgt(vm, vs2, rs1, vl);
 }
 
@@ -172,7 +170,7 @@ vbool8_t test_vmfgt_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vmfgt(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfgt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vbool8_t test_vmfgt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfgt(vm, vs2, rs1, vl);
 }
@@ -182,7 +180,7 @@ vbool4_t test_vmfgt_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vmfgt(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfgt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vbool4_t test_vmfgt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfgt(vm, vs2, rs1, vl);
 }
@@ -192,7 +190,7 @@ vbool2_t test_vmfgt_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vmfgt(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfgt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vbool2_t test_vmfgt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfgt(vm, vs2, rs1, vl);
 }

--- a/auto-generated/overloaded-api-testing/vmfle.c
+++ b/auto-generated/overloaded-api-testing/vmfle.c
@@ -10,8 +10,7 @@ vbool64_t test_vmfle_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vmfle(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfle_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool64_t test_vmfle_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vbool32_t test_vmfle_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vmfle(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfle_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool32_t test_vmfle_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vbool16_t test_vmfle_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vmfle(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfle_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfle_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vs2, rs1, vl);
 }
 
@@ -38,7 +36,7 @@ vbool8_t test_vmfle_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfle(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfle_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfle_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vs2, rs1, vl);
 }
 
@@ -46,7 +44,7 @@ vbool4_t test_vmfle_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfle(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfle_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfle_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vs2, rs1, vl);
 }
 
@@ -54,7 +52,7 @@ vbool2_t test_vmfle_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfle(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfle_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfle_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vs2, rs1, vl);
 }
 
@@ -143,7 +141,7 @@ vbool64_t test_vmfle_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vbool64_t test_vmfle_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vm, vs2, rs1, vl);
 }
 
@@ -153,7 +151,7 @@ vbool32_t test_vmfle_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vbool32_t test_vmfle_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +161,7 @@ vbool16_t test_vmfle_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vbool16_t test_vmfle_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vmfle(vm, vs2, rs1, vl);
 }
 
@@ -172,7 +170,7 @@ vbool8_t test_vmfle_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vmfle(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfle_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vbool8_t test_vmfle_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfle(vm, vs2, rs1, vl);
 }
@@ -182,7 +180,7 @@ vbool4_t test_vmfle_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vmfle(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfle_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vbool4_t test_vmfle_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfle(vm, vs2, rs1, vl);
 }
@@ -192,7 +190,7 @@ vbool2_t test_vmfle_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vmfle(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfle_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vbool2_t test_vmfle_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfle(vm, vs2, rs1, vl);
 }

--- a/auto-generated/overloaded-api-testing/vmflt.c
+++ b/auto-generated/overloaded-api-testing/vmflt.c
@@ -10,8 +10,7 @@ vbool64_t test_vmflt_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vmflt(vs2, vs1, vl);
 }
 
-vbool64_t test_vmflt_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool64_t test_vmflt_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vbool32_t test_vmflt_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vmflt(vs2, vs1, vl);
 }
 
-vbool32_t test_vmflt_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool32_t test_vmflt_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vbool16_t test_vmflt_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vmflt(vs2, vs1, vl);
 }
 
-vbool16_t test_vmflt_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmflt_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vs2, rs1, vl);
 }
 
@@ -38,7 +36,7 @@ vbool8_t test_vmflt_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmflt(vs2, vs1, vl);
 }
 
-vbool8_t test_vmflt_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmflt_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vs2, rs1, vl);
 }
 
@@ -46,7 +44,7 @@ vbool4_t test_vmflt_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmflt(vs2, vs1, vl);
 }
 
-vbool4_t test_vmflt_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmflt_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vs2, rs1, vl);
 }
 
@@ -54,7 +52,7 @@ vbool2_t test_vmflt_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmflt(vs2, vs1, vl);
 }
 
-vbool2_t test_vmflt_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmflt_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vs2, rs1, vl);
 }
 
@@ -143,7 +141,7 @@ vbool64_t test_vmflt_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vbool64_t test_vmflt_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vm, vs2, rs1, vl);
 }
 
@@ -153,7 +151,7 @@ vbool32_t test_vmflt_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vbool32_t test_vmflt_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +161,7 @@ vbool16_t test_vmflt_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vbool16_t test_vmflt_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vmflt(vm, vs2, rs1, vl);
 }
 
@@ -172,7 +170,7 @@ vbool8_t test_vmflt_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vmflt(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmflt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vbool8_t test_vmflt_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmflt(vm, vs2, rs1, vl);
 }
@@ -182,7 +180,7 @@ vbool4_t test_vmflt_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vmflt(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmflt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vbool4_t test_vmflt_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmflt(vm, vs2, rs1, vl);
 }
@@ -192,7 +190,7 @@ vbool2_t test_vmflt_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vmflt(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmflt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vbool2_t test_vmflt_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmflt(vm, vs2, rs1, vl);
 }

--- a/auto-generated/overloaded-api-testing/vmfne.c
+++ b/auto-generated/overloaded-api-testing/vmfne.c
@@ -10,8 +10,7 @@ vbool64_t test_vmfne_vv_f16mf4_b64(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
   return __riscv_vmfne(vs2, vs1, vl);
 }
 
-vbool64_t test_vmfne_vf_f16mf4_b64(vfloat16mf4_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool64_t test_vmfne_vf_f16mf4_b64(vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vs2, rs1, vl);
 }
 
@@ -20,8 +19,7 @@ vbool32_t test_vmfne_vv_f16mf2_b32(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
   return __riscv_vmfne(vs2, vs1, vl);
 }
 
-vbool32_t test_vmfne_vf_f16mf2_b32(vfloat16mf2_t vs2, float16_t rs1,
-                                   size_t vl) {
+vbool32_t test_vmfne_vf_f16mf2_b32(vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vs2, rs1, vl);
 }
 
@@ -30,7 +28,7 @@ vbool16_t test_vmfne_vv_f16m1_b16(vfloat16m1_t vs2, vfloat16m1_t vs1,
   return __riscv_vmfne(vs2, vs1, vl);
 }
 
-vbool16_t test_vmfne_vf_f16m1_b16(vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfne_vf_f16m1_b16(vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vs2, rs1, vl);
 }
 
@@ -38,7 +36,7 @@ vbool8_t test_vmfne_vv_f16m2_b8(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl) {
   return __riscv_vmfne(vs2, vs1, vl);
 }
 
-vbool8_t test_vmfne_vf_f16m2_b8(vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfne_vf_f16m2_b8(vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vs2, rs1, vl);
 }
 
@@ -46,7 +44,7 @@ vbool4_t test_vmfne_vv_f16m4_b4(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl) {
   return __riscv_vmfne(vs2, vs1, vl);
 }
 
-vbool4_t test_vmfne_vf_f16m4_b4(vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfne_vf_f16m4_b4(vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vs2, rs1, vl);
 }
 
@@ -54,7 +52,7 @@ vbool2_t test_vmfne_vv_f16m8_b2(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl) {
   return __riscv_vmfne(vs2, vs1, vl);
 }
 
-vbool2_t test_vmfne_vf_f16m8_b2(vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfne_vf_f16m8_b2(vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vs2, rs1, vl);
 }
 
@@ -143,7 +141,7 @@ vbool64_t test_vmfne_vv_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
 }
 
 vbool64_t test_vmfne_vf_f16mf4_b64_m(vbool64_t vm, vfloat16mf4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vm, vs2, rs1, vl);
 }
 
@@ -153,7 +151,7 @@ vbool32_t test_vmfne_vv_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
 }
 
 vbool32_t test_vmfne_vf_f16mf2_b32_m(vbool32_t vm, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vm, vs2, rs1, vl);
 }
 
@@ -163,7 +161,7 @@ vbool16_t test_vmfne_vv_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
 }
 
 vbool16_t test_vmfne_vf_f16m1_b16_m(vbool16_t vm, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vmfne(vm, vs2, rs1, vl);
 }
 
@@ -172,7 +170,7 @@ vbool8_t test_vmfne_vv_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2,
   return __riscv_vmfne(vm, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfne_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vbool8_t test_vmfne_vf_f16m2_b8_m(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfne(vm, vs2, rs1, vl);
 }
@@ -182,7 +180,7 @@ vbool4_t test_vmfne_vv_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2,
   return __riscv_vmfne(vm, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfne_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vbool4_t test_vmfne_vf_f16m4_b4_m(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfne(vm, vs2, rs1, vl);
 }
@@ -192,7 +190,7 @@ vbool2_t test_vmfne_vv_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2,
   return __riscv_vmfne(vm, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfne_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vbool2_t test_vmfne_vf_f16m8_b2_m(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                   size_t vl) {
   return __riscv_vmfne(vm, vs2, rs1, vl);
 }

--- a/auto-generated/overloaded_intrinsic_funcs.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs.adoc
@@ -30848,17 +30848,17 @@ vuint32m4_t __riscv_vnclipu(vbool8_t vm, vuint64m8_t vs2, size_t rs1,
 [,c]
 ----
 vfloat16mf4_t __riscv_vfadd(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfadd(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfadd(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfadd(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfadd(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfadd(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfadd(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfadd(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfadd(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfadd(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfadd(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfadd(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfadd(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfadd(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfadd(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfadd(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfadd(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfadd(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfadd(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfadd(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfadd(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -30878,17 +30878,17 @@ vfloat64m4_t __riscv_vfadd(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfadd(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vfloat64m8_t __riscv_vfadd(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfsub(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfsub(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfsub(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsub(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfsub(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfsub(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsub(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfsub(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfsub(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsub(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfsub(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfsub(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsub(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfsub(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfsub(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsub(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfsub(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfsub(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsub(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsub(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfsub(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -30907,12 +30907,12 @@ vfloat64m4_t __riscv_vfsub(vfloat64m4_t vs2, vfloat64m4_t vs1, size_t vl);
 vfloat64m4_t __riscv_vfsub(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfsub(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vfloat64m8_t __riscv_vfsub(vfloat64m8_t vs2, float64_t rs1, size_t vl);
-vfloat16mf4_t __riscv_vfrsub(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
-vfloat16mf2_t __riscv_vfrsub(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
-vfloat16m1_t __riscv_vfrsub(vfloat16m1_t vs2, float16_t rs1, size_t vl);
-vfloat16m2_t __riscv_vfrsub(vfloat16m2_t vs2, float16_t rs1, size_t vl);
-vfloat16m4_t __riscv_vfrsub(vfloat16m4_t vs2, float16_t rs1, size_t vl);
-vfloat16m8_t __riscv_vfrsub(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfrsub(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
+vfloat16mf2_t __riscv_vfrsub(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m1_t __riscv_vfrsub(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
+vfloat16m2_t __riscv_vfrsub(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m4_t __riscv_vfrsub(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
+vfloat16m8_t __riscv_vfrsub(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrsub(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfrsub(vfloat32m1_t vs2, float32_t rs1, size_t vl);
 vfloat32m2_t __riscv_vfrsub(vfloat32m2_t vs2, float32_t rs1, size_t vl);
@@ -30940,27 +30940,27 @@ vfloat64m8_t __riscv_vfneg(vfloat64m8_t vs, size_t vl);
 // masked functions
 vfloat16mf4_t __riscv_vfadd(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             size_t vl);
-vfloat16mf4_t __riscv_vfadd(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfadd(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16mf2_t __riscv_vfadd(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             size_t vl);
-vfloat16mf2_t __riscv_vfadd(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfadd(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16m1_t __riscv_vfadd(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            size_t vl);
-vfloat16m1_t __riscv_vfadd(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfadd(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m2_t __riscv_vfadd(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            size_t vl);
-vfloat16m2_t __riscv_vfadd(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfadd(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m4_t __riscv_vfadd(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            size_t vl);
-vfloat16m4_t __riscv_vfadd(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfadd(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m8_t __riscv_vfadd(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            size_t vl);
-vfloat16m8_t __riscv_vfadd(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfadd(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat32mf2_t __riscv_vfadd(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             size_t vl);
@@ -31000,27 +31000,27 @@ vfloat64m8_t __riscv_vfadd(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                            size_t vl);
 vfloat16mf4_t __riscv_vfsub(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             size_t vl);
-vfloat16mf4_t __riscv_vfsub(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsub(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16mf2_t __riscv_vfsub(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             size_t vl);
-vfloat16mf2_t __riscv_vfsub(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsub(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16m1_t __riscv_vfsub(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            size_t vl);
-vfloat16m1_t __riscv_vfsub(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfsub(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m2_t __riscv_vfsub(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            size_t vl);
-vfloat16m2_t __riscv_vfsub(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfsub(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m4_t __riscv_vfsub(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            size_t vl);
-vfloat16m4_t __riscv_vfsub(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfsub(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m8_t __riscv_vfsub(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            size_t vl);
-vfloat16m8_t __riscv_vfsub(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfsub(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat32mf2_t __riscv_vfsub(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             size_t vl);
@@ -31058,17 +31058,17 @@ vfloat64m8_t __riscv_vfsub(vbool8_t vm, vfloat64m8_t vs2, vfloat64m8_t vs1,
                            size_t vl);
 vfloat64m8_t __riscv_vfsub(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                            size_t vl);
-vfloat16mf4_t __riscv_vfrsub(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfrsub(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                              size_t vl);
-vfloat16mf2_t __riscv_vfrsub(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfrsub(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                              size_t vl);
-vfloat16m1_t __riscv_vfrsub(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfrsub(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                             size_t vl);
-vfloat16m2_t __riscv_vfrsub(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfrsub(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                             size_t vl);
-vfloat16m4_t __riscv_vfrsub(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfrsub(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                             size_t vl);
-vfloat16m8_t __riscv_vfrsub(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfrsub(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat32mf2_t __riscv_vfrsub(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
                              size_t vl);
@@ -31105,27 +31105,27 @@ vfloat64m4_t __riscv_vfneg(vbool16_t vm, vfloat64m4_t vs, size_t vl);
 vfloat64m8_t __riscv_vfneg(vbool8_t vm, vfloat64m8_t vs, size_t vl);
 vfloat16mf4_t __riscv_vfadd(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfadd(vfloat16mf4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf4_t __riscv_vfadd(vfloat16mf4_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat16mf2_t __riscv_vfadd(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfadd(vfloat16mf2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf2_t __riscv_vfadd(vfloat16mf2_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat16m1_t __riscv_vfadd(vfloat16m1_t vs2, vfloat16m1_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m1_t __riscv_vfadd(vfloat16m1_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m1_t __riscv_vfadd(vfloat16m1_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m2_t __riscv_vfadd(vfloat16m2_t vs2, vfloat16m2_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m2_t __riscv_vfadd(vfloat16m2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m2_t __riscv_vfadd(vfloat16m2_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m4_t __riscv_vfadd(vfloat16m4_t vs2, vfloat16m4_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m4_t __riscv_vfadd(vfloat16m4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m4_t __riscv_vfadd(vfloat16m4_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m8_t __riscv_vfadd(vfloat16m8_t vs2, vfloat16m8_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m8_t __riscv_vfadd(vfloat16m8_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m8_t __riscv_vfadd(vfloat16m8_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat32mf2_t __riscv_vfadd(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -31165,27 +31165,27 @@ vfloat64m8_t __riscv_vfadd(vfloat64m8_t vs2, float64_t rs1, unsigned int frm,
                            size_t vl);
 vfloat16mf4_t __riscv_vfsub(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfsub(vfloat16mf4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf4_t __riscv_vfsub(vfloat16mf4_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat16mf2_t __riscv_vfsub(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfsub(vfloat16mf2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf2_t __riscv_vfsub(vfloat16mf2_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat16m1_t __riscv_vfsub(vfloat16m1_t vs2, vfloat16m1_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m1_t __riscv_vfsub(vfloat16m1_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m1_t __riscv_vfsub(vfloat16m1_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m2_t __riscv_vfsub(vfloat16m2_t vs2, vfloat16m2_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m2_t __riscv_vfsub(vfloat16m2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m2_t __riscv_vfsub(vfloat16m2_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m4_t __riscv_vfsub(vfloat16m4_t vs2, vfloat16m4_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m4_t __riscv_vfsub(vfloat16m4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m4_t __riscv_vfsub(vfloat16m4_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m8_t __riscv_vfsub(vfloat16m8_t vs2, vfloat16m8_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m8_t __riscv_vfsub(vfloat16m8_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m8_t __riscv_vfsub(vfloat16m8_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat32mf2_t __riscv_vfsub(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -31223,17 +31223,17 @@ vfloat64m8_t __riscv_vfsub(vfloat64m8_t vs2, vfloat64m8_t vs1, unsigned int frm,
                            size_t vl);
 vfloat64m8_t __riscv_vfsub(vfloat64m8_t vs2, float64_t rs1, unsigned int frm,
                            size_t vl);
-vfloat16mf4_t __riscv_vfrsub(vfloat16mf4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf4_t __riscv_vfrsub(vfloat16mf4_t vs2, _Float16 rs1, unsigned int frm,
                              size_t vl);
-vfloat16mf2_t __riscv_vfrsub(vfloat16mf2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf2_t __riscv_vfrsub(vfloat16mf2_t vs2, _Float16 rs1, unsigned int frm,
                              size_t vl);
-vfloat16m1_t __riscv_vfrsub(vfloat16m1_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m1_t __riscv_vfrsub(vfloat16m1_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
-vfloat16m2_t __riscv_vfrsub(vfloat16m2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m2_t __riscv_vfrsub(vfloat16m2_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
-vfloat16m4_t __riscv_vfrsub(vfloat16m4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m4_t __riscv_vfrsub(vfloat16m4_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
-vfloat16m8_t __riscv_vfrsub(vfloat16m8_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m8_t __riscv_vfrsub(vfloat16m8_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat32mf2_t __riscv_vfrsub(vfloat32mf2_t vs2, float32_t rs1, unsigned int frm,
                              size_t vl);
@@ -31256,27 +31256,27 @@ vfloat64m8_t __riscv_vfrsub(vfloat64m8_t vs2, float64_t rs1, unsigned int frm,
 // masked functions
 vfloat16mf4_t __riscv_vfadd(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfadd(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfadd(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfadd(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfadd(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfadd(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfadd(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfadd(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfadd(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfadd(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfadd(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfadd(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfadd(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfadd(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfadd(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfadd(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfadd(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfadd(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfadd(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -31316,27 +31316,27 @@ vfloat64m8_t __riscv_vfadd(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                            unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfsub(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfsub(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsub(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfsub(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfsub(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsub(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfsub(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfsub(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfsub(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfsub(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfsub(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfsub(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfsub(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfsub(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfsub(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfsub(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfsub(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfsub(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfsub(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -31374,17 +31374,17 @@ vfloat64m8_t __riscv_vfsub(vbool8_t vm, vfloat64m8_t vs2, vfloat64m8_t vs1,
                            unsigned int frm, size_t vl);
 vfloat64m8_t __riscv_vfsub(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                            unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfrsub(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfrsub(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                              unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfrsub(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfrsub(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                              unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfrsub(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfrsub(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfrsub(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfrsub(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfrsub(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfrsub(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfrsub(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfrsub(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrsub(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
                              unsigned int frm, size_t vl);
@@ -31413,26 +31413,26 @@ vfloat64m8_t __riscv_vfrsub(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
 ----
 vfloat32mf2_t __riscv_vfwadd_vv(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 size_t vl);
-vfloat32mf2_t __riscv_vfwadd_vf(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat32mf2_t __riscv_vfwadd_vf(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                 size_t vl);
-vfloat32mf2_t __riscv_vfwadd_wf(vfloat32mf2_t vs2, float16_t rs1, size_t vl);
+vfloat32mf2_t __riscv_vfwadd_wf(vfloat32mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat32m1_t __riscv_vfwadd_vf(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat32m1_t __riscv_vfwadd_vf(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv(vfloat32m1_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat32m1_t __riscv_vfwadd_wf(vfloat32m1_t vs2, float16_t rs1, size_t vl);
+vfloat32m1_t __riscv_vfwadd_wf(vfloat32m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat32m2_t __riscv_vfwadd_vf(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat32m2_t __riscv_vfwadd_vf(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv(vfloat32m2_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat32m2_t __riscv_vfwadd_wf(vfloat32m2_t vs2, float16_t rs1, size_t vl);
+vfloat32m2_t __riscv_vfwadd_wf(vfloat32m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat32m4_t __riscv_vfwadd_vf(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat32m4_t __riscv_vfwadd_vf(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv(vfloat32m4_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat32m4_t __riscv_vfwadd_wf(vfloat32m4_t vs2, float16_t rs1, size_t vl);
+vfloat32m4_t __riscv_vfwadd_wf(vfloat32m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat32m8_t __riscv_vfwadd_vf(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat32m8_t __riscv_vfwadd_vf(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv(vfloat32m8_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat32m8_t __riscv_vfwadd_wf(vfloat32m8_t vs2, float16_t rs1, size_t vl);
+vfloat32m8_t __riscv_vfwadd_wf(vfloat32m8_t vs2, _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vf(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat64m1_t __riscv_vfwadd_wv(vfloat64m1_t vs2, vfloat32mf2_t vs1, size_t vl);
@@ -31451,26 +31451,26 @@ vfloat64m8_t __riscv_vfwadd_wv(vfloat64m8_t vs2, vfloat32m4_t vs1, size_t vl);
 vfloat64m8_t __riscv_vfwadd_wf(vfloat64m8_t vs2, float32_t rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vv(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 size_t vl);
-vfloat32mf2_t __riscv_vfwsub_vf(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat32mf2_t __riscv_vfwsub_vf(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                 size_t vl);
-vfloat32mf2_t __riscv_vfwsub_wf(vfloat32mf2_t vs2, float16_t rs1, size_t vl);
+vfloat32mf2_t __riscv_vfwsub_wf(vfloat32mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat32m1_t __riscv_vfwsub_vf(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat32m1_t __riscv_vfwsub_vf(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv(vfloat32m1_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat32m1_t __riscv_vfwsub_wf(vfloat32m1_t vs2, float16_t rs1, size_t vl);
+vfloat32m1_t __riscv_vfwsub_wf(vfloat32m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat32m2_t __riscv_vfwsub_vf(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat32m2_t __riscv_vfwsub_vf(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv(vfloat32m2_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat32m2_t __riscv_vfwsub_wf(vfloat32m2_t vs2, float16_t rs1, size_t vl);
+vfloat32m2_t __riscv_vfwsub_wf(vfloat32m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat32m4_t __riscv_vfwsub_vf(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat32m4_t __riscv_vfwsub_vf(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv(vfloat32m4_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat32m4_t __riscv_vfwsub_wf(vfloat32m4_t vs2, float16_t rs1, size_t vl);
+vfloat32m4_t __riscv_vfwsub_wf(vfloat32m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat32m8_t __riscv_vfwsub_vf(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat32m8_t __riscv_vfwsub_vf(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv(vfloat32m8_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat32m8_t __riscv_vfwsub_wf(vfloat32m8_t vs2, float16_t rs1, size_t vl);
+vfloat32m8_t __riscv_vfwsub_wf(vfloat32m8_t vs2, _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vf(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat64m1_t __riscv_vfwsub_wv(vfloat64m1_t vs2, vfloat32mf2_t vs1, size_t vl);
@@ -31490,43 +31490,43 @@ vfloat64m8_t __riscv_vfwsub_wf(vfloat64m8_t vs2, float32_t rs1, size_t vl);
 // masked functions
 vfloat32mf2_t __riscv_vfwadd_vv(vbool64_t vm, vfloat16mf4_t vs2,
                                 vfloat16mf4_t vs1, size_t vl);
-vfloat32mf2_t __riscv_vfwadd_vf(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_vf(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                                 size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv(vbool64_t vm, vfloat32mf2_t vs2,
                                 vfloat16mf4_t vs1, size_t vl);
-vfloat32mf2_t __riscv_vfwadd_wf(vbool64_t vm, vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_wf(vbool64_t vm, vfloat32mf2_t vs2, _Float16 rs1,
                                 size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv(vbool32_t vm, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, size_t vl);
-vfloat32m1_t __riscv_vfwadd_vf(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwadd_vf(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv(vbool32_t vm, vfloat32m1_t vs2,
                                vfloat16mf2_t vs1, size_t vl);
-vfloat32m1_t __riscv_vfwadd_wf(vbool32_t vm, vfloat32m1_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwadd_wf(vbool32_t vm, vfloat32m1_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                                size_t vl);
-vfloat32m2_t __riscv_vfwadd_vf(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwadd_vf(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv(vbool16_t vm, vfloat32m2_t vs2, vfloat16m1_t vs1,
                                size_t vl);
-vfloat32m2_t __riscv_vfwadd_wf(vbool16_t vm, vfloat32m2_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwadd_wf(vbool16_t vm, vfloat32m2_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                                size_t vl);
-vfloat32m4_t __riscv_vfwadd_vf(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwadd_vf(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv(vbool8_t vm, vfloat32m4_t vs2, vfloat16m2_t vs1,
                                size_t vl);
-vfloat32m4_t __riscv_vfwadd_wf(vbool8_t vm, vfloat32m4_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwadd_wf(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                                size_t vl);
-vfloat32m8_t __riscv_vfwadd_vf(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwadd_vf(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv(vbool4_t vm, vfloat32m8_t vs2, vfloat16m4_t vs1,
                                size_t vl);
-vfloat32m8_t __riscv_vfwadd_wf(vbool4_t vm, vfloat32m8_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwadd_wf(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv(vbool64_t vm, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, size_t vl);
@@ -31562,43 +31562,43 @@ vfloat64m8_t __riscv_vfwadd_wf(vbool8_t vm, vfloat64m8_t vs2, float32_t rs1,
                                size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vv(vbool64_t vm, vfloat16mf4_t vs2,
                                 vfloat16mf4_t vs1, size_t vl);
-vfloat32mf2_t __riscv_vfwsub_vf(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_vf(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                                 size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv(vbool64_t vm, vfloat32mf2_t vs2,
                                 vfloat16mf4_t vs1, size_t vl);
-vfloat32mf2_t __riscv_vfwsub_wf(vbool64_t vm, vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_wf(vbool64_t vm, vfloat32mf2_t vs2, _Float16 rs1,
                                 size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv(vbool32_t vm, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, size_t vl);
-vfloat32m1_t __riscv_vfwsub_vf(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwsub_vf(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv(vbool32_t vm, vfloat32m1_t vs2,
                                vfloat16mf2_t vs1, size_t vl);
-vfloat32m1_t __riscv_vfwsub_wf(vbool32_t vm, vfloat32m1_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwsub_wf(vbool32_t vm, vfloat32m1_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                                size_t vl);
-vfloat32m2_t __riscv_vfwsub_vf(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwsub_vf(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv(vbool16_t vm, vfloat32m2_t vs2, vfloat16m1_t vs1,
                                size_t vl);
-vfloat32m2_t __riscv_vfwsub_wf(vbool16_t vm, vfloat32m2_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwsub_wf(vbool16_t vm, vfloat32m2_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                                size_t vl);
-vfloat32m4_t __riscv_vfwsub_vf(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwsub_vf(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv(vbool8_t vm, vfloat32m4_t vs2, vfloat16m2_t vs1,
                                size_t vl);
-vfloat32m4_t __riscv_vfwsub_wf(vbool8_t vm, vfloat32m4_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwsub_wf(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                                size_t vl);
-vfloat32m8_t __riscv_vfwsub_vf(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwsub_vf(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv(vbool4_t vm, vfloat32m8_t vs2, vfloat16m4_t vs1,
                                size_t vl);
-vfloat32m8_t __riscv_vfwsub_wf(vbool4_t vm, vfloat32m8_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwsub_wf(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv(vbool64_t vm, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, size_t vl);
@@ -31634,44 +31634,44 @@ vfloat64m8_t __riscv_vfwsub_wf(vbool8_t vm, vfloat64m8_t vs2, float32_t rs1,
                                size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vv(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwadd_vf(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_vf(vfloat16mf4_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                 unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwadd_wf(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_wf(vfloat32mf2_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwadd_vf(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwadd_vf(vfloat16mf2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv(vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwadd_wf(vfloat32m1_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m1_t __riscv_vfwadd_wf(vfloat32m1_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwadd_vf(vfloat16m1_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfwadd_vf(vfloat16m1_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv(vfloat32m2_t vs2, vfloat16m1_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwadd_wf(vfloat32m2_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfwadd_wf(vfloat32m2_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwadd_vf(vfloat16m2_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfwadd_vf(vfloat16m2_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv(vfloat32m4_t vs2, vfloat16m2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwadd_wf(vfloat32m4_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfwadd_wf(vfloat32m4_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwadd_vf(vfloat16m4_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m8_t __riscv_vfwadd_vf(vfloat16m4_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv(vfloat32m8_t vs2, vfloat16m4_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwadd_wf(vfloat32m8_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m8_t __riscv_vfwadd_wf(vfloat32m8_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vf(vfloat32mf2_t vs2, float32_t rs1,
@@ -31706,44 +31706,44 @@ vfloat64m8_t __riscv_vfwadd_wf(vfloat64m8_t vs2, float32_t rs1,
                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vv(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwsub_vf(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_vf(vfloat16mf4_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                 unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwsub_wf(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_wf(vfloat32mf2_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwsub_vf(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwsub_vf(vfloat16mf2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv(vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwsub_wf(vfloat32m1_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m1_t __riscv_vfwsub_wf(vfloat32m1_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwsub_vf(vfloat16m1_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfwsub_vf(vfloat16m1_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv(vfloat32m2_t vs2, vfloat16m1_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwsub_wf(vfloat32m2_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfwsub_wf(vfloat32m2_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwsub_vf(vfloat16m2_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfwsub_vf(vfloat16m2_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv(vfloat32m4_t vs2, vfloat16m2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwsub_wf(vfloat32m4_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfwsub_wf(vfloat32m4_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwsub_vf(vfloat16m4_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m8_t __riscv_vfwsub_vf(vfloat16m4_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv(vfloat32m8_t vs2, vfloat16m4_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwsub_wf(vfloat32m8_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m8_t __riscv_vfwsub_wf(vfloat32m8_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vf(vfloat32mf2_t vs2, float32_t rs1,
@@ -31779,43 +31779,43 @@ vfloat64m8_t __riscv_vfwsub_wf(vfloat64m8_t vs2, float32_t rs1,
 // masked functions
 vfloat32mf2_t __riscv_vfwadd_vv(vbool64_t vm, vfloat16mf4_t vs2,
                                 vfloat16mf4_t vs1, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwadd_vf(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_vf(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv(vbool64_t vm, vfloat32mf2_t vs2,
                                 vfloat16mf4_t vs1, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwadd_wf(vbool64_t vm, vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_wf(vbool64_t vm, vfloat32mf2_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv(vbool32_t vm, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwadd_vf(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwadd_vf(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv(vbool32_t vm, vfloat32m1_t vs2,
                                vfloat16mf2_t vs1, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwadd_wf(vbool32_t vm, vfloat32m1_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwadd_wf(vbool32_t vm, vfloat32m1_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwadd_vf(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwadd_vf(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv(vbool16_t vm, vfloat32m2_t vs2, vfloat16m1_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwadd_wf(vbool16_t vm, vfloat32m2_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwadd_wf(vbool16_t vm, vfloat32m2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwadd_vf(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwadd_vf(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv(vbool8_t vm, vfloat32m4_t vs2, vfloat16m2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwadd_wf(vbool8_t vm, vfloat32m4_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwadd_wf(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwadd_vf(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwadd_vf(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv(vbool4_t vm, vfloat32m8_t vs2, vfloat16m4_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwadd_wf(vbool4_t vm, vfloat32m8_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwadd_wf(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv(vbool64_t vm, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, unsigned int frm, size_t vl);
@@ -31851,43 +31851,43 @@ vfloat64m8_t __riscv_vfwadd_wf(vbool8_t vm, vfloat64m8_t vs2, float32_t rs1,
                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vv(vbool64_t vm, vfloat16mf4_t vs2,
                                 vfloat16mf4_t vs1, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwsub_vf(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_vf(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv(vbool64_t vm, vfloat32mf2_t vs2,
                                 vfloat16mf4_t vs1, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwsub_wf(vbool64_t vm, vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_wf(vbool64_t vm, vfloat32mf2_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv(vbool32_t vm, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwsub_vf(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwsub_vf(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv(vbool32_t vm, vfloat32m1_t vs2,
                                vfloat16mf2_t vs1, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwsub_wf(vbool32_t vm, vfloat32m1_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwsub_wf(vbool32_t vm, vfloat32m1_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwsub_vf(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwsub_vf(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv(vbool16_t vm, vfloat32m2_t vs2, vfloat16m1_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwsub_wf(vbool16_t vm, vfloat32m2_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwsub_wf(vbool16_t vm, vfloat32m2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwsub_vf(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwsub_vf(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv(vbool8_t vm, vfloat32m4_t vs2, vfloat16m2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwsub_wf(vbool8_t vm, vfloat32m4_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwsub_wf(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwsub_vf(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwsub_vf(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv(vbool4_t vm, vfloat32m8_t vs2, vfloat16m4_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwsub_wf(vbool4_t vm, vfloat32m8_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwsub_wf(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv(vbool64_t vm, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, unsigned int frm, size_t vl);
@@ -31929,17 +31929,17 @@ vfloat64m8_t __riscv_vfwsub_wf(vbool8_t vm, vfloat64m8_t vs2, float32_t rs1,
 [,c]
 ----
 vfloat16mf4_t __riscv_vfmul(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfmul(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfmul(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmul(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfmul(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfmul(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmul(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfmul(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfmul(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmul(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfmul(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfmul(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmul(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfmul(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfmul(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmul(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfmul(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfmul(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmul(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmul(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfmul(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -31959,17 +31959,17 @@ vfloat64m4_t __riscv_vfmul(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfmul(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vfloat64m8_t __riscv_vfmul(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfdiv(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfdiv(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfdiv(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfdiv(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfdiv(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfdiv(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfdiv(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfdiv(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfdiv(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfdiv(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfdiv(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfdiv(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfdiv(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfdiv(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfdiv(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfdiv(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfdiv(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfdiv(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfdiv(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfdiv(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfdiv(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -31988,12 +31988,12 @@ vfloat64m4_t __riscv_vfdiv(vfloat64m4_t vs2, vfloat64m4_t vs1, size_t vl);
 vfloat64m4_t __riscv_vfdiv(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfdiv(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vfloat64m8_t __riscv_vfdiv(vfloat64m8_t vs2, float64_t rs1, size_t vl);
-vfloat16mf4_t __riscv_vfrdiv(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
-vfloat16mf2_t __riscv_vfrdiv(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
-vfloat16m1_t __riscv_vfrdiv(vfloat16m1_t vs2, float16_t rs1, size_t vl);
-vfloat16m2_t __riscv_vfrdiv(vfloat16m2_t vs2, float16_t rs1, size_t vl);
-vfloat16m4_t __riscv_vfrdiv(vfloat16m4_t vs2, float16_t rs1, size_t vl);
-vfloat16m8_t __riscv_vfrdiv(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfrdiv(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
+vfloat16mf2_t __riscv_vfrdiv(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m1_t __riscv_vfrdiv(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
+vfloat16m2_t __riscv_vfrdiv(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m4_t __riscv_vfrdiv(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
+vfloat16m8_t __riscv_vfrdiv(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfrdiv(vfloat32m1_t vs2, float32_t rs1, size_t vl);
 vfloat32m2_t __riscv_vfrdiv(vfloat32m2_t vs2, float32_t rs1, size_t vl);
@@ -32006,27 +32006,27 @@ vfloat64m8_t __riscv_vfrdiv(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 // masked functions
 vfloat16mf4_t __riscv_vfmul(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             size_t vl);
-vfloat16mf4_t __riscv_vfmul(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfmul(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16mf2_t __riscv_vfmul(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             size_t vl);
-vfloat16mf2_t __riscv_vfmul(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfmul(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16m1_t __riscv_vfmul(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            size_t vl);
-vfloat16m1_t __riscv_vfmul(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfmul(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m2_t __riscv_vfmul(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            size_t vl);
-vfloat16m2_t __riscv_vfmul(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfmul(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m4_t __riscv_vfmul(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            size_t vl);
-vfloat16m4_t __riscv_vfmul(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfmul(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m8_t __riscv_vfmul(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            size_t vl);
-vfloat16m8_t __riscv_vfmul(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfmul(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat32mf2_t __riscv_vfmul(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             size_t vl);
@@ -32066,27 +32066,27 @@ vfloat64m8_t __riscv_vfmul(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                            size_t vl);
 vfloat16mf4_t __riscv_vfdiv(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             size_t vl);
-vfloat16mf4_t __riscv_vfdiv(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfdiv(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16mf2_t __riscv_vfdiv(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             size_t vl);
-vfloat16mf2_t __riscv_vfdiv(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfdiv(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16m1_t __riscv_vfdiv(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            size_t vl);
-vfloat16m1_t __riscv_vfdiv(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfdiv(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m2_t __riscv_vfdiv(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            size_t vl);
-vfloat16m2_t __riscv_vfdiv(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfdiv(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m4_t __riscv_vfdiv(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            size_t vl);
-vfloat16m4_t __riscv_vfdiv(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfdiv(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m8_t __riscv_vfdiv(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            size_t vl);
-vfloat16m8_t __riscv_vfdiv(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfdiv(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat32mf2_t __riscv_vfdiv(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             size_t vl);
@@ -32124,17 +32124,17 @@ vfloat64m8_t __riscv_vfdiv(vbool8_t vm, vfloat64m8_t vs2, vfloat64m8_t vs1,
                            size_t vl);
 vfloat64m8_t __riscv_vfdiv(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                            size_t vl);
-vfloat16mf4_t __riscv_vfrdiv(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfrdiv(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                              size_t vl);
-vfloat16mf2_t __riscv_vfrdiv(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfrdiv(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                              size_t vl);
-vfloat16m1_t __riscv_vfrdiv(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfrdiv(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                             size_t vl);
-vfloat16m2_t __riscv_vfrdiv(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfrdiv(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                             size_t vl);
-vfloat16m4_t __riscv_vfrdiv(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfrdiv(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                             size_t vl);
-vfloat16m8_t __riscv_vfrdiv(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfrdiv(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat32mf2_t __riscv_vfrdiv(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
                              size_t vl);
@@ -32156,27 +32156,27 @@ vfloat64m8_t __riscv_vfrdiv(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                             size_t vl);
 vfloat16mf4_t __riscv_vfmul(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmul(vfloat16mf4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf4_t __riscv_vfmul(vfloat16mf4_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat16mf2_t __riscv_vfmul(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmul(vfloat16mf2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf2_t __riscv_vfmul(vfloat16mf2_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat16m1_t __riscv_vfmul(vfloat16m1_t vs2, vfloat16m1_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m1_t __riscv_vfmul(vfloat16m1_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m1_t __riscv_vfmul(vfloat16m1_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m2_t __riscv_vfmul(vfloat16m2_t vs2, vfloat16m2_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m2_t __riscv_vfmul(vfloat16m2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m2_t __riscv_vfmul(vfloat16m2_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m4_t __riscv_vfmul(vfloat16m4_t vs2, vfloat16m4_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m4_t __riscv_vfmul(vfloat16m4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m4_t __riscv_vfmul(vfloat16m4_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m8_t __riscv_vfmul(vfloat16m8_t vs2, vfloat16m8_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m8_t __riscv_vfmul(vfloat16m8_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m8_t __riscv_vfmul(vfloat16m8_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat32mf2_t __riscv_vfmul(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -32216,27 +32216,27 @@ vfloat64m8_t __riscv_vfmul(vfloat64m8_t vs2, float64_t rs1, unsigned int frm,
                            size_t vl);
 vfloat16mf4_t __riscv_vfdiv(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfdiv(vfloat16mf4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf4_t __riscv_vfdiv(vfloat16mf4_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat16mf2_t __riscv_vfdiv(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfdiv(vfloat16mf2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf2_t __riscv_vfdiv(vfloat16mf2_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat16m1_t __riscv_vfdiv(vfloat16m1_t vs2, vfloat16m1_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m1_t __riscv_vfdiv(vfloat16m1_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m1_t __riscv_vfdiv(vfloat16m1_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m2_t __riscv_vfdiv(vfloat16m2_t vs2, vfloat16m2_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m2_t __riscv_vfdiv(vfloat16m2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m2_t __riscv_vfdiv(vfloat16m2_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m4_t __riscv_vfdiv(vfloat16m4_t vs2, vfloat16m4_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m4_t __riscv_vfdiv(vfloat16m4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m4_t __riscv_vfdiv(vfloat16m4_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m8_t __riscv_vfdiv(vfloat16m8_t vs2, vfloat16m8_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m8_t __riscv_vfdiv(vfloat16m8_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m8_t __riscv_vfdiv(vfloat16m8_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat32mf2_t __riscv_vfdiv(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -32274,17 +32274,17 @@ vfloat64m8_t __riscv_vfdiv(vfloat64m8_t vs2, vfloat64m8_t vs1, unsigned int frm,
                            size_t vl);
 vfloat64m8_t __riscv_vfdiv(vfloat64m8_t vs2, float64_t rs1, unsigned int frm,
                            size_t vl);
-vfloat16mf4_t __riscv_vfrdiv(vfloat16mf4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf4_t __riscv_vfrdiv(vfloat16mf4_t vs2, _Float16 rs1, unsigned int frm,
                              size_t vl);
-vfloat16mf2_t __riscv_vfrdiv(vfloat16mf2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf2_t __riscv_vfrdiv(vfloat16mf2_t vs2, _Float16 rs1, unsigned int frm,
                              size_t vl);
-vfloat16m1_t __riscv_vfrdiv(vfloat16m1_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m1_t __riscv_vfrdiv(vfloat16m1_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
-vfloat16m2_t __riscv_vfrdiv(vfloat16m2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m2_t __riscv_vfrdiv(vfloat16m2_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
-vfloat16m4_t __riscv_vfrdiv(vfloat16m4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m4_t __riscv_vfrdiv(vfloat16m4_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
-vfloat16m8_t __riscv_vfrdiv(vfloat16m8_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m8_t __riscv_vfrdiv(vfloat16m8_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat32mf2_t __riscv_vfrdiv(vfloat32mf2_t vs2, float32_t rs1, unsigned int frm,
                              size_t vl);
@@ -32307,27 +32307,27 @@ vfloat64m8_t __riscv_vfrdiv(vfloat64m8_t vs2, float64_t rs1, unsigned int frm,
 // masked functions
 vfloat16mf4_t __riscv_vfmul(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmul(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfmul(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmul(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmul(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfmul(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmul(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmul(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfmul(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmul(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmul(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfmul(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmul(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmul(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfmul(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmul(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmul(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfmul(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmul(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -32367,27 +32367,27 @@ vfloat64m8_t __riscv_vfmul(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                            unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfdiv(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfdiv(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfdiv(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfdiv(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfdiv(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfdiv(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfdiv(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfdiv(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfdiv(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfdiv(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfdiv(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfdiv(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfdiv(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfdiv(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfdiv(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfdiv(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfdiv(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfdiv(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfdiv(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -32425,17 +32425,17 @@ vfloat64m8_t __riscv_vfdiv(vbool8_t vm, vfloat64m8_t vs2, vfloat64m8_t vs1,
                            unsigned int frm, size_t vl);
 vfloat64m8_t __riscv_vfdiv(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                            unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfrdiv(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfrdiv(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                              unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfrdiv(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfrdiv(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                              unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfrdiv(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfrdiv(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfrdiv(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfrdiv(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfrdiv(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfrdiv(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfrdiv(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfrdiv(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
                              unsigned int frm, size_t vl);
@@ -32463,15 +32463,15 @@ vfloat64m8_t __riscv_vfrdiv(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
 [,c]
 ----
 vfloat32mf2_t __riscv_vfwmul(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat32mf2_t __riscv_vfwmul(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat32mf2_t __riscv_vfwmul(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwmul(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat32m1_t __riscv_vfwmul(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat32m1_t __riscv_vfwmul(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwmul(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat32m2_t __riscv_vfwmul(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat32m2_t __riscv_vfwmul(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwmul(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat32m4_t __riscv_vfwmul(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat32m4_t __riscv_vfwmul(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwmul(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat32m8_t __riscv_vfwmul(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat32m8_t __riscv_vfwmul(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwmul(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat64m1_t __riscv_vfwmul(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat64m2_t __riscv_vfwmul(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -32483,23 +32483,23 @@ vfloat64m8_t __riscv_vfwmul(vfloat32m4_t vs2, float32_t rs1, size_t vl);
 // masked functions
 vfloat32mf2_t __riscv_vfwmul(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                              size_t vl);
-vfloat32mf2_t __riscv_vfwmul(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwmul(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat32m1_t __riscv_vfwmul(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             size_t vl);
-vfloat32m1_t __riscv_vfwmul(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwmul(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat32m2_t __riscv_vfwmul(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                             size_t vl);
-vfloat32m2_t __riscv_vfwmul(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwmul(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat32m4_t __riscv_vfwmul(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                             size_t vl);
-vfloat32m4_t __riscv_vfwmul(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwmul(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat32m8_t __riscv_vfwmul(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                             size_t vl);
-vfloat32m8_t __riscv_vfwmul(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwmul(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat64m1_t __riscv_vfwmul(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             size_t vl);
@@ -32519,23 +32519,23 @@ vfloat64m8_t __riscv_vfwmul(vbool8_t vm, vfloat32m4_t vs2, float32_t rs1,
                             size_t vl);
 vfloat32mf2_t __riscv_vfwmul(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                              unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmul(vfloat16mf4_t vs2, float16_t rs1, unsigned int frm,
+vfloat32mf2_t __riscv_vfwmul(vfloat16mf4_t vs2, _Float16 rs1, unsigned int frm,
                              size_t vl);
 vfloat32m1_t __riscv_vfwmul(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmul(vfloat16mf2_t vs2, float16_t rs1, unsigned int frm,
+vfloat32m1_t __riscv_vfwmul(vfloat16mf2_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat32m2_t __riscv_vfwmul(vfloat16m1_t vs2, vfloat16m1_t vs1,
                             unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmul(vfloat16m1_t vs2, float16_t rs1, unsigned int frm,
+vfloat32m2_t __riscv_vfwmul(vfloat16m1_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat32m4_t __riscv_vfwmul(vfloat16m2_t vs2, vfloat16m2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmul(vfloat16m2_t vs2, float16_t rs1, unsigned int frm,
+vfloat32m4_t __riscv_vfwmul(vfloat16m2_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat32m8_t __riscv_vfwmul(vfloat16m4_t vs2, vfloat16m4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmul(vfloat16m4_t vs2, float16_t rs1, unsigned int frm,
+vfloat32m8_t __riscv_vfwmul(vfloat16m4_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat64m1_t __riscv_vfwmul(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -32556,23 +32556,23 @@ vfloat64m8_t __riscv_vfwmul(vfloat32m4_t vs2, float32_t rs1, unsigned int frm,
 // masked functions
 vfloat32mf2_t __riscv_vfwmul(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                              unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmul(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwmul(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmul(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmul(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwmul(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmul(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                             unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmul(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwmul(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmul(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmul(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwmul(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmul(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmul(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwmul(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmul(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -32599,27 +32599,27 @@ vfloat64m8_t __riscv_vfwmul(vbool8_t vm, vfloat32m4_t vs2, float32_t rs1,
 ----
 vfloat16mf4_t __riscv_vfmacc(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmacc(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2,
+vfloat16mf4_t __riscv_vfmacc(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
                              size_t vl);
 vfloat16mf2_t __riscv_vfmacc(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmacc(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2,
+vfloat16mf2_t __riscv_vfmacc(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
                              size_t vl);
 vfloat16m1_t __riscv_vfmacc(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_t vs2,
                             size_t vl);
-vfloat16m1_t __riscv_vfmacc(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmacc(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                             size_t vl);
 vfloat16m2_t __riscv_vfmacc(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_t vs2,
                             size_t vl);
-vfloat16m2_t __riscv_vfmacc(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmacc(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                             size_t vl);
 vfloat16m4_t __riscv_vfmacc(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_t vs2,
                             size_t vl);
-vfloat16m4_t __riscv_vfmacc(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmacc(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                             size_t vl);
 vfloat16m8_t __riscv_vfmacc(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_t vs2,
                             size_t vl);
-vfloat16m8_t __riscv_vfmacc(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmacc(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                             size_t vl);
 vfloat32mf2_t __riscv_vfmacc(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -32659,27 +32659,27 @@ vfloat64m8_t __riscv_vfmacc(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                             size_t vl);
 vfloat16mf4_t __riscv_vfnmacc(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmacc(vfloat16mf4_t vd, float16_t rs1,
-                              vfloat16mf4_t vs2, size_t vl);
+vfloat16mf4_t __riscv_vfnmacc(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
+                              size_t vl);
 vfloat16mf2_t __riscv_vfnmacc(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmacc(vfloat16mf2_t vd, float16_t rs1,
-                              vfloat16mf2_t vs2, size_t vl);
+vfloat16mf2_t __riscv_vfnmacc(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
+                              size_t vl);
 vfloat16m1_t __riscv_vfnmacc(vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmacc(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfnmacc(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                              size_t vl);
 vfloat16m2_t __riscv_vfnmacc(vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmacc(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfnmacc(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                              size_t vl);
 vfloat16m4_t __riscv_vfnmacc(vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmacc(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfnmacc(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                              size_t vl);
 vfloat16m8_t __riscv_vfnmacc(vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmacc(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfnmacc(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                              size_t vl);
 vfloat32mf2_t __riscv_vfnmacc(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -32719,27 +32719,27 @@ vfloat64m8_t __riscv_vfnmacc(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                              size_t vl);
 vfloat16mf4_t __riscv_vfmsac(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmsac(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2,
+vfloat16mf4_t __riscv_vfmsac(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
                              size_t vl);
 vfloat16mf2_t __riscv_vfmsac(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmsac(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2,
+vfloat16mf2_t __riscv_vfmsac(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
                              size_t vl);
 vfloat16m1_t __riscv_vfmsac(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_t vs2,
                             size_t vl);
-vfloat16m1_t __riscv_vfmsac(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmsac(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                             size_t vl);
 vfloat16m2_t __riscv_vfmsac(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_t vs2,
                             size_t vl);
-vfloat16m2_t __riscv_vfmsac(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmsac(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                             size_t vl);
 vfloat16m4_t __riscv_vfmsac(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_t vs2,
                             size_t vl);
-vfloat16m4_t __riscv_vfmsac(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmsac(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                             size_t vl);
 vfloat16m8_t __riscv_vfmsac(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_t vs2,
                             size_t vl);
-vfloat16m8_t __riscv_vfmsac(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmsac(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                             size_t vl);
 vfloat32mf2_t __riscv_vfmsac(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -32779,27 +32779,27 @@ vfloat64m8_t __riscv_vfmsac(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                             size_t vl);
 vfloat16mf4_t __riscv_vfnmsac(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmsac(vfloat16mf4_t vd, float16_t rs1,
-                              vfloat16mf4_t vs2, size_t vl);
+vfloat16mf4_t __riscv_vfnmsac(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
+                              size_t vl);
 vfloat16mf2_t __riscv_vfnmsac(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmsac(vfloat16mf2_t vd, float16_t rs1,
-                              vfloat16mf2_t vs2, size_t vl);
+vfloat16mf2_t __riscv_vfnmsac(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
+                              size_t vl);
 vfloat16m1_t __riscv_vfnmsac(vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsac(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfnmsac(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                              size_t vl);
 vfloat16m2_t __riscv_vfnmsac(vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsac(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfnmsac(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                              size_t vl);
 vfloat16m4_t __riscv_vfnmsac(vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsac(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfnmsac(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                              size_t vl);
 vfloat16m8_t __riscv_vfnmsac(vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsac(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfnmsac(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                              size_t vl);
 vfloat32mf2_t __riscv_vfnmsac(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -32839,27 +32839,27 @@ vfloat64m8_t __riscv_vfnmsac(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                              size_t vl);
 vfloat16mf4_t __riscv_vfmadd(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmadd(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2,
+vfloat16mf4_t __riscv_vfmadd(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
                              size_t vl);
 vfloat16mf2_t __riscv_vfmadd(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmadd(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2,
+vfloat16mf2_t __riscv_vfmadd(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
                              size_t vl);
 vfloat16m1_t __riscv_vfmadd(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_t vs2,
                             size_t vl);
-vfloat16m1_t __riscv_vfmadd(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmadd(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                             size_t vl);
 vfloat16m2_t __riscv_vfmadd(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_t vs2,
                             size_t vl);
-vfloat16m2_t __riscv_vfmadd(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmadd(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                             size_t vl);
 vfloat16m4_t __riscv_vfmadd(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_t vs2,
                             size_t vl);
-vfloat16m4_t __riscv_vfmadd(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmadd(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                             size_t vl);
 vfloat16m8_t __riscv_vfmadd(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_t vs2,
                             size_t vl);
-vfloat16m8_t __riscv_vfmadd(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmadd(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                             size_t vl);
 vfloat32mf2_t __riscv_vfmadd(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -32899,27 +32899,27 @@ vfloat64m8_t __riscv_vfmadd(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                             size_t vl);
 vfloat16mf4_t __riscv_vfnmadd(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmadd(vfloat16mf4_t vd, float16_t rs1,
-                              vfloat16mf4_t vs2, size_t vl);
+vfloat16mf4_t __riscv_vfnmadd(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
+                              size_t vl);
 vfloat16mf2_t __riscv_vfnmadd(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmadd(vfloat16mf2_t vd, float16_t rs1,
-                              vfloat16mf2_t vs2, size_t vl);
+vfloat16mf2_t __riscv_vfnmadd(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
+                              size_t vl);
 vfloat16m1_t __riscv_vfnmadd(vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmadd(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfnmadd(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                              size_t vl);
 vfloat16m2_t __riscv_vfnmadd(vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmadd(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfnmadd(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                              size_t vl);
 vfloat16m4_t __riscv_vfnmadd(vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmadd(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfnmadd(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                              size_t vl);
 vfloat16m8_t __riscv_vfnmadd(vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmadd(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfnmadd(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                              size_t vl);
 vfloat32mf2_t __riscv_vfnmadd(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -32959,27 +32959,27 @@ vfloat64m8_t __riscv_vfnmadd(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                              size_t vl);
 vfloat16mf4_t __riscv_vfmsub(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmsub(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2,
+vfloat16mf4_t __riscv_vfmsub(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
                              size_t vl);
 vfloat16mf2_t __riscv_vfmsub(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmsub(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2,
+vfloat16mf2_t __riscv_vfmsub(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
                              size_t vl);
 vfloat16m1_t __riscv_vfmsub(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_t vs2,
                             size_t vl);
-vfloat16m1_t __riscv_vfmsub(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmsub(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                             size_t vl);
 vfloat16m2_t __riscv_vfmsub(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_t vs2,
                             size_t vl);
-vfloat16m2_t __riscv_vfmsub(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmsub(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                             size_t vl);
 vfloat16m4_t __riscv_vfmsub(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_t vs2,
                             size_t vl);
-vfloat16m4_t __riscv_vfmsub(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmsub(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                             size_t vl);
 vfloat16m8_t __riscv_vfmsub(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_t vs2,
                             size_t vl);
-vfloat16m8_t __riscv_vfmsub(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmsub(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                             size_t vl);
 vfloat32mf2_t __riscv_vfmsub(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -33019,27 +33019,27 @@ vfloat64m8_t __riscv_vfmsub(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                             size_t vl);
 vfloat16mf4_t __riscv_vfnmsub(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmsub(vfloat16mf4_t vd, float16_t rs1,
-                              vfloat16mf4_t vs2, size_t vl);
+vfloat16mf4_t __riscv_vfnmsub(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
+                              size_t vl);
 vfloat16mf2_t __riscv_vfnmsub(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmsub(vfloat16mf2_t vd, float16_t rs1,
-                              vfloat16mf2_t vs2, size_t vl);
+vfloat16mf2_t __riscv_vfnmsub(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
+                              size_t vl);
 vfloat16m1_t __riscv_vfnmsub(vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsub(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfnmsub(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                              size_t vl);
 vfloat16m2_t __riscv_vfnmsub(vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsub(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfnmsub(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                              size_t vl);
 vfloat16m4_t __riscv_vfnmsub(vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsub(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfnmsub(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                              size_t vl);
 vfloat16m8_t __riscv_vfnmsub(vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsub(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfnmsub(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                              size_t vl);
 vfloat32mf2_t __riscv_vfnmsub(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -33080,27 +33080,27 @@ vfloat64m8_t __riscv_vfnmsub(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
 // masked functions
 vfloat16mf4_t __riscv_vfmacc(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmacc(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmacc(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                              vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmacc(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmacc(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmacc(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                              vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmacc(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                             vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmacc(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmacc(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                             vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmacc(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                             vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmacc(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmacc(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                             vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmacc(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                             vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmacc(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmacc(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                             vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmacc(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                             vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmacc(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmacc(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                             vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmacc(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -33140,27 +33140,27 @@ vfloat64m8_t __riscv_vfmacc(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                             vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmacc(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmacc(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmacc(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                               vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmacc(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmacc(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                               vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmacc(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmacc(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmacc(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                              vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmacc(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmacc(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmacc(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                              vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmacc(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmacc(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmacc(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                              vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmacc(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmacc(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmacc(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                              vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -33200,27 +33200,27 @@ vfloat64m8_t __riscv_vfnmacc(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                              vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmsac(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmsac(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsac(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                              vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsac(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmsac(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsac(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                              vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmsac(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                             vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmsac(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsac(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                             vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmsac(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                             vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmsac(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsac(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                             vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmsac(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                             vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmsac(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsac(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                             vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmsac(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                             vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmsac(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsac(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                             vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmsac(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -33260,27 +33260,27 @@ vfloat64m8_t __riscv_vfmsac(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                             vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmsac(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmsac(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsac(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                               vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmsac(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsac(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                               vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmsac(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsac(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsac(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                              vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmsac(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsac(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsac(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                              vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmsac(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsac(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsac(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                              vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmsac(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsac(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsac(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                              vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -33320,27 +33320,27 @@ vfloat64m8_t __riscv_vfnmsac(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                              vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmadd(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmadd(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmadd(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                              vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmadd(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmadd(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmadd(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                              vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmadd(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                             vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmadd(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmadd(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                             vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmadd(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                             vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmadd(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmadd(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                             vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmadd(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                             vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmadd(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmadd(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                             vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmadd(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                             vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmadd(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmadd(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                             vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmadd(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -33380,27 +33380,27 @@ vfloat64m8_t __riscv_vfmadd(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                             vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmadd(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmadd(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmadd(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                               vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmadd(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmadd(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                               vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmadd(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmadd(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmadd(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                              vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmadd(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmadd(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmadd(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                              vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmadd(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmadd(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmadd(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                              vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmadd(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmadd(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmadd(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                              vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -33440,27 +33440,27 @@ vfloat64m8_t __riscv_vfnmadd(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                              vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmsub(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmsub(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsub(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                              vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsub(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmsub(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsub(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                              vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmsub(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                             vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmsub(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsub(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                             vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmsub(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                             vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmsub(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsub(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                             vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmsub(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                             vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmsub(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsub(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                             vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmsub(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                             vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmsub(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsub(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                             vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmsub(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -33500,27 +33500,27 @@ vfloat64m8_t __riscv_vfmsub(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                             vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmsub(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmsub(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsub(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                               vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmsub(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsub(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                               vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmsub(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsub(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsub(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                              vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmsub(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsub(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsub(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                              vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmsub(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsub(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsub(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                              vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmsub(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsub(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsub(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                              vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -33560,27 +33560,27 @@ vfloat64m8_t __riscv_vfnmsub(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                              vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmacc(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmacc(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2,
+vfloat16mf4_t __riscv_vfmacc(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmacc(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmacc(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2,
+vfloat16mf2_t __riscv_vfmacc(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmacc(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmacc(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmacc(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmacc(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmacc(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmacc(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmacc(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmacc(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmacc(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmacc(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmacc(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmacc(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmacc(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -33620,27 +33620,27 @@ vfloat64m8_t __riscv_vfmacc(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmacc(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmacc(vfloat16mf4_t vd, float16_t rs1,
-                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat16mf4_t __riscv_vfnmacc(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmacc(vfloat16mf2_t vd, float16_t rs1,
-                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat16mf2_t __riscv_vfnmacc(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmacc(vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmacc(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfnmacc(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmacc(vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmacc(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfnmacc(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmacc(vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmacc(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfnmacc(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmacc(vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmacc(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfnmacc(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -33680,27 +33680,27 @@ vfloat64m8_t __riscv_vfnmacc(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmsac(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmsac(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2,
+vfloat16mf4_t __riscv_vfmsac(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsac(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmsac(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2,
+vfloat16mf2_t __riscv_vfmsac(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsac(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmsac(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmsac(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsac(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmsac(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmsac(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsac(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmsac(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmsac(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsac(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmsac(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmsac(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsac(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -33740,27 +33740,27 @@ vfloat64m8_t __riscv_vfmsac(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmsac(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmsac(vfloat16mf4_t vd, float16_t rs1,
-                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat16mf4_t __riscv_vfnmsac(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmsac(vfloat16mf2_t vd, float16_t rs1,
-                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat16mf2_t __riscv_vfnmsac(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsac(vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmsac(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfnmsac(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsac(vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmsac(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfnmsac(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsac(vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmsac(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfnmsac(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsac(vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmsac(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfnmsac(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -33800,27 +33800,27 @@ vfloat64m8_t __riscv_vfnmsac(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmadd(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmadd(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2,
+vfloat16mf4_t __riscv_vfmadd(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmadd(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmadd(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2,
+vfloat16mf2_t __riscv_vfmadd(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmadd(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmadd(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmadd(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmadd(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmadd(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmadd(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmadd(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmadd(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmadd(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmadd(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmadd(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmadd(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmadd(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -33860,27 +33860,27 @@ vfloat64m8_t __riscv_vfmadd(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmadd(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmadd(vfloat16mf4_t vd, float16_t rs1,
-                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat16mf4_t __riscv_vfnmadd(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmadd(vfloat16mf2_t vd, float16_t rs1,
-                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat16mf2_t __riscv_vfnmadd(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmadd(vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmadd(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfnmadd(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmadd(vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmadd(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfnmadd(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmadd(vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmadd(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfnmadd(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmadd(vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmadd(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfnmadd(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -33920,27 +33920,27 @@ vfloat64m8_t __riscv_vfnmadd(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmsub(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmsub(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2,
+vfloat16mf4_t __riscv_vfmsub(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsub(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmsub(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2,
+vfloat16mf2_t __riscv_vfmsub(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsub(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmsub(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmsub(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsub(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmsub(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmsub(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsub(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmsub(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmsub(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsub(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmsub(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmsub(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsub(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -33980,27 +33980,27 @@ vfloat64m8_t __riscv_vfmsub(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmsub(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmsub(vfloat16mf4_t vd, float16_t rs1,
-                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat16mf4_t __riscv_vfnmsub(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmsub(vfloat16mf2_t vd, float16_t rs1,
-                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat16mf2_t __riscv_vfnmsub(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsub(vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmsub(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfnmsub(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsub(vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmsub(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfnmsub(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsub(vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmsub(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfnmsub(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsub(vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmsub(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfnmsub(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -34041,27 +34041,27 @@ vfloat64m8_t __riscv_vfnmsub(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
 // masked functions
 vfloat16mf4_t __riscv_vfmacc(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmacc(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmacc(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmacc(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmacc(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmacc(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmacc(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                             vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmacc(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmacc(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                             vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmacc(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                             vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmacc(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmacc(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                             vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmacc(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                             vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmacc(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmacc(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                             vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmacc(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                             vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmacc(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmacc(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                             vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmacc(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -34101,27 +34101,27 @@ vfloat64m8_t __riscv_vfmacc(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                             vfloat64m8_t vs2, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmacc(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmacc(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmacc(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmacc(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmacc(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmacc(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmacc(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmacc(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmacc(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmacc(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmacc(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmacc(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmacc(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmacc(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmacc(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmacc(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmacc(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -34161,27 +34161,27 @@ vfloat64m8_t __riscv_vfnmacc(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                              vfloat64m8_t vs2, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmsac(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmsac(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsac(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsac(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmsac(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsac(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsac(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                             vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmsac(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsac(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                             vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsac(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                             vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmsac(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsac(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                             vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsac(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                             vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmsac(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsac(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                             vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsac(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                             vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmsac(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsac(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                             vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsac(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -34221,27 +34221,27 @@ vfloat64m8_t __riscv_vfmsac(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                             vfloat64m8_t vs2, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmsac(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmsac(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsac(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmsac(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsac(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsac(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmsac(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsac(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsac(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmsac(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsac(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsac(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmsac(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsac(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsac(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmsac(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsac(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -34281,27 +34281,27 @@ vfloat64m8_t __riscv_vfnmsac(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                              vfloat64m8_t vs2, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmadd(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmadd(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmadd(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmadd(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmadd(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmadd(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmadd(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                             vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmadd(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmadd(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                             vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmadd(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                             vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmadd(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmadd(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                             vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmadd(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                             vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmadd(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmadd(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                             vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmadd(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                             vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmadd(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmadd(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                             vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmadd(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -34341,27 +34341,27 @@ vfloat64m8_t __riscv_vfmadd(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                             vfloat64m8_t vs2, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmadd(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmadd(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmadd(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmadd(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmadd(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmadd(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmadd(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmadd(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmadd(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmadd(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmadd(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmadd(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmadd(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmadd(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmadd(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmadd(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmadd(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -34401,27 +34401,27 @@ vfloat64m8_t __riscv_vfnmadd(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                              vfloat64m8_t vs2, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmsub(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmsub(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsub(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsub(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmsub(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsub(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsub(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                             vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmsub(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsub(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                             vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsub(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                             vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmsub(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsub(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                             vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsub(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                             vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmsub(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsub(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                             vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsub(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                             vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmsub(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsub(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                             vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsub(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -34461,27 +34461,27 @@ vfloat64m8_t __riscv_vfmsub(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                             vfloat64m8_t vs2, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmsub(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmsub(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsub(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmsub(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsub(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsub(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmsub(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsub(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsub(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmsub(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsub(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsub(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmsub(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsub(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsub(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmsub(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsub(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -34528,23 +34528,23 @@ vfloat64m8_t __riscv_vfnmsub(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 ----
 vfloat32mf2_t __riscv_vfwmacc(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwmacc(vfloat32mf2_t vd, float16_t vs1,
-                              vfloat16mf4_t vs2, size_t vl);
+vfloat32mf2_t __riscv_vfwmacc(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2,
+                              size_t vl);
 vfloat32m1_t __riscv_vfwmacc(vfloat32m1_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwmacc(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2,
+vfloat32m1_t __riscv_vfwmacc(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2,
                              size_t vl);
 vfloat32m2_t __riscv_vfwmacc(vfloat32m2_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmacc(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2,
+vfloat32m2_t __riscv_vfwmacc(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
                              size_t vl);
 vfloat32m4_t __riscv_vfwmacc(vfloat32m4_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmacc(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2,
+vfloat32m4_t __riscv_vfwmacc(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
                              size_t vl);
 vfloat32m8_t __riscv_vfwmacc(vfloat32m8_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmacc(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2,
+vfloat32m8_t __riscv_vfwmacc(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
                              size_t vl);
 vfloat64m1_t __riscv_vfwmacc(vfloat64m1_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -34564,23 +34564,23 @@ vfloat64m8_t __riscv_vfwmacc(vfloat64m8_t vd, float32_t vs1, vfloat32m4_t vs2,
                              size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmacc(vfloat32mf2_t vd, _Float16 vs1,
                                vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc(vfloat32m1_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwnmacc(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2,
+vfloat32m1_t __riscv_vfwnmacc(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2,
                               size_t vl);
 vfloat32m2_t __riscv_vfwnmacc(vfloat32m2_t vd, vfloat16m1_t vs1,
                               vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwnmacc(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2,
+vfloat32m2_t __riscv_vfwnmacc(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
                               size_t vl);
 vfloat32m4_t __riscv_vfwnmacc(vfloat32m4_t vd, vfloat16m2_t vs1,
                               vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwnmacc(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2,
+vfloat32m4_t __riscv_vfwnmacc(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
                               size_t vl);
 vfloat32m8_t __riscv_vfwnmacc(vfloat32m8_t vd, vfloat16m4_t vs1,
                               vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwnmacc(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2,
+vfloat32m8_t __riscv_vfwnmacc(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
                               size_t vl);
 vfloat64m1_t __riscv_vfwnmacc(vfloat64m1_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -34600,23 +34600,23 @@ vfloat64m8_t __riscv_vfwnmacc(vfloat64m8_t vd, float32_t vs1, vfloat32m4_t vs2,
                               size_t vl);
 vfloat32mf2_t __riscv_vfwmsac(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwmsac(vfloat32mf2_t vd, float16_t vs1,
-                              vfloat16mf4_t vs2, size_t vl);
+vfloat32mf2_t __riscv_vfwmsac(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2,
+                              size_t vl);
 vfloat32m1_t __riscv_vfwmsac(vfloat32m1_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwmsac(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2,
+vfloat32m1_t __riscv_vfwmsac(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2,
                              size_t vl);
 vfloat32m2_t __riscv_vfwmsac(vfloat32m2_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmsac(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2,
+vfloat32m2_t __riscv_vfwmsac(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
                              size_t vl);
 vfloat32m4_t __riscv_vfwmsac(vfloat32m4_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmsac(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2,
+vfloat32m4_t __riscv_vfwmsac(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
                              size_t vl);
 vfloat32m8_t __riscv_vfwmsac(vfloat32m8_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmsac(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2,
+vfloat32m8_t __riscv_vfwmsac(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
                              size_t vl);
 vfloat64m1_t __riscv_vfwmsac(vfloat64m1_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -34636,23 +34636,23 @@ vfloat64m8_t __riscv_vfwmsac(vfloat64m8_t vd, float32_t vs1, vfloat32m4_t vs2,
                              size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmsac(vfloat32mf2_t vd, _Float16 vs1,
                                vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac(vfloat32m1_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwnmsac(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2,
+vfloat32m1_t __riscv_vfwnmsac(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2,
                               size_t vl);
 vfloat32m2_t __riscv_vfwnmsac(vfloat32m2_t vd, vfloat16m1_t vs1,
                               vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwnmsac(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2,
+vfloat32m2_t __riscv_vfwnmsac(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
                               size_t vl);
 vfloat32m4_t __riscv_vfwnmsac(vfloat32m4_t vd, vfloat16m2_t vs1,
                               vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwnmsac(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2,
+vfloat32m4_t __riscv_vfwnmsac(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
                               size_t vl);
 vfloat32m8_t __riscv_vfwnmsac(vfloat32m8_t vd, vfloat16m4_t vs1,
                               vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwnmsac(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2,
+vfloat32m8_t __riscv_vfwnmsac(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
                               size_t vl);
 vfloat64m1_t __riscv_vfwnmsac(vfloat64m1_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -34673,23 +34673,23 @@ vfloat64m8_t __riscv_vfwnmsac(vfloat64m8_t vd, float32_t vs1, vfloat32m4_t vs2,
 // masked functions
 vfloat32mf2_t __riscv_vfwmacc(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwmacc(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmacc(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                               vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwmacc(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwmacc(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmacc(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                              vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwmacc(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmacc(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmacc(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                              vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwmacc(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmacc(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmacc(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                              vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwmacc(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmacc(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmacc(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                              vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwmacc(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -34709,23 +34709,23 @@ vfloat64m8_t __riscv_vfwmacc(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
                              vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc(vbool64_t vm, vfloat32mf2_t vd,
                                vfloat16mf4_t vs1, vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmacc(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwnmacc(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmacc(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                               vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                               vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwnmacc(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmacc(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                               vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                               vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwnmacc(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmacc(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                               vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                               vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwnmacc(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmacc(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                               vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -34745,23 +34745,23 @@ vfloat64m8_t __riscv_vfwnmacc(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
                               vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwmsac(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwmsac(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmsac(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                               vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwmsac(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwmsac(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmsac(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                              vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwmsac(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmsac(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmsac(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                              vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwmsac(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmsac(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmsac(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                              vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwmsac(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmsac(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmsac(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                              vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwmsac(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -34781,23 +34781,23 @@ vfloat64m8_t __riscv_vfwmsac(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
                              vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac(vbool64_t vm, vfloat32mf2_t vd,
                                vfloat16mf4_t vs1, vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmsac(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwnmsac(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmsac(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                               vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                               vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwnmsac(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmsac(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                               vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                               vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwnmsac(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmsac(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                               vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                               vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwnmsac(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmsac(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                               vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -34817,23 +34817,23 @@ vfloat64m8_t __riscv_vfwnmsac(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
                               vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwmacc(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmacc(vfloat32mf2_t vd, float16_t vs1,
-                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat32mf2_t __riscv_vfwmacc(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmacc(vfloat32m1_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmacc(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2,
+vfloat32m1_t __riscv_vfwmacc(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmacc(vfloat32m2_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmacc(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2,
+vfloat32m2_t __riscv_vfwmacc(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmacc(vfloat32m4_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmacc(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2,
+vfloat32m4_t __riscv_vfwmacc(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmacc(vfloat32m8_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmacc(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2,
+vfloat32m8_t __riscv_vfwmacc(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmacc(vfloat64m1_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -34853,23 +34853,23 @@ vfloat64m8_t __riscv_vfwmacc(vfloat64m8_t vd, float32_t vs1, vfloat32m4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmacc(vfloat32mf2_t vd, _Float16 vs1,
                                vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc(vfloat32m1_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwnmacc(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2,
+vfloat32m1_t __riscv_vfwnmacc(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2,
                               unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc(vfloat32m2_t vd, vfloat16m1_t vs1,
                               vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwnmacc(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2,
+vfloat32m2_t __riscv_vfwnmacc(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
                               unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc(vfloat32m4_t vd, vfloat16m2_t vs1,
                               vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwnmacc(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2,
+vfloat32m4_t __riscv_vfwnmacc(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
                               unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc(vfloat32m8_t vd, vfloat16m4_t vs1,
                               vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwnmacc(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2,
+vfloat32m8_t __riscv_vfwnmacc(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
                               unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc(vfloat64m1_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -34889,23 +34889,23 @@ vfloat64m8_t __riscv_vfwnmacc(vfloat64m8_t vd, float32_t vs1, vfloat32m4_t vs2,
                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmsac(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmsac(vfloat32mf2_t vd, float16_t vs1,
-                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat32mf2_t __riscv_vfwmsac(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmsac(vfloat32m1_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmsac(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2,
+vfloat32m1_t __riscv_vfwmsac(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmsac(vfloat32m2_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmsac(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2,
+vfloat32m2_t __riscv_vfwmsac(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmsac(vfloat32m4_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmsac(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2,
+vfloat32m4_t __riscv_vfwmsac(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmsac(vfloat32m8_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmsac(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2,
+vfloat32m8_t __riscv_vfwmsac(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmsac(vfloat64m1_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -34925,23 +34925,23 @@ vfloat64m8_t __riscv_vfwmsac(vfloat64m8_t vd, float32_t vs1, vfloat32m4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmsac(vfloat32mf2_t vd, _Float16 vs1,
                                vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac(vfloat32m1_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwnmsac(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2,
+vfloat32m1_t __riscv_vfwnmsac(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2,
                               unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac(vfloat32m2_t vd, vfloat16m1_t vs1,
                               vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwnmsac(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2,
+vfloat32m2_t __riscv_vfwnmsac(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
                               unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac(vfloat32m4_t vd, vfloat16m2_t vs1,
                               vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwnmsac(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2,
+vfloat32m4_t __riscv_vfwnmsac(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
                               unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac(vfloat32m8_t vd, vfloat16m4_t vs1,
                               vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwnmsac(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2,
+vfloat32m8_t __riscv_vfwnmsac(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
                               unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac(vfloat64m1_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -34962,23 +34962,23 @@ vfloat64m8_t __riscv_vfwnmsac(vfloat64m8_t vd, float32_t vs1, vfloat32m4_t vs2,
 // masked functions
 vfloat32mf2_t __riscv_vfwmacc(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmacc(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmacc(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmacc(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmacc(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmacc(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmacc(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmacc(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmacc(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmacc(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmacc(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmacc(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmacc(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmacc(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmacc(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmacc(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -34999,23 +34999,23 @@ vfloat64m8_t __riscv_vfwmacc(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwnmacc(vbool64_t vm, vfloat32mf2_t vd,
                                vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmacc(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwnmacc(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmacc(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                               vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwnmacc(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmacc(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                               vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                               vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwnmacc(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmacc(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                               vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                               vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwnmacc(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmacc(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                               vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -35035,23 +35035,23 @@ vfloat64m8_t __riscv_vfwnmacc(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
                               vfloat32m4_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmsac(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmsac(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmsac(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmsac(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmsac(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmsac(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmsac(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmsac(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmsac(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmsac(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmsac(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmsac(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmsac(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmsac(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmsac(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmsac(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -35072,23 +35072,23 @@ vfloat64m8_t __riscv_vfwmsac(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwnmsac(vbool64_t vm, vfloat32mf2_t vd,
                                vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmsac(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwnmsac(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmsac(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                               vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwnmsac(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmsac(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                               vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                               vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwnmsac(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmsac(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                               vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                               vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwnmsac(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmsac(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                               vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -35320,17 +35320,17 @@ vfloat64m8_t __riscv_vfrec7(vbool8_t vm, vfloat64m8_t vs2, unsigned int frm,
 [,c]
 ----
 vfloat16mf4_t __riscv_vfmin(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfmin(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfmin(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmin(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfmin(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfmin(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmin(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfmin(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfmin(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmin(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfmin(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfmin(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmin(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfmin(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfmin(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmin(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfmin(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfmin(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmin(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmin(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfmin(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -35350,17 +35350,17 @@ vfloat64m4_t __riscv_vfmin(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfmin(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vfloat64m8_t __riscv_vfmin(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfmax(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfmax(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfmax(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmax(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfmax(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfmax(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmax(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfmax(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfmax(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmax(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfmax(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfmax(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmax(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfmax(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfmax(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmax(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfmax(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfmax(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmax(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmax(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfmax(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -35382,27 +35382,27 @@ vfloat64m8_t __riscv_vfmax(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 // masked functions
 vfloat16mf4_t __riscv_vfmin(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             size_t vl);
-vfloat16mf4_t __riscv_vfmin(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfmin(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16mf2_t __riscv_vfmin(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             size_t vl);
-vfloat16mf2_t __riscv_vfmin(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfmin(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16m1_t __riscv_vfmin(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            size_t vl);
-vfloat16m1_t __riscv_vfmin(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfmin(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m2_t __riscv_vfmin(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            size_t vl);
-vfloat16m2_t __riscv_vfmin(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfmin(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m4_t __riscv_vfmin(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            size_t vl);
-vfloat16m4_t __riscv_vfmin(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfmin(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m8_t __riscv_vfmin(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            size_t vl);
-vfloat16m8_t __riscv_vfmin(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfmin(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat32mf2_t __riscv_vfmin(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             size_t vl);
@@ -35442,27 +35442,27 @@ vfloat64m8_t __riscv_vfmin(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                            size_t vl);
 vfloat16mf4_t __riscv_vfmax(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             size_t vl);
-vfloat16mf4_t __riscv_vfmax(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfmax(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16mf2_t __riscv_vfmax(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             size_t vl);
-vfloat16mf2_t __riscv_vfmax(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfmax(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16m1_t __riscv_vfmax(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            size_t vl);
-vfloat16m1_t __riscv_vfmax(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfmax(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m2_t __riscv_vfmax(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            size_t vl);
-vfloat16m2_t __riscv_vfmax(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfmax(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m4_t __riscv_vfmax(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            size_t vl);
-vfloat16m4_t __riscv_vfmax(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfmax(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m8_t __riscv_vfmax(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            size_t vl);
-vfloat16m8_t __riscv_vfmax(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfmax(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat32mf2_t __riscv_vfmax(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             size_t vl);
@@ -35508,17 +35508,17 @@ vfloat64m8_t __riscv_vfmax(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
 [,c]
 ----
 vfloat16mf4_t __riscv_vfsgnj(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfsgnj(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfsgnj(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnj(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfsgnj(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfsgnj(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnj(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfsgnj(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfsgnj(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnj(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfsgnj(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfsgnj(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnj(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfsgnj(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfsgnj(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnj(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfsgnj(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfsgnj(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnj(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnj(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfsgnj(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -35538,17 +35538,17 @@ vfloat64m4_t __riscv_vfsgnj(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfsgnj(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vfloat64m8_t __riscv_vfsgnj(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnjn(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfsgnjn(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfsgnjn(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfsgnjn(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfsgnjn(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjn(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfsgnjn(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfsgnjn(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjn(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfsgnjn(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfsgnjn(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjn(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfsgnjn(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfsgnjn(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjn(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfsgnjn(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfsgnjn(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfsgnjn(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -35568,17 +35568,17 @@ vfloat64m4_t __riscv_vfsgnjn(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfsgnjn(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vfloat64m8_t __riscv_vfsgnjn(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnjx(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfsgnjx(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfsgnjx(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfsgnjx(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfsgnjx(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjx(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfsgnjx(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfsgnjx(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjx(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfsgnjx(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfsgnjx(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjx(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfsgnjx(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfsgnjx(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjx(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfsgnjx(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfsgnjx(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfsgnjx(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -35600,27 +35600,27 @@ vfloat64m8_t __riscv_vfsgnjx(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 // masked functions
 vfloat16mf4_t __riscv_vfsgnj(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                              size_t vl);
-vfloat16mf4_t __riscv_vfsgnj(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsgnj(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat16mf2_t __riscv_vfsgnj(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                              size_t vl);
-vfloat16mf2_t __riscv_vfsgnj(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsgnj(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat16m1_t __riscv_vfsgnj(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                             size_t vl);
-vfloat16m1_t __riscv_vfsgnj(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfsgnj(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16m2_t __riscv_vfsgnj(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                             size_t vl);
-vfloat16m2_t __riscv_vfsgnj(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfsgnj(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16m4_t __riscv_vfsgnj(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                             size_t vl);
-vfloat16m4_t __riscv_vfsgnj(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfsgnj(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16m8_t __riscv_vfsgnj(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                             size_t vl);
-vfloat16m8_t __riscv_vfsgnj(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfsgnj(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat32mf2_t __riscv_vfsgnj(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                              size_t vl);
@@ -35660,27 +35660,27 @@ vfloat64m8_t __riscv_vfsgnj(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                             size_t vl);
 vfloat16mf4_t __riscv_vfsgnjn(vbool64_t vm, vfloat16mf4_t vs2,
                               vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfsgnjn(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsgnjn(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn(vbool32_t vm, vfloat16mf2_t vs2,
                               vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfsgnjn(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsgnjn(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m1_t __riscv_vfsgnjn(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                              size_t vl);
-vfloat16m1_t __riscv_vfsgnjn(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfsgnjn(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat16m2_t __riscv_vfsgnjn(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                              size_t vl);
-vfloat16m2_t __riscv_vfsgnjn(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfsgnjn(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat16m4_t __riscv_vfsgnjn(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                              size_t vl);
-vfloat16m4_t __riscv_vfsgnjn(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfsgnjn(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat16m8_t __riscv_vfsgnjn(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                              size_t vl);
-vfloat16m8_t __riscv_vfsgnjn(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfsgnjn(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn(vbool64_t vm, vfloat32mf2_t vs2,
                               vfloat32mf2_t vs1, size_t vl);
@@ -35720,27 +35720,27 @@ vfloat64m8_t __riscv_vfsgnjn(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                              size_t vl);
 vfloat16mf4_t __riscv_vfsgnjx(vbool64_t vm, vfloat16mf4_t vs2,
                               vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfsgnjx(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsgnjx(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx(vbool32_t vm, vfloat16mf2_t vs2,
                               vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfsgnjx(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsgnjx(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m1_t __riscv_vfsgnjx(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                              size_t vl);
-vfloat16m1_t __riscv_vfsgnjx(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfsgnjx(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat16m2_t __riscv_vfsgnjx(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                              size_t vl);
-vfloat16m2_t __riscv_vfsgnjx(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfsgnjx(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat16m4_t __riscv_vfsgnjx(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                              size_t vl);
-vfloat16m4_t __riscv_vfsgnjx(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfsgnjx(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat16m8_t __riscv_vfsgnjx(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                              size_t vl);
-vfloat16m8_t __riscv_vfsgnjx(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfsgnjx(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx(vbool64_t vm, vfloat32mf2_t vs2,
                               vfloat32mf2_t vs1, size_t vl);
@@ -35824,17 +35824,17 @@ vfloat64m8_t __riscv_vfabs(vbool8_t vm, vfloat64m8_t vs2, size_t vl);
 [,c]
 ----
 vbool64_t __riscv_vmfeq(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vbool64_t __riscv_vmfeq(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vbool64_t __riscv_vmfeq(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfeq(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vbool32_t __riscv_vmfeq(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vbool32_t __riscv_vmfeq(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfeq(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vbool16_t __riscv_vmfeq(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vbool16_t __riscv_vmfeq(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfeq(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vbool8_t __riscv_vmfeq(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfeq(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfeq(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vbool4_t __riscv_vmfeq(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfeq(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfeq(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vbool2_t __riscv_vmfeq(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfeq(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfeq(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfeq(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vbool32_t __riscv_vmfeq(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -35854,17 +35854,17 @@ vbool16_t __riscv_vmfeq(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vbool8_t __riscv_vmfeq(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vbool8_t __riscv_vmfeq(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfne(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vbool64_t __riscv_vmfne(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vbool64_t __riscv_vmfne(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfne(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vbool32_t __riscv_vmfne(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vbool32_t __riscv_vmfne(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfne(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vbool16_t __riscv_vmfne(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vbool16_t __riscv_vmfne(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfne(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vbool8_t __riscv_vmfne(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfne(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfne(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vbool4_t __riscv_vmfne(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfne(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfne(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vbool2_t __riscv_vmfne(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfne(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfne(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfne(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vbool32_t __riscv_vmfne(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -35884,17 +35884,17 @@ vbool16_t __riscv_vmfne(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vbool8_t __riscv_vmfne(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vbool8_t __riscv_vmfne(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmflt(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vbool64_t __riscv_vmflt(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vbool64_t __riscv_vmflt(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmflt(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vbool32_t __riscv_vmflt(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vbool32_t __riscv_vmflt(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmflt(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vbool16_t __riscv_vmflt(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vbool16_t __riscv_vmflt(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmflt(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vbool8_t __riscv_vmflt(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmflt(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmflt(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vbool4_t __riscv_vmflt(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmflt(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmflt(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vbool2_t __riscv_vmflt(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmflt(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmflt(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmflt(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vbool32_t __riscv_vmflt(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -35914,17 +35914,17 @@ vbool16_t __riscv_vmflt(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vbool8_t __riscv_vmflt(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vbool8_t __riscv_vmflt(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfle(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vbool64_t __riscv_vmfle(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vbool64_t __riscv_vmfle(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfle(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vbool32_t __riscv_vmfle(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vbool32_t __riscv_vmfle(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfle(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vbool16_t __riscv_vmfle(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vbool16_t __riscv_vmfle(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfle(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vbool8_t __riscv_vmfle(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfle(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfle(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vbool4_t __riscv_vmfle(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfle(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfle(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vbool2_t __riscv_vmfle(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfle(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfle(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfle(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vbool32_t __riscv_vmfle(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -35944,17 +35944,17 @@ vbool16_t __riscv_vmfle(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vbool8_t __riscv_vmfle(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vbool8_t __riscv_vmfle(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfgt(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vbool64_t __riscv_vmfgt(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vbool64_t __riscv_vmfgt(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfgt(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vbool32_t __riscv_vmfgt(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vbool32_t __riscv_vmfgt(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfgt(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vbool16_t __riscv_vmfgt(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vbool16_t __riscv_vmfgt(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfgt(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vbool8_t __riscv_vmfgt(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfgt(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfgt(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vbool4_t __riscv_vmfgt(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfgt(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfgt(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vbool2_t __riscv_vmfgt(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfgt(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfgt(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfgt(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vbool32_t __riscv_vmfgt(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -35974,17 +35974,17 @@ vbool16_t __riscv_vmfgt(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vbool8_t __riscv_vmfgt(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vbool8_t __riscv_vmfgt(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfge(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vbool64_t __riscv_vmfge(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vbool64_t __riscv_vmfge(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfge(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vbool32_t __riscv_vmfge(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vbool32_t __riscv_vmfge(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfge(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vbool16_t __riscv_vmfge(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vbool16_t __riscv_vmfge(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfge(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vbool8_t __riscv_vmfge(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfge(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfge(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vbool4_t __riscv_vmfge(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfge(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfge(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vbool2_t __riscv_vmfge(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfge(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfge(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfge(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vbool32_t __riscv_vmfge(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -36006,25 +36006,25 @@ vbool8_t __riscv_vmfge(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 // masked functions
 vbool64_t __riscv_vmfeq(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                         size_t vl);
-vbool64_t __riscv_vmfeq(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfeq(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                         size_t vl);
 vbool32_t __riscv_vmfeq(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                         size_t vl);
-vbool32_t __riscv_vmfeq(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfeq(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                         size_t vl);
 vbool16_t __riscv_vmfeq(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                         size_t vl);
-vbool16_t __riscv_vmfeq(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vbool16_t __riscv_vmfeq(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                         size_t vl);
 vbool8_t __riscv_vmfeq(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                        size_t vl);
-vbool8_t __riscv_vmfeq(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfeq(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfeq(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                        size_t vl);
-vbool4_t __riscv_vmfeq(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfeq(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfeq(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                        size_t vl);
-vbool2_t __riscv_vmfeq(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfeq(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfeq(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                         size_t vl);
 vbool64_t __riscv_vmfeq(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
@@ -36060,25 +36060,25 @@ vbool8_t __riscv_vmfeq(vbool8_t vm, vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmfeq(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfne(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                         size_t vl);
-vbool64_t __riscv_vmfne(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfne(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                         size_t vl);
 vbool32_t __riscv_vmfne(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                         size_t vl);
-vbool32_t __riscv_vmfne(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfne(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                         size_t vl);
 vbool16_t __riscv_vmfne(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                         size_t vl);
-vbool16_t __riscv_vmfne(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vbool16_t __riscv_vmfne(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                         size_t vl);
 vbool8_t __riscv_vmfne(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                        size_t vl);
-vbool8_t __riscv_vmfne(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfne(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfne(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                        size_t vl);
-vbool4_t __riscv_vmfne(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfne(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfne(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                        size_t vl);
-vbool2_t __riscv_vmfne(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfne(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfne(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                         size_t vl);
 vbool64_t __riscv_vmfne(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
@@ -36114,25 +36114,25 @@ vbool8_t __riscv_vmfne(vbool8_t vm, vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmfne(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmflt(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                         size_t vl);
-vbool64_t __riscv_vmflt(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmflt(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                         size_t vl);
 vbool32_t __riscv_vmflt(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                         size_t vl);
-vbool32_t __riscv_vmflt(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmflt(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                         size_t vl);
 vbool16_t __riscv_vmflt(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                         size_t vl);
-vbool16_t __riscv_vmflt(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vbool16_t __riscv_vmflt(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                         size_t vl);
 vbool8_t __riscv_vmflt(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                        size_t vl);
-vbool8_t __riscv_vmflt(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmflt(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmflt(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                        size_t vl);
-vbool4_t __riscv_vmflt(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmflt(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmflt(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                        size_t vl);
-vbool2_t __riscv_vmflt(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmflt(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmflt(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                         size_t vl);
 vbool64_t __riscv_vmflt(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
@@ -36168,25 +36168,25 @@ vbool8_t __riscv_vmflt(vbool8_t vm, vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmflt(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfle(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                         size_t vl);
-vbool64_t __riscv_vmfle(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfle(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                         size_t vl);
 vbool32_t __riscv_vmfle(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                         size_t vl);
-vbool32_t __riscv_vmfle(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfle(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                         size_t vl);
 vbool16_t __riscv_vmfle(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                         size_t vl);
-vbool16_t __riscv_vmfle(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vbool16_t __riscv_vmfle(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                         size_t vl);
 vbool8_t __riscv_vmfle(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                        size_t vl);
-vbool8_t __riscv_vmfle(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfle(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfle(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                        size_t vl);
-vbool4_t __riscv_vmfle(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfle(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfle(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                        size_t vl);
-vbool2_t __riscv_vmfle(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfle(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfle(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                         size_t vl);
 vbool64_t __riscv_vmfle(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
@@ -36222,25 +36222,25 @@ vbool8_t __riscv_vmfle(vbool8_t vm, vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmfle(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfgt(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                         size_t vl);
-vbool64_t __riscv_vmfgt(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfgt(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                         size_t vl);
 vbool32_t __riscv_vmfgt(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                         size_t vl);
-vbool32_t __riscv_vmfgt(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfgt(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                         size_t vl);
 vbool16_t __riscv_vmfgt(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                         size_t vl);
-vbool16_t __riscv_vmfgt(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vbool16_t __riscv_vmfgt(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                         size_t vl);
 vbool8_t __riscv_vmfgt(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                        size_t vl);
-vbool8_t __riscv_vmfgt(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfgt(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfgt(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                        size_t vl);
-vbool4_t __riscv_vmfgt(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfgt(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfgt(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                        size_t vl);
-vbool2_t __riscv_vmfgt(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfgt(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfgt(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                         size_t vl);
 vbool64_t __riscv_vmfgt(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
@@ -36276,25 +36276,25 @@ vbool8_t __riscv_vmfgt(vbool8_t vm, vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmfgt(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfge(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                         size_t vl);
-vbool64_t __riscv_vmfge(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfge(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                         size_t vl);
 vbool32_t __riscv_vmfge(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                         size_t vl);
-vbool32_t __riscv_vmfge(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfge(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                         size_t vl);
 vbool16_t __riscv_vmfge(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                         size_t vl);
-vbool16_t __riscv_vmfge(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vbool16_t __riscv_vmfge(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                         size_t vl);
 vbool8_t __riscv_vmfge(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                        size_t vl);
-vbool8_t __riscv_vmfge(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfge(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfge(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                        size_t vl);
-vbool4_t __riscv_vmfge(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfge(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfge(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                        size_t vl);
-vbool2_t __riscv_vmfge(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfge(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfge(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                         size_t vl);
 vbool64_t __riscv_vmfge(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
@@ -36375,27 +36375,27 @@ vuint64m8_t __riscv_vfclass(vbool8_t vm, vfloat64m8_t vs2, size_t vl);
 ----
 vfloat16mf4_t __riscv_vmerge(vfloat16mf4_t vs2, vfloat16mf4_t vs1, vbool64_t v0,
                              size_t vl);
-vfloat16mf4_t __riscv_vfmerge(vfloat16mf4_t vs2, float16_t rs1, vbool64_t v0,
+vfloat16mf4_t __riscv_vfmerge(vfloat16mf4_t vs2, _Float16 rs1, vbool64_t v0,
                               size_t vl);
 vfloat16mf2_t __riscv_vmerge(vfloat16mf2_t vs2, vfloat16mf2_t vs1, vbool32_t v0,
                              size_t vl);
-vfloat16mf2_t __riscv_vfmerge(vfloat16mf2_t vs2, float16_t rs1, vbool32_t v0,
+vfloat16mf2_t __riscv_vfmerge(vfloat16mf2_t vs2, _Float16 rs1, vbool32_t v0,
                               size_t vl);
 vfloat16m1_t __riscv_vmerge(vfloat16m1_t vs2, vfloat16m1_t vs1, vbool16_t v0,
                             size_t vl);
-vfloat16m1_t __riscv_vfmerge(vfloat16m1_t vs2, float16_t rs1, vbool16_t v0,
+vfloat16m1_t __riscv_vfmerge(vfloat16m1_t vs2, _Float16 rs1, vbool16_t v0,
                              size_t vl);
 vfloat16m2_t __riscv_vmerge(vfloat16m2_t vs2, vfloat16m2_t vs1, vbool8_t v0,
                             size_t vl);
-vfloat16m2_t __riscv_vfmerge(vfloat16m2_t vs2, float16_t rs1, vbool8_t v0,
+vfloat16m2_t __riscv_vfmerge(vfloat16m2_t vs2, _Float16 rs1, vbool8_t v0,
                              size_t vl);
 vfloat16m4_t __riscv_vmerge(vfloat16m4_t vs2, vfloat16m4_t vs1, vbool4_t v0,
                             size_t vl);
-vfloat16m4_t __riscv_vfmerge(vfloat16m4_t vs2, float16_t rs1, vbool4_t v0,
+vfloat16m4_t __riscv_vfmerge(vfloat16m4_t vs2, _Float16 rs1, vbool4_t v0,
                              size_t vl);
 vfloat16m8_t __riscv_vmerge(vfloat16m8_t vs2, vfloat16m8_t vs1, vbool2_t v0,
                             size_t vl);
-vfloat16m8_t __riscv_vfmerge(vfloat16m8_t vs2, float16_t rs1, vbool2_t v0,
+vfloat16m8_t __riscv_vfmerge(vfloat16m8_t vs2, _Float16 rs1, vbool2_t v0,
                              size_t vl);
 vfloat32mf2_t __riscv_vmerge(vfloat32mf2_t vs2, vfloat32mf2_t vs1, vbool64_t v0,
                              size_t vl);
@@ -38989,12 +38989,12 @@ vbool64_t __riscv_vmsof(vbool64_t vm, vbool64_t vs2, size_t vl);
 
 [,c]
 ----
-float16_t __riscv_vfmv_f(vfloat16mf4_t vs1);
-float16_t __riscv_vfmv_f(vfloat16mf2_t vs1);
-float16_t __riscv_vfmv_f(vfloat16m1_t vs1);
-float16_t __riscv_vfmv_f(vfloat16m2_t vs1);
-float16_t __riscv_vfmv_f(vfloat16m4_t vs1);
-float16_t __riscv_vfmv_f(vfloat16m8_t vs1);
+_Float16 __riscv_vfmv_f(vfloat16mf4_t vs1);
+_Float16 __riscv_vfmv_f(vfloat16mf2_t vs1);
+_Float16 __riscv_vfmv_f(vfloat16m1_t vs1);
+_Float16 __riscv_vfmv_f(vfloat16m2_t vs1);
+_Float16 __riscv_vfmv_f(vfloat16m4_t vs1);
+_Float16 __riscv_vfmv_f(vfloat16m8_t vs1);
 float32_t __riscv_vfmv_f(vfloat32mf2_t vs1);
 float32_t __riscv_vfmv_f(vfloat32m1_t vs1);
 float32_t __riscv_vfmv_f(vfloat32m2_t vs1);
@@ -39476,12 +39476,12 @@ vuint64m8_t __riscv_vslidedown(vbool8_t vm, vuint64m8_t vs2, size_t rs1,
 
 [,c]
 ----
-vfloat16mf4_t __riscv_vfslide1up(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
-vfloat16mf2_t __riscv_vfslide1up(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
-vfloat16m1_t __riscv_vfslide1up(vfloat16m1_t vs2, float16_t rs1, size_t vl);
-vfloat16m2_t __riscv_vfslide1up(vfloat16m2_t vs2, float16_t rs1, size_t vl);
-vfloat16m4_t __riscv_vfslide1up(vfloat16m4_t vs2, float16_t rs1, size_t vl);
-vfloat16m8_t __riscv_vfslide1up(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfslide1up(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
+vfloat16mf2_t __riscv_vfslide1up(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m1_t __riscv_vfslide1up(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
+vfloat16m2_t __riscv_vfslide1up(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m4_t __riscv_vfslide1up(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
+vfloat16m8_t __riscv_vfslide1up(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfslide1up(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfslide1up(vfloat32m1_t vs2, float32_t rs1, size_t vl);
 vfloat32m2_t __riscv_vfslide1up(vfloat32m2_t vs2, float32_t rs1, size_t vl);
@@ -39491,12 +39491,12 @@ vfloat64m1_t __riscv_vfslide1up(vfloat64m1_t vs2, float64_t rs1, size_t vl);
 vfloat64m2_t __riscv_vfslide1up(vfloat64m2_t vs2, float64_t rs1, size_t vl);
 vfloat64m4_t __riscv_vfslide1up(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfslide1up(vfloat64m8_t vs2, float64_t rs1, size_t vl);
-vfloat16mf4_t __riscv_vfslide1down(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
-vfloat16mf2_t __riscv_vfslide1down(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
-vfloat16m1_t __riscv_vfslide1down(vfloat16m1_t vs2, float16_t rs1, size_t vl);
-vfloat16m2_t __riscv_vfslide1down(vfloat16m2_t vs2, float16_t rs1, size_t vl);
-vfloat16m4_t __riscv_vfslide1down(vfloat16m4_t vs2, float16_t rs1, size_t vl);
-vfloat16m8_t __riscv_vfslide1down(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfslide1down(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
+vfloat16mf2_t __riscv_vfslide1down(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m1_t __riscv_vfslide1down(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
+vfloat16m2_t __riscv_vfslide1down(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m4_t __riscv_vfslide1down(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
+vfloat16m8_t __riscv_vfslide1down(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfslide1down(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfslide1down(vfloat32m1_t vs2, float32_t rs1, size_t vl);
 vfloat32m2_t __riscv_vfslide1down(vfloat32m2_t vs2, float32_t rs1, size_t vl);
@@ -39595,17 +39595,17 @@ vuint64m2_t __riscv_vslide1down(vuint64m2_t vs2, uint64_t rs1, size_t vl);
 vuint64m4_t __riscv_vslide1down(vuint64m4_t vs2, uint64_t rs1, size_t vl);
 vuint64m8_t __riscv_vslide1down(vuint64m8_t vs2, uint64_t rs1, size_t vl);
 // masked functions
-vfloat16mf4_t __riscv_vfslide1up(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfslide1up(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                                  size_t vl);
-vfloat16mf2_t __riscv_vfslide1up(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfslide1up(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                                  size_t vl);
-vfloat16m1_t __riscv_vfslide1up(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfslide1up(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                                 size_t vl);
-vfloat16m2_t __riscv_vfslide1up(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfslide1up(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                 size_t vl);
-vfloat16m4_t __riscv_vfslide1up(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfslide1up(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                 size_t vl);
-vfloat16m8_t __riscv_vfslide1up(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfslide1up(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                 size_t vl);
 vfloat32mf2_t __riscv_vfslide1up(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
                                  size_t vl);
@@ -39626,16 +39626,16 @@ vfloat64m4_t __riscv_vfslide1up(vbool16_t vm, vfloat64m4_t vs2, float64_t rs1,
 vfloat64m8_t __riscv_vfslide1up(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                                 size_t vl);
 vfloat16mf4_t __riscv_vfslide1down(vbool64_t vm, vfloat16mf4_t vs2,
-                                   float16_t rs1, size_t vl);
+                                   _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfslide1down(vbool32_t vm, vfloat16mf2_t vs2,
-                                   float16_t rs1, size_t vl);
-vfloat16m1_t __riscv_vfslide1down(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+                                   _Float16 rs1, size_t vl);
+vfloat16m1_t __riscv_vfslide1down(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                                   size_t vl);
-vfloat16m2_t __riscv_vfslide1down(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfslide1down(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                   size_t vl);
-vfloat16m4_t __riscv_vfslide1down(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfslide1down(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                   size_t vl);
-vfloat16m8_t __riscv_vfslide1down(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfslide1down(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                   size_t vl);
 vfloat32mf2_t __riscv_vfslide1down(vbool64_t vm, vfloat32mf2_t vs2,
                                    float32_t rs1, size_t vl);

--- a/auto-generated/overloaded_intrinsic_funcs.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs.adoc
@@ -38861,21 +38861,21 @@ vbool64_t __riscv_vmnot(vbool64_t vs, size_t vl);
 
 [,c]
 ----
-unsigned long __riscv_vcpop(vbool1_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool2_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool4_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool8_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool16_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool32_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool64_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool1_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool2_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool4_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool8_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool16_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool32_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool64_t vs2, size_t vl);
 // masked functions
-unsigned long __riscv_vcpop(vbool1_t vm, vbool1_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool2_t vm, vbool2_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool4_t vm, vbool4_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool8_t vm, vbool8_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool16_t vm, vbool16_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool32_t vm, vbool32_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool64_t vm, vbool64_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool1_t vm, vbool1_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool2_t vm, vbool2_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool4_t vm, vbool4_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool8_t vm, vbool8_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool16_t vm, vbool16_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool32_t vm, vbool32_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool64_t vm, vbool64_t vs2, size_t vl);
 ----
 
 [[overloaded-vfirst-find-first-set-mask-bit]]
@@ -38883,21 +38883,21 @@ unsigned long __riscv_vcpop(vbool64_t vm, vbool64_t vs2, size_t vl);
 
 [,c]
 ----
-long __riscv_vfirst(vbool1_t vs2, size_t vl);
-long __riscv_vfirst(vbool2_t vs2, size_t vl);
-long __riscv_vfirst(vbool4_t vs2, size_t vl);
-long __riscv_vfirst(vbool8_t vs2, size_t vl);
-long __riscv_vfirst(vbool16_t vs2, size_t vl);
-long __riscv_vfirst(vbool32_t vs2, size_t vl);
-long __riscv_vfirst(vbool64_t vs2, size_t vl);
+int __riscv_vfirst(vbool1_t vs2, size_t vl);
+int __riscv_vfirst(vbool2_t vs2, size_t vl);
+int __riscv_vfirst(vbool4_t vs2, size_t vl);
+int __riscv_vfirst(vbool8_t vs2, size_t vl);
+int __riscv_vfirst(vbool16_t vs2, size_t vl);
+int __riscv_vfirst(vbool32_t vs2, size_t vl);
+int __riscv_vfirst(vbool64_t vs2, size_t vl);
 // masked functions
-long __riscv_vfirst(vbool1_t vm, vbool1_t vs2, size_t vl);
-long __riscv_vfirst(vbool2_t vm, vbool2_t vs2, size_t vl);
-long __riscv_vfirst(vbool4_t vm, vbool4_t vs2, size_t vl);
-long __riscv_vfirst(vbool8_t vm, vbool8_t vs2, size_t vl);
-long __riscv_vfirst(vbool16_t vm, vbool16_t vs2, size_t vl);
-long __riscv_vfirst(vbool32_t vm, vbool32_t vs2, size_t vl);
-long __riscv_vfirst(vbool64_t vm, vbool64_t vs2, size_t vl);
+int __riscv_vfirst(vbool1_t vm, vbool1_t vs2, size_t vl);
+int __riscv_vfirst(vbool2_t vm, vbool2_t vs2, size_t vl);
+int __riscv_vfirst(vbool4_t vm, vbool4_t vs2, size_t vl);
+int __riscv_vfirst(vbool8_t vm, vbool8_t vs2, size_t vl);
+int __riscv_vfirst(vbool16_t vm, vbool16_t vs2, size_t vl);
+int __riscv_vfirst(vbool32_t vm, vbool32_t vs2, size_t vl);
+int __riscv_vfirst(vbool64_t vm, vbool64_t vs2, size_t vl);
 ----
 
 [[overloaded-vmsbfm-set-before-first-mask-bit]]

--- a/auto-generated/overloaded_intrinsic_funcs/04_vector_floating-point_instructions.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs/04_vector_floating-point_instructions.adoc
@@ -7,17 +7,17 @@
 [,c]
 ----
 vfloat16mf4_t __riscv_vfadd(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfadd(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfadd(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfadd(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfadd(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfadd(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfadd(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfadd(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfadd(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfadd(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfadd(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfadd(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfadd(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfadd(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfadd(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfadd(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfadd(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfadd(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfadd(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfadd(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfadd(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -37,17 +37,17 @@ vfloat64m4_t __riscv_vfadd(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfadd(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vfloat64m8_t __riscv_vfadd(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfsub(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfsub(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfsub(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsub(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfsub(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfsub(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsub(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfsub(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfsub(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsub(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfsub(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfsub(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsub(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfsub(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfsub(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsub(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfsub(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfsub(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsub(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsub(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfsub(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -66,12 +66,12 @@ vfloat64m4_t __riscv_vfsub(vfloat64m4_t vs2, vfloat64m4_t vs1, size_t vl);
 vfloat64m4_t __riscv_vfsub(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfsub(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vfloat64m8_t __riscv_vfsub(vfloat64m8_t vs2, float64_t rs1, size_t vl);
-vfloat16mf4_t __riscv_vfrsub(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
-vfloat16mf2_t __riscv_vfrsub(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
-vfloat16m1_t __riscv_vfrsub(vfloat16m1_t vs2, float16_t rs1, size_t vl);
-vfloat16m2_t __riscv_vfrsub(vfloat16m2_t vs2, float16_t rs1, size_t vl);
-vfloat16m4_t __riscv_vfrsub(vfloat16m4_t vs2, float16_t rs1, size_t vl);
-vfloat16m8_t __riscv_vfrsub(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfrsub(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
+vfloat16mf2_t __riscv_vfrsub(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m1_t __riscv_vfrsub(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
+vfloat16m2_t __riscv_vfrsub(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m4_t __riscv_vfrsub(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
+vfloat16m8_t __riscv_vfrsub(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrsub(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfrsub(vfloat32m1_t vs2, float32_t rs1, size_t vl);
 vfloat32m2_t __riscv_vfrsub(vfloat32m2_t vs2, float32_t rs1, size_t vl);
@@ -99,27 +99,27 @@ vfloat64m8_t __riscv_vfneg(vfloat64m8_t vs, size_t vl);
 // masked functions
 vfloat16mf4_t __riscv_vfadd(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             size_t vl);
-vfloat16mf4_t __riscv_vfadd(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfadd(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16mf2_t __riscv_vfadd(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             size_t vl);
-vfloat16mf2_t __riscv_vfadd(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfadd(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16m1_t __riscv_vfadd(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            size_t vl);
-vfloat16m1_t __riscv_vfadd(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfadd(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m2_t __riscv_vfadd(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            size_t vl);
-vfloat16m2_t __riscv_vfadd(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfadd(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m4_t __riscv_vfadd(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            size_t vl);
-vfloat16m4_t __riscv_vfadd(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfadd(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m8_t __riscv_vfadd(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            size_t vl);
-vfloat16m8_t __riscv_vfadd(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfadd(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat32mf2_t __riscv_vfadd(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             size_t vl);
@@ -159,27 +159,27 @@ vfloat64m8_t __riscv_vfadd(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                            size_t vl);
 vfloat16mf4_t __riscv_vfsub(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             size_t vl);
-vfloat16mf4_t __riscv_vfsub(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsub(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16mf2_t __riscv_vfsub(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             size_t vl);
-vfloat16mf2_t __riscv_vfsub(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsub(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16m1_t __riscv_vfsub(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            size_t vl);
-vfloat16m1_t __riscv_vfsub(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfsub(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m2_t __riscv_vfsub(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            size_t vl);
-vfloat16m2_t __riscv_vfsub(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfsub(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m4_t __riscv_vfsub(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            size_t vl);
-vfloat16m4_t __riscv_vfsub(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfsub(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m8_t __riscv_vfsub(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            size_t vl);
-vfloat16m8_t __riscv_vfsub(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfsub(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat32mf2_t __riscv_vfsub(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             size_t vl);
@@ -217,17 +217,17 @@ vfloat64m8_t __riscv_vfsub(vbool8_t vm, vfloat64m8_t vs2, vfloat64m8_t vs1,
                            size_t vl);
 vfloat64m8_t __riscv_vfsub(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                            size_t vl);
-vfloat16mf4_t __riscv_vfrsub(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfrsub(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                              size_t vl);
-vfloat16mf2_t __riscv_vfrsub(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfrsub(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                              size_t vl);
-vfloat16m1_t __riscv_vfrsub(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfrsub(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                             size_t vl);
-vfloat16m2_t __riscv_vfrsub(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfrsub(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                             size_t vl);
-vfloat16m4_t __riscv_vfrsub(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfrsub(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                             size_t vl);
-vfloat16m8_t __riscv_vfrsub(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfrsub(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat32mf2_t __riscv_vfrsub(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
                              size_t vl);
@@ -264,27 +264,27 @@ vfloat64m4_t __riscv_vfneg(vbool16_t vm, vfloat64m4_t vs, size_t vl);
 vfloat64m8_t __riscv_vfneg(vbool8_t vm, vfloat64m8_t vs, size_t vl);
 vfloat16mf4_t __riscv_vfadd(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfadd(vfloat16mf4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf4_t __riscv_vfadd(vfloat16mf4_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat16mf2_t __riscv_vfadd(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfadd(vfloat16mf2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf2_t __riscv_vfadd(vfloat16mf2_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat16m1_t __riscv_vfadd(vfloat16m1_t vs2, vfloat16m1_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m1_t __riscv_vfadd(vfloat16m1_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m1_t __riscv_vfadd(vfloat16m1_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m2_t __riscv_vfadd(vfloat16m2_t vs2, vfloat16m2_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m2_t __riscv_vfadd(vfloat16m2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m2_t __riscv_vfadd(vfloat16m2_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m4_t __riscv_vfadd(vfloat16m4_t vs2, vfloat16m4_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m4_t __riscv_vfadd(vfloat16m4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m4_t __riscv_vfadd(vfloat16m4_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m8_t __riscv_vfadd(vfloat16m8_t vs2, vfloat16m8_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m8_t __riscv_vfadd(vfloat16m8_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m8_t __riscv_vfadd(vfloat16m8_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat32mf2_t __riscv_vfadd(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -324,27 +324,27 @@ vfloat64m8_t __riscv_vfadd(vfloat64m8_t vs2, float64_t rs1, unsigned int frm,
                            size_t vl);
 vfloat16mf4_t __riscv_vfsub(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfsub(vfloat16mf4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf4_t __riscv_vfsub(vfloat16mf4_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat16mf2_t __riscv_vfsub(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfsub(vfloat16mf2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf2_t __riscv_vfsub(vfloat16mf2_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat16m1_t __riscv_vfsub(vfloat16m1_t vs2, vfloat16m1_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m1_t __riscv_vfsub(vfloat16m1_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m1_t __riscv_vfsub(vfloat16m1_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m2_t __riscv_vfsub(vfloat16m2_t vs2, vfloat16m2_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m2_t __riscv_vfsub(vfloat16m2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m2_t __riscv_vfsub(vfloat16m2_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m4_t __riscv_vfsub(vfloat16m4_t vs2, vfloat16m4_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m4_t __riscv_vfsub(vfloat16m4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m4_t __riscv_vfsub(vfloat16m4_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m8_t __riscv_vfsub(vfloat16m8_t vs2, vfloat16m8_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m8_t __riscv_vfsub(vfloat16m8_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m8_t __riscv_vfsub(vfloat16m8_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat32mf2_t __riscv_vfsub(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -382,17 +382,17 @@ vfloat64m8_t __riscv_vfsub(vfloat64m8_t vs2, vfloat64m8_t vs1, unsigned int frm,
                            size_t vl);
 vfloat64m8_t __riscv_vfsub(vfloat64m8_t vs2, float64_t rs1, unsigned int frm,
                            size_t vl);
-vfloat16mf4_t __riscv_vfrsub(vfloat16mf4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf4_t __riscv_vfrsub(vfloat16mf4_t vs2, _Float16 rs1, unsigned int frm,
                              size_t vl);
-vfloat16mf2_t __riscv_vfrsub(vfloat16mf2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf2_t __riscv_vfrsub(vfloat16mf2_t vs2, _Float16 rs1, unsigned int frm,
                              size_t vl);
-vfloat16m1_t __riscv_vfrsub(vfloat16m1_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m1_t __riscv_vfrsub(vfloat16m1_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
-vfloat16m2_t __riscv_vfrsub(vfloat16m2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m2_t __riscv_vfrsub(vfloat16m2_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
-vfloat16m4_t __riscv_vfrsub(vfloat16m4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m4_t __riscv_vfrsub(vfloat16m4_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
-vfloat16m8_t __riscv_vfrsub(vfloat16m8_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m8_t __riscv_vfrsub(vfloat16m8_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat32mf2_t __riscv_vfrsub(vfloat32mf2_t vs2, float32_t rs1, unsigned int frm,
                              size_t vl);
@@ -415,27 +415,27 @@ vfloat64m8_t __riscv_vfrsub(vfloat64m8_t vs2, float64_t rs1, unsigned int frm,
 // masked functions
 vfloat16mf4_t __riscv_vfadd(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfadd(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfadd(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfadd(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfadd(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfadd(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfadd(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfadd(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfadd(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfadd(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfadd(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfadd(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfadd(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfadd(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfadd(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfadd(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfadd(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfadd(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfadd(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -475,27 +475,27 @@ vfloat64m8_t __riscv_vfadd(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                            unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfsub(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfsub(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsub(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfsub(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfsub(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsub(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfsub(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfsub(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfsub(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfsub(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfsub(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfsub(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfsub(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfsub(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfsub(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfsub(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfsub(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfsub(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfsub(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -533,17 +533,17 @@ vfloat64m8_t __riscv_vfsub(vbool8_t vm, vfloat64m8_t vs2, vfloat64m8_t vs1,
                            unsigned int frm, size_t vl);
 vfloat64m8_t __riscv_vfsub(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                            unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfrsub(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfrsub(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                              unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfrsub(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfrsub(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                              unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfrsub(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfrsub(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfrsub(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfrsub(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfrsub(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfrsub(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfrsub(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfrsub(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrsub(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
                              unsigned int frm, size_t vl);
@@ -572,26 +572,26 @@ vfloat64m8_t __riscv_vfrsub(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
 ----
 vfloat32mf2_t __riscv_vfwadd_vv(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 size_t vl);
-vfloat32mf2_t __riscv_vfwadd_vf(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat32mf2_t __riscv_vfwadd_vf(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                 size_t vl);
-vfloat32mf2_t __riscv_vfwadd_wf(vfloat32mf2_t vs2, float16_t rs1, size_t vl);
+vfloat32mf2_t __riscv_vfwadd_wf(vfloat32mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat32m1_t __riscv_vfwadd_vf(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat32m1_t __riscv_vfwadd_vf(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv(vfloat32m1_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat32m1_t __riscv_vfwadd_wf(vfloat32m1_t vs2, float16_t rs1, size_t vl);
+vfloat32m1_t __riscv_vfwadd_wf(vfloat32m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat32m2_t __riscv_vfwadd_vf(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat32m2_t __riscv_vfwadd_vf(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv(vfloat32m2_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat32m2_t __riscv_vfwadd_wf(vfloat32m2_t vs2, float16_t rs1, size_t vl);
+vfloat32m2_t __riscv_vfwadd_wf(vfloat32m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat32m4_t __riscv_vfwadd_vf(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat32m4_t __riscv_vfwadd_vf(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv(vfloat32m4_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat32m4_t __riscv_vfwadd_wf(vfloat32m4_t vs2, float16_t rs1, size_t vl);
+vfloat32m4_t __riscv_vfwadd_wf(vfloat32m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat32m8_t __riscv_vfwadd_vf(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat32m8_t __riscv_vfwadd_vf(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv(vfloat32m8_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat32m8_t __riscv_vfwadd_wf(vfloat32m8_t vs2, float16_t rs1, size_t vl);
+vfloat32m8_t __riscv_vfwadd_wf(vfloat32m8_t vs2, _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vf(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat64m1_t __riscv_vfwadd_wv(vfloat64m1_t vs2, vfloat32mf2_t vs1, size_t vl);
@@ -610,26 +610,26 @@ vfloat64m8_t __riscv_vfwadd_wv(vfloat64m8_t vs2, vfloat32m4_t vs1, size_t vl);
 vfloat64m8_t __riscv_vfwadd_wf(vfloat64m8_t vs2, float32_t rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vv(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 size_t vl);
-vfloat32mf2_t __riscv_vfwsub_vf(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat32mf2_t __riscv_vfwsub_vf(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                 size_t vl);
-vfloat32mf2_t __riscv_vfwsub_wf(vfloat32mf2_t vs2, float16_t rs1, size_t vl);
+vfloat32mf2_t __riscv_vfwsub_wf(vfloat32mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat32m1_t __riscv_vfwsub_vf(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat32m1_t __riscv_vfwsub_vf(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv(vfloat32m1_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat32m1_t __riscv_vfwsub_wf(vfloat32m1_t vs2, float16_t rs1, size_t vl);
+vfloat32m1_t __riscv_vfwsub_wf(vfloat32m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat32m2_t __riscv_vfwsub_vf(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat32m2_t __riscv_vfwsub_vf(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv(vfloat32m2_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat32m2_t __riscv_vfwsub_wf(vfloat32m2_t vs2, float16_t rs1, size_t vl);
+vfloat32m2_t __riscv_vfwsub_wf(vfloat32m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat32m4_t __riscv_vfwsub_vf(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat32m4_t __riscv_vfwsub_vf(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv(vfloat32m4_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat32m4_t __riscv_vfwsub_wf(vfloat32m4_t vs2, float16_t rs1, size_t vl);
+vfloat32m4_t __riscv_vfwsub_wf(vfloat32m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat32m8_t __riscv_vfwsub_vf(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat32m8_t __riscv_vfwsub_vf(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv(vfloat32m8_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat32m8_t __riscv_vfwsub_wf(vfloat32m8_t vs2, float16_t rs1, size_t vl);
+vfloat32m8_t __riscv_vfwsub_wf(vfloat32m8_t vs2, _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vf(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat64m1_t __riscv_vfwsub_wv(vfloat64m1_t vs2, vfloat32mf2_t vs1, size_t vl);
@@ -649,43 +649,43 @@ vfloat64m8_t __riscv_vfwsub_wf(vfloat64m8_t vs2, float32_t rs1, size_t vl);
 // masked functions
 vfloat32mf2_t __riscv_vfwadd_vv(vbool64_t vm, vfloat16mf4_t vs2,
                                 vfloat16mf4_t vs1, size_t vl);
-vfloat32mf2_t __riscv_vfwadd_vf(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_vf(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                                 size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv(vbool64_t vm, vfloat32mf2_t vs2,
                                 vfloat16mf4_t vs1, size_t vl);
-vfloat32mf2_t __riscv_vfwadd_wf(vbool64_t vm, vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_wf(vbool64_t vm, vfloat32mf2_t vs2, _Float16 rs1,
                                 size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv(vbool32_t vm, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, size_t vl);
-vfloat32m1_t __riscv_vfwadd_vf(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwadd_vf(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv(vbool32_t vm, vfloat32m1_t vs2,
                                vfloat16mf2_t vs1, size_t vl);
-vfloat32m1_t __riscv_vfwadd_wf(vbool32_t vm, vfloat32m1_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwadd_wf(vbool32_t vm, vfloat32m1_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                                size_t vl);
-vfloat32m2_t __riscv_vfwadd_vf(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwadd_vf(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv(vbool16_t vm, vfloat32m2_t vs2, vfloat16m1_t vs1,
                                size_t vl);
-vfloat32m2_t __riscv_vfwadd_wf(vbool16_t vm, vfloat32m2_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwadd_wf(vbool16_t vm, vfloat32m2_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                                size_t vl);
-vfloat32m4_t __riscv_vfwadd_vf(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwadd_vf(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv(vbool8_t vm, vfloat32m4_t vs2, vfloat16m2_t vs1,
                                size_t vl);
-vfloat32m4_t __riscv_vfwadd_wf(vbool8_t vm, vfloat32m4_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwadd_wf(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                                size_t vl);
-vfloat32m8_t __riscv_vfwadd_vf(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwadd_vf(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv(vbool4_t vm, vfloat32m8_t vs2, vfloat16m4_t vs1,
                                size_t vl);
-vfloat32m8_t __riscv_vfwadd_wf(vbool4_t vm, vfloat32m8_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwadd_wf(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv(vbool64_t vm, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, size_t vl);
@@ -721,43 +721,43 @@ vfloat64m8_t __riscv_vfwadd_wf(vbool8_t vm, vfloat64m8_t vs2, float32_t rs1,
                                size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vv(vbool64_t vm, vfloat16mf4_t vs2,
                                 vfloat16mf4_t vs1, size_t vl);
-vfloat32mf2_t __riscv_vfwsub_vf(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_vf(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                                 size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv(vbool64_t vm, vfloat32mf2_t vs2,
                                 vfloat16mf4_t vs1, size_t vl);
-vfloat32mf2_t __riscv_vfwsub_wf(vbool64_t vm, vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_wf(vbool64_t vm, vfloat32mf2_t vs2, _Float16 rs1,
                                 size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv(vbool32_t vm, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, size_t vl);
-vfloat32m1_t __riscv_vfwsub_vf(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwsub_vf(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv(vbool32_t vm, vfloat32m1_t vs2,
                                vfloat16mf2_t vs1, size_t vl);
-vfloat32m1_t __riscv_vfwsub_wf(vbool32_t vm, vfloat32m1_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwsub_wf(vbool32_t vm, vfloat32m1_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                                size_t vl);
-vfloat32m2_t __riscv_vfwsub_vf(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwsub_vf(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv(vbool16_t vm, vfloat32m2_t vs2, vfloat16m1_t vs1,
                                size_t vl);
-vfloat32m2_t __riscv_vfwsub_wf(vbool16_t vm, vfloat32m2_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwsub_wf(vbool16_t vm, vfloat32m2_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                                size_t vl);
-vfloat32m4_t __riscv_vfwsub_vf(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwsub_vf(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv(vbool8_t vm, vfloat32m4_t vs2, vfloat16m2_t vs1,
                                size_t vl);
-vfloat32m4_t __riscv_vfwsub_wf(vbool8_t vm, vfloat32m4_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwsub_wf(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                                size_t vl);
-vfloat32m8_t __riscv_vfwsub_vf(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwsub_vf(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv(vbool4_t vm, vfloat32m8_t vs2, vfloat16m4_t vs1,
                                size_t vl);
-vfloat32m8_t __riscv_vfwsub_wf(vbool4_t vm, vfloat32m8_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwsub_wf(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv(vbool64_t vm, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, size_t vl);
@@ -793,44 +793,44 @@ vfloat64m8_t __riscv_vfwsub_wf(vbool8_t vm, vfloat64m8_t vs2, float32_t rs1,
                                size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vv(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwadd_vf(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_vf(vfloat16mf4_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                 unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwadd_wf(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_wf(vfloat32mf2_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwadd_vf(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwadd_vf(vfloat16mf2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv(vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwadd_wf(vfloat32m1_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m1_t __riscv_vfwadd_wf(vfloat32m1_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwadd_vf(vfloat16m1_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfwadd_vf(vfloat16m1_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv(vfloat32m2_t vs2, vfloat16m1_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwadd_wf(vfloat32m2_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfwadd_wf(vfloat32m2_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwadd_vf(vfloat16m2_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfwadd_vf(vfloat16m2_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv(vfloat32m4_t vs2, vfloat16m2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwadd_wf(vfloat32m4_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfwadd_wf(vfloat32m4_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwadd_vf(vfloat16m4_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m8_t __riscv_vfwadd_vf(vfloat16m4_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv(vfloat32m8_t vs2, vfloat16m4_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwadd_wf(vfloat32m8_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m8_t __riscv_vfwadd_wf(vfloat32m8_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vf(vfloat32mf2_t vs2, float32_t rs1,
@@ -865,44 +865,44 @@ vfloat64m8_t __riscv_vfwadd_wf(vfloat64m8_t vs2, float32_t rs1,
                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vv(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwsub_vf(vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_vf(vfloat16mf4_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv(vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                 unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwsub_wf(vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_wf(vfloat32mf2_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwsub_vf(vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwsub_vf(vfloat16mf2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv(vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwsub_wf(vfloat32m1_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m1_t __riscv_vfwsub_wf(vfloat32m1_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv(vfloat16m1_t vs2, vfloat16m1_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwsub_vf(vfloat16m1_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfwsub_vf(vfloat16m1_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv(vfloat32m2_t vs2, vfloat16m1_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwsub_wf(vfloat32m2_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfwsub_wf(vfloat32m2_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv(vfloat16m2_t vs2, vfloat16m2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwsub_vf(vfloat16m2_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfwsub_vf(vfloat16m2_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv(vfloat32m4_t vs2, vfloat16m2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwsub_wf(vfloat32m4_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfwsub_wf(vfloat32m4_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv(vfloat16m4_t vs2, vfloat16m4_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwsub_vf(vfloat16m4_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m8_t __riscv_vfwsub_vf(vfloat16m4_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv(vfloat32m8_t vs2, vfloat16m4_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwsub_wf(vfloat32m8_t vs2, float16_t rs1,
-                               unsigned int frm, size_t vl);
+vfloat32m8_t __riscv_vfwsub_wf(vfloat32m8_t vs2, _Float16 rs1, unsigned int frm,
+                               size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vf(vfloat32mf2_t vs2, float32_t rs1,
@@ -938,43 +938,43 @@ vfloat64m8_t __riscv_vfwsub_wf(vfloat64m8_t vs2, float32_t rs1,
 // masked functions
 vfloat32mf2_t __riscv_vfwadd_vv(vbool64_t vm, vfloat16mf4_t vs2,
                                 vfloat16mf4_t vs1, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwadd_vf(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_vf(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv(vbool64_t vm, vfloat32mf2_t vs2,
                                 vfloat16mf4_t vs1, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwadd_wf(vbool64_t vm, vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwadd_wf(vbool64_t vm, vfloat32mf2_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv(vbool32_t vm, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwadd_vf(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwadd_vf(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv(vbool32_t vm, vfloat32m1_t vs2,
                                vfloat16mf2_t vs1, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwadd_wf(vbool32_t vm, vfloat32m1_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwadd_wf(vbool32_t vm, vfloat32m1_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwadd_vf(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwadd_vf(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv(vbool16_t vm, vfloat32m2_t vs2, vfloat16m1_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwadd_wf(vbool16_t vm, vfloat32m2_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwadd_wf(vbool16_t vm, vfloat32m2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwadd_vf(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwadd_vf(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv(vbool8_t vm, vfloat32m4_t vs2, vfloat16m2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwadd_wf(vbool8_t vm, vfloat32m4_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwadd_wf(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwadd_vf(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwadd_vf(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv(vbool4_t vm, vfloat32m8_t vs2, vfloat16m4_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwadd_wf(vbool4_t vm, vfloat32m8_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwadd_wf(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv(vbool64_t vm, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, unsigned int frm, size_t vl);
@@ -1010,43 +1010,43 @@ vfloat64m8_t __riscv_vfwadd_wf(vbool8_t vm, vfloat64m8_t vs2, float32_t rs1,
                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vv(vbool64_t vm, vfloat16mf4_t vs2,
                                 vfloat16mf4_t vs1, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwsub_vf(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_vf(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv(vbool64_t vm, vfloat32mf2_t vs2,
                                 vfloat16mf4_t vs1, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwsub_wf(vbool64_t vm, vfloat32mf2_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwsub_wf(vbool64_t vm, vfloat32mf2_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv(vbool32_t vm, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwsub_vf(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwsub_vf(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv(vbool32_t vm, vfloat32m1_t vs2,
                                vfloat16mf2_t vs1, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwsub_wf(vbool32_t vm, vfloat32m1_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwsub_wf(vbool32_t vm, vfloat32m1_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwsub_vf(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwsub_vf(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv(vbool16_t vm, vfloat32m2_t vs2, vfloat16m1_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwsub_wf(vbool16_t vm, vfloat32m2_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwsub_wf(vbool16_t vm, vfloat32m2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwsub_vf(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwsub_vf(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv(vbool8_t vm, vfloat32m4_t vs2, vfloat16m2_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwsub_wf(vbool8_t vm, vfloat32m4_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwsub_wf(vbool8_t vm, vfloat32m4_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwsub_vf(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwsub_vf(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv(vbool4_t vm, vfloat32m8_t vs2, vfloat16m4_t vs1,
                                unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwsub_wf(vbool4_t vm, vfloat32m8_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwsub_wf(vbool4_t vm, vfloat32m8_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv(vbool64_t vm, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, unsigned int frm, size_t vl);
@@ -1088,17 +1088,17 @@ vfloat64m8_t __riscv_vfwsub_wf(vbool8_t vm, vfloat64m8_t vs2, float32_t rs1,
 [,c]
 ----
 vfloat16mf4_t __riscv_vfmul(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfmul(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfmul(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmul(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfmul(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfmul(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmul(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfmul(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfmul(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmul(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfmul(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfmul(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmul(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfmul(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfmul(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmul(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfmul(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfmul(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmul(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmul(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfmul(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -1118,17 +1118,17 @@ vfloat64m4_t __riscv_vfmul(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfmul(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vfloat64m8_t __riscv_vfmul(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfdiv(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfdiv(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfdiv(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfdiv(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfdiv(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfdiv(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfdiv(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfdiv(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfdiv(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfdiv(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfdiv(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfdiv(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfdiv(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfdiv(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfdiv(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfdiv(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfdiv(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfdiv(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfdiv(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfdiv(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfdiv(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -1147,12 +1147,12 @@ vfloat64m4_t __riscv_vfdiv(vfloat64m4_t vs2, vfloat64m4_t vs1, size_t vl);
 vfloat64m4_t __riscv_vfdiv(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfdiv(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vfloat64m8_t __riscv_vfdiv(vfloat64m8_t vs2, float64_t rs1, size_t vl);
-vfloat16mf4_t __riscv_vfrdiv(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
-vfloat16mf2_t __riscv_vfrdiv(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
-vfloat16m1_t __riscv_vfrdiv(vfloat16m1_t vs2, float16_t rs1, size_t vl);
-vfloat16m2_t __riscv_vfrdiv(vfloat16m2_t vs2, float16_t rs1, size_t vl);
-vfloat16m4_t __riscv_vfrdiv(vfloat16m4_t vs2, float16_t rs1, size_t vl);
-vfloat16m8_t __riscv_vfrdiv(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfrdiv(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
+vfloat16mf2_t __riscv_vfrdiv(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m1_t __riscv_vfrdiv(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
+vfloat16m2_t __riscv_vfrdiv(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m4_t __riscv_vfrdiv(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
+vfloat16m8_t __riscv_vfrdiv(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfrdiv(vfloat32m1_t vs2, float32_t rs1, size_t vl);
 vfloat32m2_t __riscv_vfrdiv(vfloat32m2_t vs2, float32_t rs1, size_t vl);
@@ -1165,27 +1165,27 @@ vfloat64m8_t __riscv_vfrdiv(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 // masked functions
 vfloat16mf4_t __riscv_vfmul(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             size_t vl);
-vfloat16mf4_t __riscv_vfmul(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfmul(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16mf2_t __riscv_vfmul(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             size_t vl);
-vfloat16mf2_t __riscv_vfmul(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfmul(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16m1_t __riscv_vfmul(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            size_t vl);
-vfloat16m1_t __riscv_vfmul(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfmul(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m2_t __riscv_vfmul(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            size_t vl);
-vfloat16m2_t __riscv_vfmul(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfmul(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m4_t __riscv_vfmul(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            size_t vl);
-vfloat16m4_t __riscv_vfmul(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfmul(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m8_t __riscv_vfmul(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            size_t vl);
-vfloat16m8_t __riscv_vfmul(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfmul(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat32mf2_t __riscv_vfmul(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             size_t vl);
@@ -1225,27 +1225,27 @@ vfloat64m8_t __riscv_vfmul(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                            size_t vl);
 vfloat16mf4_t __riscv_vfdiv(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             size_t vl);
-vfloat16mf4_t __riscv_vfdiv(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfdiv(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16mf2_t __riscv_vfdiv(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             size_t vl);
-vfloat16mf2_t __riscv_vfdiv(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfdiv(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16m1_t __riscv_vfdiv(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            size_t vl);
-vfloat16m1_t __riscv_vfdiv(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfdiv(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m2_t __riscv_vfdiv(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            size_t vl);
-vfloat16m2_t __riscv_vfdiv(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfdiv(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m4_t __riscv_vfdiv(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            size_t vl);
-vfloat16m4_t __riscv_vfdiv(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfdiv(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m8_t __riscv_vfdiv(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            size_t vl);
-vfloat16m8_t __riscv_vfdiv(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfdiv(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat32mf2_t __riscv_vfdiv(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             size_t vl);
@@ -1283,17 +1283,17 @@ vfloat64m8_t __riscv_vfdiv(vbool8_t vm, vfloat64m8_t vs2, vfloat64m8_t vs1,
                            size_t vl);
 vfloat64m8_t __riscv_vfdiv(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                            size_t vl);
-vfloat16mf4_t __riscv_vfrdiv(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfrdiv(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                              size_t vl);
-vfloat16mf2_t __riscv_vfrdiv(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfrdiv(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                              size_t vl);
-vfloat16m1_t __riscv_vfrdiv(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfrdiv(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                             size_t vl);
-vfloat16m2_t __riscv_vfrdiv(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfrdiv(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                             size_t vl);
-vfloat16m4_t __riscv_vfrdiv(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfrdiv(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                             size_t vl);
-vfloat16m8_t __riscv_vfrdiv(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfrdiv(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat32mf2_t __riscv_vfrdiv(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
                              size_t vl);
@@ -1315,27 +1315,27 @@ vfloat64m8_t __riscv_vfrdiv(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                             size_t vl);
 vfloat16mf4_t __riscv_vfmul(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmul(vfloat16mf4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf4_t __riscv_vfmul(vfloat16mf4_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat16mf2_t __riscv_vfmul(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmul(vfloat16mf2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf2_t __riscv_vfmul(vfloat16mf2_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat16m1_t __riscv_vfmul(vfloat16m1_t vs2, vfloat16m1_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m1_t __riscv_vfmul(vfloat16m1_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m1_t __riscv_vfmul(vfloat16m1_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m2_t __riscv_vfmul(vfloat16m2_t vs2, vfloat16m2_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m2_t __riscv_vfmul(vfloat16m2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m2_t __riscv_vfmul(vfloat16m2_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m4_t __riscv_vfmul(vfloat16m4_t vs2, vfloat16m4_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m4_t __riscv_vfmul(vfloat16m4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m4_t __riscv_vfmul(vfloat16m4_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m8_t __riscv_vfmul(vfloat16m8_t vs2, vfloat16m8_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m8_t __riscv_vfmul(vfloat16m8_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m8_t __riscv_vfmul(vfloat16m8_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat32mf2_t __riscv_vfmul(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -1375,27 +1375,27 @@ vfloat64m8_t __riscv_vfmul(vfloat64m8_t vs2, float64_t rs1, unsigned int frm,
                            size_t vl);
 vfloat16mf4_t __riscv_vfdiv(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfdiv(vfloat16mf4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf4_t __riscv_vfdiv(vfloat16mf4_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat16mf2_t __riscv_vfdiv(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfdiv(vfloat16mf2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf2_t __riscv_vfdiv(vfloat16mf2_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat16m1_t __riscv_vfdiv(vfloat16m1_t vs2, vfloat16m1_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m1_t __riscv_vfdiv(vfloat16m1_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m1_t __riscv_vfdiv(vfloat16m1_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m2_t __riscv_vfdiv(vfloat16m2_t vs2, vfloat16m2_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m2_t __riscv_vfdiv(vfloat16m2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m2_t __riscv_vfdiv(vfloat16m2_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m4_t __riscv_vfdiv(vfloat16m4_t vs2, vfloat16m4_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m4_t __riscv_vfdiv(vfloat16m4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m4_t __riscv_vfdiv(vfloat16m4_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat16m8_t __riscv_vfdiv(vfloat16m8_t vs2, vfloat16m8_t vs1, unsigned int frm,
                            size_t vl);
-vfloat16m8_t __riscv_vfdiv(vfloat16m8_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m8_t __riscv_vfdiv(vfloat16m8_t vs2, _Float16 rs1, unsigned int frm,
                            size_t vl);
 vfloat32mf2_t __riscv_vfdiv(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -1433,17 +1433,17 @@ vfloat64m8_t __riscv_vfdiv(vfloat64m8_t vs2, vfloat64m8_t vs1, unsigned int frm,
                            size_t vl);
 vfloat64m8_t __riscv_vfdiv(vfloat64m8_t vs2, float64_t rs1, unsigned int frm,
                            size_t vl);
-vfloat16mf4_t __riscv_vfrdiv(vfloat16mf4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf4_t __riscv_vfrdiv(vfloat16mf4_t vs2, _Float16 rs1, unsigned int frm,
                              size_t vl);
-vfloat16mf2_t __riscv_vfrdiv(vfloat16mf2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16mf2_t __riscv_vfrdiv(vfloat16mf2_t vs2, _Float16 rs1, unsigned int frm,
                              size_t vl);
-vfloat16m1_t __riscv_vfrdiv(vfloat16m1_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m1_t __riscv_vfrdiv(vfloat16m1_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
-vfloat16m2_t __riscv_vfrdiv(vfloat16m2_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m2_t __riscv_vfrdiv(vfloat16m2_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
-vfloat16m4_t __riscv_vfrdiv(vfloat16m4_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m4_t __riscv_vfrdiv(vfloat16m4_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
-vfloat16m8_t __riscv_vfrdiv(vfloat16m8_t vs2, float16_t rs1, unsigned int frm,
+vfloat16m8_t __riscv_vfrdiv(vfloat16m8_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat32mf2_t __riscv_vfrdiv(vfloat32mf2_t vs2, float32_t rs1, unsigned int frm,
                              size_t vl);
@@ -1466,27 +1466,27 @@ vfloat64m8_t __riscv_vfrdiv(vfloat64m8_t vs2, float64_t rs1, unsigned int frm,
 // masked functions
 vfloat16mf4_t __riscv_vfmul(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmul(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfmul(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmul(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmul(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfmul(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmul(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmul(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfmul(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmul(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmul(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfmul(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmul(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmul(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfmul(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmul(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmul(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfmul(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmul(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -1526,27 +1526,27 @@ vfloat64m8_t __riscv_vfmul(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                            unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfdiv(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfdiv(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfdiv(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfdiv(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfdiv(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfdiv(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfdiv(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfdiv(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfdiv(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfdiv(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfdiv(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfdiv(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfdiv(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfdiv(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfdiv(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfdiv(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfdiv(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfdiv(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfdiv(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -1584,17 +1584,17 @@ vfloat64m8_t __riscv_vfdiv(vbool8_t vm, vfloat64m8_t vs2, vfloat64m8_t vs1,
                            unsigned int frm, size_t vl);
 vfloat64m8_t __riscv_vfdiv(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                            unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfrdiv(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfrdiv(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                              unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfrdiv(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfrdiv(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                              unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfrdiv(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfrdiv(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfrdiv(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfrdiv(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfrdiv(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfrdiv(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfrdiv(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfrdiv(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
                              unsigned int frm, size_t vl);
@@ -1622,15 +1622,15 @@ vfloat64m8_t __riscv_vfrdiv(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
 [,c]
 ----
 vfloat32mf2_t __riscv_vfwmul(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat32mf2_t __riscv_vfwmul(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat32mf2_t __riscv_vfwmul(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwmul(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat32m1_t __riscv_vfwmul(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat32m1_t __riscv_vfwmul(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwmul(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat32m2_t __riscv_vfwmul(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat32m2_t __riscv_vfwmul(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwmul(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat32m4_t __riscv_vfwmul(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat32m4_t __riscv_vfwmul(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwmul(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat32m8_t __riscv_vfwmul(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat32m8_t __riscv_vfwmul(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwmul(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat64m1_t __riscv_vfwmul(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat64m2_t __riscv_vfwmul(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -1642,23 +1642,23 @@ vfloat64m8_t __riscv_vfwmul(vfloat32m4_t vs2, float32_t rs1, size_t vl);
 // masked functions
 vfloat32mf2_t __riscv_vfwmul(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                              size_t vl);
-vfloat32mf2_t __riscv_vfwmul(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwmul(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat32m1_t __riscv_vfwmul(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             size_t vl);
-vfloat32m1_t __riscv_vfwmul(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwmul(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat32m2_t __riscv_vfwmul(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                             size_t vl);
-vfloat32m2_t __riscv_vfwmul(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwmul(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat32m4_t __riscv_vfwmul(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                             size_t vl);
-vfloat32m4_t __riscv_vfwmul(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwmul(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat32m8_t __riscv_vfwmul(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                             size_t vl);
-vfloat32m8_t __riscv_vfwmul(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwmul(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat64m1_t __riscv_vfwmul(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             size_t vl);
@@ -1678,23 +1678,23 @@ vfloat64m8_t __riscv_vfwmul(vbool8_t vm, vfloat32m4_t vs2, float32_t rs1,
                             size_t vl);
 vfloat32mf2_t __riscv_vfwmul(vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                              unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmul(vfloat16mf4_t vs2, float16_t rs1, unsigned int frm,
+vfloat32mf2_t __riscv_vfwmul(vfloat16mf4_t vs2, _Float16 rs1, unsigned int frm,
                              size_t vl);
 vfloat32m1_t __riscv_vfwmul(vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmul(vfloat16mf2_t vs2, float16_t rs1, unsigned int frm,
+vfloat32m1_t __riscv_vfwmul(vfloat16mf2_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat32m2_t __riscv_vfwmul(vfloat16m1_t vs2, vfloat16m1_t vs1,
                             unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmul(vfloat16m1_t vs2, float16_t rs1, unsigned int frm,
+vfloat32m2_t __riscv_vfwmul(vfloat16m1_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat32m4_t __riscv_vfwmul(vfloat16m2_t vs2, vfloat16m2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmul(vfloat16m2_t vs2, float16_t rs1, unsigned int frm,
+vfloat32m4_t __riscv_vfwmul(vfloat16m2_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat32m8_t __riscv_vfwmul(vfloat16m4_t vs2, vfloat16m4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmul(vfloat16m4_t vs2, float16_t rs1, unsigned int frm,
+vfloat32m8_t __riscv_vfwmul(vfloat16m4_t vs2, _Float16 rs1, unsigned int frm,
                             size_t vl);
 vfloat64m1_t __riscv_vfwmul(vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -1715,23 +1715,23 @@ vfloat64m8_t __riscv_vfwmul(vfloat32m4_t vs2, float32_t rs1, unsigned int frm,
 // masked functions
 vfloat32mf2_t __riscv_vfwmul(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                              unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmul(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat32mf2_t __riscv_vfwmul(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmul(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmul(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat32m1_t __riscv_vfwmul(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmul(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                             unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmul(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwmul(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmul(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                             unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmul(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwmul(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmul(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                             unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmul(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwmul(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                             unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmul(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             unsigned int frm, size_t vl);
@@ -1758,27 +1758,27 @@ vfloat64m8_t __riscv_vfwmul(vbool8_t vm, vfloat32m4_t vs2, float32_t rs1,
 ----
 vfloat16mf4_t __riscv_vfmacc(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmacc(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2,
+vfloat16mf4_t __riscv_vfmacc(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
                              size_t vl);
 vfloat16mf2_t __riscv_vfmacc(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmacc(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2,
+vfloat16mf2_t __riscv_vfmacc(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
                              size_t vl);
 vfloat16m1_t __riscv_vfmacc(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_t vs2,
                             size_t vl);
-vfloat16m1_t __riscv_vfmacc(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmacc(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                             size_t vl);
 vfloat16m2_t __riscv_vfmacc(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_t vs2,
                             size_t vl);
-vfloat16m2_t __riscv_vfmacc(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmacc(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                             size_t vl);
 vfloat16m4_t __riscv_vfmacc(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_t vs2,
                             size_t vl);
-vfloat16m4_t __riscv_vfmacc(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmacc(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                             size_t vl);
 vfloat16m8_t __riscv_vfmacc(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_t vs2,
                             size_t vl);
-vfloat16m8_t __riscv_vfmacc(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmacc(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                             size_t vl);
 vfloat32mf2_t __riscv_vfmacc(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -1818,27 +1818,27 @@ vfloat64m8_t __riscv_vfmacc(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                             size_t vl);
 vfloat16mf4_t __riscv_vfnmacc(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmacc(vfloat16mf4_t vd, float16_t rs1,
-                              vfloat16mf4_t vs2, size_t vl);
+vfloat16mf4_t __riscv_vfnmacc(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
+                              size_t vl);
 vfloat16mf2_t __riscv_vfnmacc(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmacc(vfloat16mf2_t vd, float16_t rs1,
-                              vfloat16mf2_t vs2, size_t vl);
+vfloat16mf2_t __riscv_vfnmacc(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
+                              size_t vl);
 vfloat16m1_t __riscv_vfnmacc(vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmacc(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfnmacc(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                              size_t vl);
 vfloat16m2_t __riscv_vfnmacc(vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmacc(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfnmacc(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                              size_t vl);
 vfloat16m4_t __riscv_vfnmacc(vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmacc(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfnmacc(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                              size_t vl);
 vfloat16m8_t __riscv_vfnmacc(vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmacc(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfnmacc(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                              size_t vl);
 vfloat32mf2_t __riscv_vfnmacc(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -1878,27 +1878,27 @@ vfloat64m8_t __riscv_vfnmacc(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                              size_t vl);
 vfloat16mf4_t __riscv_vfmsac(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmsac(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2,
+vfloat16mf4_t __riscv_vfmsac(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
                              size_t vl);
 vfloat16mf2_t __riscv_vfmsac(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmsac(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2,
+vfloat16mf2_t __riscv_vfmsac(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
                              size_t vl);
 vfloat16m1_t __riscv_vfmsac(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_t vs2,
                             size_t vl);
-vfloat16m1_t __riscv_vfmsac(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmsac(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                             size_t vl);
 vfloat16m2_t __riscv_vfmsac(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_t vs2,
                             size_t vl);
-vfloat16m2_t __riscv_vfmsac(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmsac(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                             size_t vl);
 vfloat16m4_t __riscv_vfmsac(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_t vs2,
                             size_t vl);
-vfloat16m4_t __riscv_vfmsac(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmsac(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                             size_t vl);
 vfloat16m8_t __riscv_vfmsac(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_t vs2,
                             size_t vl);
-vfloat16m8_t __riscv_vfmsac(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmsac(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                             size_t vl);
 vfloat32mf2_t __riscv_vfmsac(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -1938,27 +1938,27 @@ vfloat64m8_t __riscv_vfmsac(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                             size_t vl);
 vfloat16mf4_t __riscv_vfnmsac(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmsac(vfloat16mf4_t vd, float16_t rs1,
-                              vfloat16mf4_t vs2, size_t vl);
+vfloat16mf4_t __riscv_vfnmsac(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
+                              size_t vl);
 vfloat16mf2_t __riscv_vfnmsac(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmsac(vfloat16mf2_t vd, float16_t rs1,
-                              vfloat16mf2_t vs2, size_t vl);
+vfloat16mf2_t __riscv_vfnmsac(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
+                              size_t vl);
 vfloat16m1_t __riscv_vfnmsac(vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsac(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfnmsac(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                              size_t vl);
 vfloat16m2_t __riscv_vfnmsac(vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsac(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfnmsac(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                              size_t vl);
 vfloat16m4_t __riscv_vfnmsac(vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsac(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfnmsac(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                              size_t vl);
 vfloat16m8_t __riscv_vfnmsac(vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsac(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfnmsac(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                              size_t vl);
 vfloat32mf2_t __riscv_vfnmsac(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -1998,27 +1998,27 @@ vfloat64m8_t __riscv_vfnmsac(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                              size_t vl);
 vfloat16mf4_t __riscv_vfmadd(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmadd(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2,
+vfloat16mf4_t __riscv_vfmadd(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
                              size_t vl);
 vfloat16mf2_t __riscv_vfmadd(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmadd(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2,
+vfloat16mf2_t __riscv_vfmadd(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
                              size_t vl);
 vfloat16m1_t __riscv_vfmadd(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_t vs2,
                             size_t vl);
-vfloat16m1_t __riscv_vfmadd(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmadd(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                             size_t vl);
 vfloat16m2_t __riscv_vfmadd(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_t vs2,
                             size_t vl);
-vfloat16m2_t __riscv_vfmadd(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmadd(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                             size_t vl);
 vfloat16m4_t __riscv_vfmadd(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_t vs2,
                             size_t vl);
-vfloat16m4_t __riscv_vfmadd(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmadd(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                             size_t vl);
 vfloat16m8_t __riscv_vfmadd(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_t vs2,
                             size_t vl);
-vfloat16m8_t __riscv_vfmadd(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmadd(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                             size_t vl);
 vfloat32mf2_t __riscv_vfmadd(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -2058,27 +2058,27 @@ vfloat64m8_t __riscv_vfmadd(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                             size_t vl);
 vfloat16mf4_t __riscv_vfnmadd(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmadd(vfloat16mf4_t vd, float16_t rs1,
-                              vfloat16mf4_t vs2, size_t vl);
+vfloat16mf4_t __riscv_vfnmadd(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
+                              size_t vl);
 vfloat16mf2_t __riscv_vfnmadd(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmadd(vfloat16mf2_t vd, float16_t rs1,
-                              vfloat16mf2_t vs2, size_t vl);
+vfloat16mf2_t __riscv_vfnmadd(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
+                              size_t vl);
 vfloat16m1_t __riscv_vfnmadd(vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmadd(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfnmadd(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                              size_t vl);
 vfloat16m2_t __riscv_vfnmadd(vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmadd(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfnmadd(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                              size_t vl);
 vfloat16m4_t __riscv_vfnmadd(vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmadd(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfnmadd(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                              size_t vl);
 vfloat16m8_t __riscv_vfnmadd(vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmadd(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfnmadd(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                              size_t vl);
 vfloat32mf2_t __riscv_vfnmadd(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -2118,27 +2118,27 @@ vfloat64m8_t __riscv_vfnmadd(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                              size_t vl);
 vfloat16mf4_t __riscv_vfmsub(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmsub(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2,
+vfloat16mf4_t __riscv_vfmsub(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
                              size_t vl);
 vfloat16mf2_t __riscv_vfmsub(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmsub(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2,
+vfloat16mf2_t __riscv_vfmsub(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
                              size_t vl);
 vfloat16m1_t __riscv_vfmsub(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_t vs2,
                             size_t vl);
-vfloat16m1_t __riscv_vfmsub(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmsub(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                             size_t vl);
 vfloat16m2_t __riscv_vfmsub(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_t vs2,
                             size_t vl);
-vfloat16m2_t __riscv_vfmsub(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmsub(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                             size_t vl);
 vfloat16m4_t __riscv_vfmsub(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_t vs2,
                             size_t vl);
-vfloat16m4_t __riscv_vfmsub(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmsub(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                             size_t vl);
 vfloat16m8_t __riscv_vfmsub(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_t vs2,
                             size_t vl);
-vfloat16m8_t __riscv_vfmsub(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmsub(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                             size_t vl);
 vfloat32mf2_t __riscv_vfmsub(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -2178,27 +2178,27 @@ vfloat64m8_t __riscv_vfmsub(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                             size_t vl);
 vfloat16mf4_t __riscv_vfnmsub(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmsub(vfloat16mf4_t vd, float16_t rs1,
-                              vfloat16mf4_t vs2, size_t vl);
+vfloat16mf4_t __riscv_vfnmsub(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
+                              size_t vl);
 vfloat16mf2_t __riscv_vfnmsub(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmsub(vfloat16mf2_t vd, float16_t rs1,
-                              vfloat16mf2_t vs2, size_t vl);
+vfloat16mf2_t __riscv_vfnmsub(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
+                              size_t vl);
 vfloat16m1_t __riscv_vfnmsub(vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsub(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfnmsub(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                              size_t vl);
 vfloat16m2_t __riscv_vfnmsub(vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsub(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfnmsub(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                              size_t vl);
 vfloat16m4_t __riscv_vfnmsub(vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsub(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfnmsub(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                              size_t vl);
 vfloat16m8_t __riscv_vfnmsub(vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsub(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfnmsub(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                              size_t vl);
 vfloat32mf2_t __riscv_vfnmsub(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -2239,27 +2239,27 @@ vfloat64m8_t __riscv_vfnmsub(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
 // masked functions
 vfloat16mf4_t __riscv_vfmacc(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmacc(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmacc(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                              vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmacc(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmacc(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmacc(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                              vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmacc(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                             vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmacc(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmacc(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                             vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmacc(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                             vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmacc(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmacc(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                             vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmacc(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                             vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmacc(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmacc(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                             vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmacc(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                             vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmacc(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmacc(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                             vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmacc(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -2299,27 +2299,27 @@ vfloat64m8_t __riscv_vfmacc(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                             vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmacc(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmacc(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmacc(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                               vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmacc(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmacc(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                               vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmacc(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmacc(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmacc(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                              vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmacc(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmacc(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmacc(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                              vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmacc(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmacc(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmacc(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                              vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmacc(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmacc(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmacc(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                              vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -2359,27 +2359,27 @@ vfloat64m8_t __riscv_vfnmacc(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                              vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmsac(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmsac(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsac(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                              vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsac(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmsac(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsac(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                              vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmsac(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                             vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmsac(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsac(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                             vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmsac(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                             vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmsac(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsac(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                             vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmsac(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                             vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmsac(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsac(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                             vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmsac(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                             vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmsac(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsac(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                             vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmsac(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -2419,27 +2419,27 @@ vfloat64m8_t __riscv_vfmsac(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                             vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmsac(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmsac(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsac(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                               vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmsac(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsac(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                               vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmsac(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsac(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsac(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                              vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmsac(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsac(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsac(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                              vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmsac(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsac(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsac(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                              vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmsac(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsac(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsac(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                              vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -2479,27 +2479,27 @@ vfloat64m8_t __riscv_vfnmsac(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                              vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmadd(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmadd(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmadd(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                              vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmadd(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmadd(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmadd(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                              vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmadd(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                             vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmadd(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmadd(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                             vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmadd(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                             vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmadd(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmadd(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                             vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmadd(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                             vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmadd(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmadd(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                             vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmadd(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                             vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmadd(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmadd(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                             vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmadd(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -2539,27 +2539,27 @@ vfloat64m8_t __riscv_vfmadd(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                             vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmadd(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmadd(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmadd(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                               vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmadd(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmadd(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                               vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmadd(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmadd(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmadd(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                              vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmadd(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmadd(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmadd(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                              vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmadd(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmadd(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmadd(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                              vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmadd(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmadd(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmadd(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                              vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -2599,27 +2599,27 @@ vfloat64m8_t __riscv_vfnmadd(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                              vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmsub(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmsub(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsub(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                              vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsub(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmsub(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsub(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                              vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmsub(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                             vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmsub(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsub(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                             vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmsub(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                             vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmsub(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsub(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                             vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmsub(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                             vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmsub(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsub(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                             vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmsub(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                             vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmsub(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsub(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                             vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmsub(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -2659,27 +2659,27 @@ vfloat64m8_t __riscv_vfmsub(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                             vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmsub(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmsub(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsub(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                               vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmsub(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsub(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                               vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmsub(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsub(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsub(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                              vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmsub(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsub(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsub(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                              vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmsub(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsub(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsub(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                              vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmsub(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsub(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsub(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                              vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -2719,27 +2719,27 @@ vfloat64m8_t __riscv_vfnmsub(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                              vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmacc(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmacc(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2,
+vfloat16mf4_t __riscv_vfmacc(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmacc(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmacc(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2,
+vfloat16mf2_t __riscv_vfmacc(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmacc(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmacc(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmacc(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmacc(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmacc(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmacc(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmacc(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmacc(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmacc(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmacc(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmacc(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmacc(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmacc(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -2779,27 +2779,27 @@ vfloat64m8_t __riscv_vfmacc(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmacc(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmacc(vfloat16mf4_t vd, float16_t rs1,
-                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat16mf4_t __riscv_vfnmacc(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmacc(vfloat16mf2_t vd, float16_t rs1,
-                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat16mf2_t __riscv_vfnmacc(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmacc(vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmacc(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfnmacc(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmacc(vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmacc(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfnmacc(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmacc(vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmacc(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfnmacc(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmacc(vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmacc(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfnmacc(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -2839,27 +2839,27 @@ vfloat64m8_t __riscv_vfnmacc(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmsac(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmsac(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2,
+vfloat16mf4_t __riscv_vfmsac(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsac(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmsac(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2,
+vfloat16mf2_t __riscv_vfmsac(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsac(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmsac(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmsac(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsac(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmsac(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmsac(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsac(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmsac(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmsac(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsac(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmsac(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmsac(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsac(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -2899,27 +2899,27 @@ vfloat64m8_t __riscv_vfmsac(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmsac(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmsac(vfloat16mf4_t vd, float16_t rs1,
-                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat16mf4_t __riscv_vfnmsac(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmsac(vfloat16mf2_t vd, float16_t rs1,
-                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat16mf2_t __riscv_vfnmsac(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsac(vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmsac(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfnmsac(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsac(vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmsac(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfnmsac(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsac(vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmsac(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfnmsac(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsac(vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmsac(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfnmsac(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -2959,27 +2959,27 @@ vfloat64m8_t __riscv_vfnmsac(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmadd(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmadd(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2,
+vfloat16mf4_t __riscv_vfmadd(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmadd(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmadd(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2,
+vfloat16mf2_t __riscv_vfmadd(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmadd(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmadd(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmadd(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmadd(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmadd(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmadd(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmadd(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmadd(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmadd(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmadd(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmadd(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmadd(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmadd(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -3019,27 +3019,27 @@ vfloat64m8_t __riscv_vfmadd(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmadd(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmadd(vfloat16mf4_t vd, float16_t rs1,
-                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat16mf4_t __riscv_vfnmadd(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmadd(vfloat16mf2_t vd, float16_t rs1,
-                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat16mf2_t __riscv_vfnmadd(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmadd(vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmadd(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfnmadd(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmadd(vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmadd(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfnmadd(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmadd(vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmadd(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfnmadd(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmadd(vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmadd(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfnmadd(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -3079,27 +3079,27 @@ vfloat64m8_t __riscv_vfnmadd(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmsub(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmsub(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2,
+vfloat16mf4_t __riscv_vfmsub(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsub(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmsub(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2,
+vfloat16mf2_t __riscv_vfmsub(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsub(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16m1_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmsub(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmsub(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsub(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16m2_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmsub(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmsub(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsub(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16m4_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmsub(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmsub(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsub(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16m8_t vs2,
                             unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmsub(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmsub(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsub(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -3139,27 +3139,27 @@ vfloat64m8_t __riscv_vfmsub(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                             unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmsub(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmsub(vfloat16mf4_t vd, float16_t rs1,
-                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat16mf4_t __riscv_vfnmsub(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmsub(vfloat16mf2_t vd, float16_t rs1,
-                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat16mf2_t __riscv_vfnmsub(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsub(vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmsub(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfnmsub(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsub(vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmsub(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfnmsub(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsub(vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmsub(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfnmsub(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsub(vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmsub(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfnmsub(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -3200,27 +3200,27 @@ vfloat64m8_t __riscv_vfnmsub(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
 // masked functions
 vfloat16mf4_t __riscv_vfmacc(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmacc(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmacc(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmacc(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmacc(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmacc(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmacc(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                             vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmacc(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmacc(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                             vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmacc(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                             vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmacc(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmacc(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                             vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmacc(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                             vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmacc(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmacc(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                             vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmacc(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                             vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmacc(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmacc(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                             vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmacc(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -3260,27 +3260,27 @@ vfloat64m8_t __riscv_vfmacc(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                             vfloat64m8_t vs2, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmacc(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmacc(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmacc(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmacc(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmacc(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmacc(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmacc(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmacc(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmacc(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmacc(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmacc(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmacc(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmacc(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmacc(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmacc(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmacc(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmacc(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -3320,27 +3320,27 @@ vfloat64m8_t __riscv_vfnmacc(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                              vfloat64m8_t vs2, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmsac(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmsac(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsac(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsac(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmsac(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsac(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsac(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                             vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmsac(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsac(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                             vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsac(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                             vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmsac(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsac(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                             vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsac(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                             vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmsac(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsac(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                             vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsac(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                             vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmsac(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsac(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                             vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsac(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -3380,27 +3380,27 @@ vfloat64m8_t __riscv_vfmsac(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                             vfloat64m8_t vs2, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmsac(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmsac(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsac(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmsac(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsac(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsac(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmsac(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsac(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsac(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmsac(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsac(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsac(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmsac(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsac(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsac(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmsac(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsac(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -3440,27 +3440,27 @@ vfloat64m8_t __riscv_vfnmsac(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                              vfloat64m8_t vs2, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmadd(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmadd(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmadd(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmadd(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmadd(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmadd(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmadd(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                             vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmadd(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmadd(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                             vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmadd(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                             vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmadd(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmadd(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                             vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmadd(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                             vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmadd(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmadd(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                             vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmadd(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                             vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmadd(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmadd(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                             vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmadd(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -3500,27 +3500,27 @@ vfloat64m8_t __riscv_vfmadd(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                             vfloat64m8_t vs2, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmadd(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmadd(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmadd(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmadd(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmadd(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmadd(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmadd(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmadd(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmadd(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmadd(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmadd(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmadd(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmadd(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmadd(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmadd(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmadd(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmadd(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -3560,27 +3560,27 @@ vfloat64m8_t __riscv_vfnmadd(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                              vfloat64m8_t vs2, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmsub(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmsub(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsub(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsub(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmsub(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsub(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsub(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                             vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmsub(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsub(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                             vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsub(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                             vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmsub(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsub(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                             vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsub(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                             vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmsub(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsub(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                             vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsub(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                             vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmsub(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsub(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                             vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsub(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -3620,27 +3620,27 @@ vfloat64m8_t __riscv_vfmsub(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                             vfloat64m8_t vs2, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmsub(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmsub(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsub(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmsub(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsub(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsub(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmsub(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsub(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsub(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmsub(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsub(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsub(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmsub(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsub(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsub(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmsub(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsub(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                              vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -3687,23 +3687,23 @@ vfloat64m8_t __riscv_vfnmsub(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 ----
 vfloat32mf2_t __riscv_vfwmacc(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwmacc(vfloat32mf2_t vd, float16_t vs1,
-                              vfloat16mf4_t vs2, size_t vl);
+vfloat32mf2_t __riscv_vfwmacc(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2,
+                              size_t vl);
 vfloat32m1_t __riscv_vfwmacc(vfloat32m1_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwmacc(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2,
+vfloat32m1_t __riscv_vfwmacc(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2,
                              size_t vl);
 vfloat32m2_t __riscv_vfwmacc(vfloat32m2_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmacc(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2,
+vfloat32m2_t __riscv_vfwmacc(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
                              size_t vl);
 vfloat32m4_t __riscv_vfwmacc(vfloat32m4_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmacc(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2,
+vfloat32m4_t __riscv_vfwmacc(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
                              size_t vl);
 vfloat32m8_t __riscv_vfwmacc(vfloat32m8_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmacc(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2,
+vfloat32m8_t __riscv_vfwmacc(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
                              size_t vl);
 vfloat64m1_t __riscv_vfwmacc(vfloat64m1_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -3723,23 +3723,23 @@ vfloat64m8_t __riscv_vfwmacc(vfloat64m8_t vd, float32_t vs1, vfloat32m4_t vs2,
                              size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmacc(vfloat32mf2_t vd, _Float16 vs1,
                                vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc(vfloat32m1_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwnmacc(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2,
+vfloat32m1_t __riscv_vfwnmacc(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2,
                               size_t vl);
 vfloat32m2_t __riscv_vfwnmacc(vfloat32m2_t vd, vfloat16m1_t vs1,
                               vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwnmacc(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2,
+vfloat32m2_t __riscv_vfwnmacc(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
                               size_t vl);
 vfloat32m4_t __riscv_vfwnmacc(vfloat32m4_t vd, vfloat16m2_t vs1,
                               vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwnmacc(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2,
+vfloat32m4_t __riscv_vfwnmacc(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
                               size_t vl);
 vfloat32m8_t __riscv_vfwnmacc(vfloat32m8_t vd, vfloat16m4_t vs1,
                               vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwnmacc(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2,
+vfloat32m8_t __riscv_vfwnmacc(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
                               size_t vl);
 vfloat64m1_t __riscv_vfwnmacc(vfloat64m1_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -3759,23 +3759,23 @@ vfloat64m8_t __riscv_vfwnmacc(vfloat64m8_t vd, float32_t vs1, vfloat32m4_t vs2,
                               size_t vl);
 vfloat32mf2_t __riscv_vfwmsac(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwmsac(vfloat32mf2_t vd, float16_t vs1,
-                              vfloat16mf4_t vs2, size_t vl);
+vfloat32mf2_t __riscv_vfwmsac(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2,
+                              size_t vl);
 vfloat32m1_t __riscv_vfwmsac(vfloat32m1_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwmsac(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2,
+vfloat32m1_t __riscv_vfwmsac(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2,
                              size_t vl);
 vfloat32m2_t __riscv_vfwmsac(vfloat32m2_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmsac(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2,
+vfloat32m2_t __riscv_vfwmsac(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
                              size_t vl);
 vfloat32m4_t __riscv_vfwmsac(vfloat32m4_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmsac(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2,
+vfloat32m4_t __riscv_vfwmsac(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
                              size_t vl);
 vfloat32m8_t __riscv_vfwmsac(vfloat32m8_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmsac(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2,
+vfloat32m8_t __riscv_vfwmsac(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
                              size_t vl);
 vfloat64m1_t __riscv_vfwmsac(vfloat64m1_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -3795,23 +3795,23 @@ vfloat64m8_t __riscv_vfwmsac(vfloat64m8_t vd, float32_t vs1, vfloat32m4_t vs2,
                              size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmsac(vfloat32mf2_t vd, _Float16 vs1,
                                vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac(vfloat32m1_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwnmsac(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2,
+vfloat32m1_t __riscv_vfwnmsac(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2,
                               size_t vl);
 vfloat32m2_t __riscv_vfwnmsac(vfloat32m2_t vd, vfloat16m1_t vs1,
                               vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwnmsac(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2,
+vfloat32m2_t __riscv_vfwnmsac(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
                               size_t vl);
 vfloat32m4_t __riscv_vfwnmsac(vfloat32m4_t vd, vfloat16m2_t vs1,
                               vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwnmsac(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2,
+vfloat32m4_t __riscv_vfwnmsac(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
                               size_t vl);
 vfloat32m8_t __riscv_vfwnmsac(vfloat32m8_t vd, vfloat16m4_t vs1,
                               vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwnmsac(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2,
+vfloat32m8_t __riscv_vfwnmsac(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
                               size_t vl);
 vfloat64m1_t __riscv_vfwnmsac(vfloat64m1_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -3832,23 +3832,23 @@ vfloat64m8_t __riscv_vfwnmsac(vfloat64m8_t vd, float32_t vs1, vfloat32m4_t vs2,
 // masked functions
 vfloat32mf2_t __riscv_vfwmacc(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwmacc(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmacc(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                               vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwmacc(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwmacc(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmacc(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                              vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwmacc(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmacc(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmacc(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                              vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwmacc(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmacc(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmacc(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                              vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwmacc(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmacc(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmacc(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                              vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwmacc(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -3868,23 +3868,23 @@ vfloat64m8_t __riscv_vfwmacc(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
                              vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc(vbool64_t vm, vfloat32mf2_t vd,
                                vfloat16mf4_t vs1, vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmacc(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwnmacc(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmacc(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                               vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                               vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwnmacc(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmacc(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                               vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                               vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwnmacc(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmacc(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                               vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                               vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwnmacc(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmacc(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                               vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -3904,23 +3904,23 @@ vfloat64m8_t __riscv_vfwnmacc(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
                               vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwmsac(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwmsac(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmsac(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                               vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwmsac(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwmsac(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmsac(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                              vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwmsac(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmsac(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmsac(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                              vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwmsac(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmsac(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmsac(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                              vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwmsac(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmsac(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmsac(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                              vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwmsac(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, size_t vl);
@@ -3940,23 +3940,23 @@ vfloat64m8_t __riscv_vfwmsac(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
                              vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac(vbool64_t vm, vfloat32mf2_t vd,
                                vfloat16mf4_t vs1, vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmsac(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwnmsac(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmsac(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                               vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                               vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwnmsac(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmsac(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                               vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                               vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwnmsac(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmsac(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                               vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                               vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwnmsac(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmsac(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                               vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, size_t vl);
@@ -3976,23 +3976,23 @@ vfloat64m8_t __riscv_vfwnmsac(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
                               vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwmacc(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmacc(vfloat32mf2_t vd, float16_t vs1,
-                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat32mf2_t __riscv_vfwmacc(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmacc(vfloat32m1_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmacc(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2,
+vfloat32m1_t __riscv_vfwmacc(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmacc(vfloat32m2_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmacc(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2,
+vfloat32m2_t __riscv_vfwmacc(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmacc(vfloat32m4_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmacc(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2,
+vfloat32m4_t __riscv_vfwmacc(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmacc(vfloat32m8_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmacc(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2,
+vfloat32m8_t __riscv_vfwmacc(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmacc(vfloat64m1_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -4012,23 +4012,23 @@ vfloat64m8_t __riscv_vfwmacc(vfloat64m8_t vd, float32_t vs1, vfloat32m4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmacc(vfloat32mf2_t vd, _Float16 vs1,
                                vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc(vfloat32m1_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwnmacc(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2,
+vfloat32m1_t __riscv_vfwnmacc(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2,
                               unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc(vfloat32m2_t vd, vfloat16m1_t vs1,
                               vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwnmacc(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2,
+vfloat32m2_t __riscv_vfwnmacc(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
                               unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc(vfloat32m4_t vd, vfloat16m2_t vs1,
                               vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwnmacc(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2,
+vfloat32m4_t __riscv_vfwnmacc(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
                               unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc(vfloat32m8_t vd, vfloat16m4_t vs1,
                               vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwnmacc(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2,
+vfloat32m8_t __riscv_vfwnmacc(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
                               unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc(vfloat64m1_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -4048,23 +4048,23 @@ vfloat64m8_t __riscv_vfwnmacc(vfloat64m8_t vd, float32_t vs1, vfloat32m4_t vs2,
                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmsac(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmsac(vfloat32mf2_t vd, float16_t vs1,
-                              vfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat32mf2_t __riscv_vfwmsac(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2,
+                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmsac(vfloat32m1_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmsac(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2,
+vfloat32m1_t __riscv_vfwmsac(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmsac(vfloat32m2_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmsac(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2,
+vfloat32m2_t __riscv_vfwmsac(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmsac(vfloat32m4_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmsac(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2,
+vfloat32m4_t __riscv_vfwmsac(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmsac(vfloat32m8_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmsac(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2,
+vfloat32m8_t __riscv_vfwmsac(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmsac(vfloat64m1_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -4084,23 +4084,23 @@ vfloat64m8_t __riscv_vfwmsac(vfloat64m8_t vd, float32_t vs1, vfloat32m4_t vs2,
                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmsac(vfloat32mf2_t vd, _Float16 vs1,
                                vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac(vfloat32m1_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwnmsac(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2,
+vfloat32m1_t __riscv_vfwnmsac(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2,
                               unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac(vfloat32m2_t vd, vfloat16m1_t vs1,
                               vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwnmsac(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2,
+vfloat32m2_t __riscv_vfwnmsac(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
                               unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac(vfloat32m4_t vd, vfloat16m2_t vs1,
                               vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwnmsac(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2,
+vfloat32m4_t __riscv_vfwnmsac(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
                               unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac(vfloat32m8_t vd, vfloat16m4_t vs1,
                               vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwnmsac(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2,
+vfloat32m8_t __riscv_vfwnmsac(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
                               unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac(vfloat64m1_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -4121,23 +4121,23 @@ vfloat64m8_t __riscv_vfwnmsac(vfloat64m8_t vd, float32_t vs1, vfloat32m4_t vs2,
 // masked functions
 vfloat32mf2_t __riscv_vfwmacc(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmacc(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmacc(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmacc(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmacc(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmacc(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmacc(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmacc(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmacc(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmacc(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmacc(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmacc(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmacc(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmacc(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmacc(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmacc(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -4158,23 +4158,23 @@ vfloat64m8_t __riscv_vfwmacc(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwnmacc(vbool64_t vm, vfloat32mf2_t vd,
                                vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmacc(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwnmacc(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmacc(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                               vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwnmacc(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmacc(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                               vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                               vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwnmacc(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmacc(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                               vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                               vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwnmacc(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmacc(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                               vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -4194,23 +4194,23 @@ vfloat64m8_t __riscv_vfwnmacc(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
                               vfloat32m4_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmsac(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmsac(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmsac(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                               vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmsac(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmsac(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmsac(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                              vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmsac(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmsac(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmsac(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                              vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmsac(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmsac(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmsac(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                              vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmsac(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmsac(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmsac(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                              vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmsac(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs1,
                              vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -4231,23 +4231,23 @@ vfloat64m8_t __riscv_vfwmsac(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwnmsac(vbool64_t vm, vfloat32mf2_t vd,
                                vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmsac(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwnmsac(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmsac(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                               vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                               vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwnmsac(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmsac(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                               vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                               vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwnmsac(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmsac(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                               vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                               vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwnmsac(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmsac(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                               vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs1,
                               vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -4479,17 +4479,17 @@ vfloat64m8_t __riscv_vfrec7(vbool8_t vm, vfloat64m8_t vs2, unsigned int frm,
 [,c]
 ----
 vfloat16mf4_t __riscv_vfmin(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfmin(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfmin(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmin(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfmin(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfmin(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmin(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfmin(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfmin(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmin(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfmin(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfmin(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmin(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfmin(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfmin(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmin(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfmin(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfmin(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmin(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmin(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfmin(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -4509,17 +4509,17 @@ vfloat64m4_t __riscv_vfmin(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfmin(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vfloat64m8_t __riscv_vfmin(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfmax(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfmax(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfmax(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmax(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfmax(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfmax(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmax(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfmax(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfmax(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmax(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfmax(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfmax(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmax(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfmax(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfmax(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmax(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfmax(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfmax(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmax(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmax(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfmax(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -4541,27 +4541,27 @@ vfloat64m8_t __riscv_vfmax(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 // masked functions
 vfloat16mf4_t __riscv_vfmin(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             size_t vl);
-vfloat16mf4_t __riscv_vfmin(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfmin(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16mf2_t __riscv_vfmin(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             size_t vl);
-vfloat16mf2_t __riscv_vfmin(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfmin(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16m1_t __riscv_vfmin(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            size_t vl);
-vfloat16m1_t __riscv_vfmin(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfmin(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m2_t __riscv_vfmin(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            size_t vl);
-vfloat16m2_t __riscv_vfmin(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfmin(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m4_t __riscv_vfmin(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            size_t vl);
-vfloat16m4_t __riscv_vfmin(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfmin(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m8_t __riscv_vfmin(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            size_t vl);
-vfloat16m8_t __riscv_vfmin(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfmin(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat32mf2_t __riscv_vfmin(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             size_t vl);
@@ -4601,27 +4601,27 @@ vfloat64m8_t __riscv_vfmin(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                            size_t vl);
 vfloat16mf4_t __riscv_vfmax(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                             size_t vl);
-vfloat16mf4_t __riscv_vfmax(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfmax(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16mf2_t __riscv_vfmax(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                             size_t vl);
-vfloat16mf2_t __riscv_vfmax(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfmax(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16m1_t __riscv_vfmax(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                            size_t vl);
-vfloat16m1_t __riscv_vfmax(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfmax(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m2_t __riscv_vfmax(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                            size_t vl);
-vfloat16m2_t __riscv_vfmax(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfmax(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m4_t __riscv_vfmax(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                            size_t vl);
-vfloat16m4_t __riscv_vfmax(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfmax(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat16m8_t __riscv_vfmax(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                            size_t vl);
-vfloat16m8_t __riscv_vfmax(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfmax(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                            size_t vl);
 vfloat32mf2_t __riscv_vfmax(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                             size_t vl);
@@ -4667,17 +4667,17 @@ vfloat64m8_t __riscv_vfmax(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
 [,c]
 ----
 vfloat16mf4_t __riscv_vfsgnj(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfsgnj(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfsgnj(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnj(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfsgnj(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfsgnj(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnj(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfsgnj(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfsgnj(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnj(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfsgnj(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfsgnj(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnj(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfsgnj(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfsgnj(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnj(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfsgnj(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfsgnj(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnj(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnj(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfsgnj(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -4697,17 +4697,17 @@ vfloat64m4_t __riscv_vfsgnj(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfsgnj(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vfloat64m8_t __riscv_vfsgnj(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnjn(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfsgnjn(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfsgnjn(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfsgnjn(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfsgnjn(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjn(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfsgnjn(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfsgnjn(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjn(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfsgnjn(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfsgnjn(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjn(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfsgnjn(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfsgnjn(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjn(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfsgnjn(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfsgnjn(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfsgnjn(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -4727,17 +4727,17 @@ vfloat64m4_t __riscv_vfsgnjn(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfsgnjn(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vfloat64m8_t __riscv_vfsgnjn(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnjx(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfsgnjx(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfsgnjx(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfsgnjx(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfsgnjx(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjx(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfsgnjx(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfsgnjx(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjx(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfsgnjx(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfsgnjx(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjx(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfsgnjx(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfsgnjx(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjx(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfsgnjx(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfsgnjx(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfsgnjx(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -4759,27 +4759,27 @@ vfloat64m8_t __riscv_vfsgnjx(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 // masked functions
 vfloat16mf4_t __riscv_vfsgnj(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                              size_t vl);
-vfloat16mf4_t __riscv_vfsgnj(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsgnj(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat16mf2_t __riscv_vfsgnj(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                              size_t vl);
-vfloat16mf2_t __riscv_vfsgnj(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsgnj(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat16m1_t __riscv_vfsgnj(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                             size_t vl);
-vfloat16m1_t __riscv_vfsgnj(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfsgnj(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16m2_t __riscv_vfsgnj(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                             size_t vl);
-vfloat16m2_t __riscv_vfsgnj(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfsgnj(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16m4_t __riscv_vfsgnj(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                             size_t vl);
-vfloat16m4_t __riscv_vfsgnj(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfsgnj(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat16m8_t __riscv_vfsgnj(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                             size_t vl);
-vfloat16m8_t __riscv_vfsgnj(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfsgnj(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                             size_t vl);
 vfloat32mf2_t __riscv_vfsgnj(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                              size_t vl);
@@ -4819,27 +4819,27 @@ vfloat64m8_t __riscv_vfsgnj(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                             size_t vl);
 vfloat16mf4_t __riscv_vfsgnjn(vbool64_t vm, vfloat16mf4_t vs2,
                               vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfsgnjn(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsgnjn(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn(vbool32_t vm, vfloat16mf2_t vs2,
                               vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfsgnjn(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsgnjn(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m1_t __riscv_vfsgnjn(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                              size_t vl);
-vfloat16m1_t __riscv_vfsgnjn(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfsgnjn(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat16m2_t __riscv_vfsgnjn(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                              size_t vl);
-vfloat16m2_t __riscv_vfsgnjn(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfsgnjn(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat16m4_t __riscv_vfsgnjn(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                              size_t vl);
-vfloat16m4_t __riscv_vfsgnjn(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfsgnjn(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat16m8_t __riscv_vfsgnjn(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                              size_t vl);
-vfloat16m8_t __riscv_vfsgnjn(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfsgnjn(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn(vbool64_t vm, vfloat32mf2_t vs2,
                               vfloat32mf2_t vs1, size_t vl);
@@ -4879,27 +4879,27 @@ vfloat64m8_t __riscv_vfsgnjn(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                              size_t vl);
 vfloat16mf4_t __riscv_vfsgnjx(vbool64_t vm, vfloat16mf4_t vs2,
                               vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfsgnjx(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfsgnjx(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx(vbool32_t vm, vfloat16mf2_t vs2,
                               vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfsgnjx(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfsgnjx(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m1_t __riscv_vfsgnjx(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                              size_t vl);
-vfloat16m1_t __riscv_vfsgnjx(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfsgnjx(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat16m2_t __riscv_vfsgnjx(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                              size_t vl);
-vfloat16m2_t __riscv_vfsgnjx(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfsgnjx(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat16m4_t __riscv_vfsgnjx(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                              size_t vl);
-vfloat16m4_t __riscv_vfsgnjx(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfsgnjx(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat16m8_t __riscv_vfsgnjx(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                              size_t vl);
-vfloat16m8_t __riscv_vfsgnjx(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfsgnjx(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                              size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx(vbool64_t vm, vfloat32mf2_t vs2,
                               vfloat32mf2_t vs1, size_t vl);
@@ -4983,17 +4983,17 @@ vfloat64m8_t __riscv_vfabs(vbool8_t vm, vfloat64m8_t vs2, size_t vl);
 [,c]
 ----
 vbool64_t __riscv_vmfeq(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vbool64_t __riscv_vmfeq(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vbool64_t __riscv_vmfeq(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfeq(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vbool32_t __riscv_vmfeq(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vbool32_t __riscv_vmfeq(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfeq(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vbool16_t __riscv_vmfeq(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vbool16_t __riscv_vmfeq(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfeq(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vbool8_t __riscv_vmfeq(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfeq(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfeq(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vbool4_t __riscv_vmfeq(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfeq(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfeq(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vbool2_t __riscv_vmfeq(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfeq(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfeq(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfeq(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vbool32_t __riscv_vmfeq(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -5013,17 +5013,17 @@ vbool16_t __riscv_vmfeq(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vbool8_t __riscv_vmfeq(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vbool8_t __riscv_vmfeq(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfne(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vbool64_t __riscv_vmfne(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vbool64_t __riscv_vmfne(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfne(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vbool32_t __riscv_vmfne(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vbool32_t __riscv_vmfne(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfne(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vbool16_t __riscv_vmfne(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vbool16_t __riscv_vmfne(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfne(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vbool8_t __riscv_vmfne(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfne(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfne(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vbool4_t __riscv_vmfne(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfne(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfne(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vbool2_t __riscv_vmfne(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfne(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfne(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfne(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vbool32_t __riscv_vmfne(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -5043,17 +5043,17 @@ vbool16_t __riscv_vmfne(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vbool8_t __riscv_vmfne(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vbool8_t __riscv_vmfne(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmflt(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vbool64_t __riscv_vmflt(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vbool64_t __riscv_vmflt(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmflt(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vbool32_t __riscv_vmflt(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vbool32_t __riscv_vmflt(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmflt(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vbool16_t __riscv_vmflt(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vbool16_t __riscv_vmflt(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmflt(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vbool8_t __riscv_vmflt(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmflt(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmflt(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vbool4_t __riscv_vmflt(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmflt(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmflt(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vbool2_t __riscv_vmflt(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmflt(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmflt(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmflt(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vbool32_t __riscv_vmflt(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -5073,17 +5073,17 @@ vbool16_t __riscv_vmflt(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vbool8_t __riscv_vmflt(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vbool8_t __riscv_vmflt(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfle(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vbool64_t __riscv_vmfle(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vbool64_t __riscv_vmfle(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfle(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vbool32_t __riscv_vmfle(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vbool32_t __riscv_vmfle(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfle(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vbool16_t __riscv_vmfle(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vbool16_t __riscv_vmfle(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfle(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vbool8_t __riscv_vmfle(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfle(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfle(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vbool4_t __riscv_vmfle(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfle(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfle(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vbool2_t __riscv_vmfle(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfle(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfle(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfle(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vbool32_t __riscv_vmfle(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -5103,17 +5103,17 @@ vbool16_t __riscv_vmfle(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vbool8_t __riscv_vmfle(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vbool8_t __riscv_vmfle(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfgt(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vbool64_t __riscv_vmfgt(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vbool64_t __riscv_vmfgt(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfgt(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vbool32_t __riscv_vmfgt(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vbool32_t __riscv_vmfgt(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfgt(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vbool16_t __riscv_vmfgt(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vbool16_t __riscv_vmfgt(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfgt(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vbool8_t __riscv_vmfgt(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfgt(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfgt(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vbool4_t __riscv_vmfgt(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfgt(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfgt(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vbool2_t __riscv_vmfgt(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfgt(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfgt(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfgt(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vbool32_t __riscv_vmfgt(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -5133,17 +5133,17 @@ vbool16_t __riscv_vmfgt(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vbool8_t __riscv_vmfgt(vfloat64m8_t vs2, vfloat64m8_t vs1, size_t vl);
 vbool8_t __riscv_vmfgt(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfge(vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
-vbool64_t __riscv_vmfge(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+vbool64_t __riscv_vmfge(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfge(vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
-vbool32_t __riscv_vmfge(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+vbool32_t __riscv_vmfge(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfge(vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
-vbool16_t __riscv_vmfge(vfloat16m1_t vs2, float16_t rs1, size_t vl);
+vbool16_t __riscv_vmfge(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfge(vfloat16m2_t vs2, vfloat16m2_t vs1, size_t vl);
-vbool8_t __riscv_vmfge(vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfge(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfge(vfloat16m4_t vs2, vfloat16m4_t vs1, size_t vl);
-vbool4_t __riscv_vmfge(vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfge(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfge(vfloat16m8_t vs2, vfloat16m8_t vs1, size_t vl);
-vbool2_t __riscv_vmfge(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfge(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfge(vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfge(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vbool32_t __riscv_vmfge(vfloat32m1_t vs2, vfloat32m1_t vs1, size_t vl);
@@ -5165,25 +5165,25 @@ vbool8_t __riscv_vmfge(vfloat64m8_t vs2, float64_t rs1, size_t vl);
 // masked functions
 vbool64_t __riscv_vmfeq(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                         size_t vl);
-vbool64_t __riscv_vmfeq(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfeq(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                         size_t vl);
 vbool32_t __riscv_vmfeq(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                         size_t vl);
-vbool32_t __riscv_vmfeq(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfeq(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                         size_t vl);
 vbool16_t __riscv_vmfeq(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                         size_t vl);
-vbool16_t __riscv_vmfeq(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vbool16_t __riscv_vmfeq(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                         size_t vl);
 vbool8_t __riscv_vmfeq(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                        size_t vl);
-vbool8_t __riscv_vmfeq(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfeq(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfeq(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                        size_t vl);
-vbool4_t __riscv_vmfeq(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfeq(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfeq(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                        size_t vl);
-vbool2_t __riscv_vmfeq(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfeq(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfeq(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                         size_t vl);
 vbool64_t __riscv_vmfeq(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
@@ -5219,25 +5219,25 @@ vbool8_t __riscv_vmfeq(vbool8_t vm, vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmfeq(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfne(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                         size_t vl);
-vbool64_t __riscv_vmfne(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfne(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                         size_t vl);
 vbool32_t __riscv_vmfne(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                         size_t vl);
-vbool32_t __riscv_vmfne(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfne(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                         size_t vl);
 vbool16_t __riscv_vmfne(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                         size_t vl);
-vbool16_t __riscv_vmfne(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vbool16_t __riscv_vmfne(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                         size_t vl);
 vbool8_t __riscv_vmfne(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                        size_t vl);
-vbool8_t __riscv_vmfne(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfne(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfne(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                        size_t vl);
-vbool4_t __riscv_vmfne(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfne(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfne(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                        size_t vl);
-vbool2_t __riscv_vmfne(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfne(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfne(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                         size_t vl);
 vbool64_t __riscv_vmfne(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
@@ -5273,25 +5273,25 @@ vbool8_t __riscv_vmfne(vbool8_t vm, vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmfne(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmflt(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                         size_t vl);
-vbool64_t __riscv_vmflt(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmflt(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                         size_t vl);
 vbool32_t __riscv_vmflt(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                         size_t vl);
-vbool32_t __riscv_vmflt(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmflt(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                         size_t vl);
 vbool16_t __riscv_vmflt(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                         size_t vl);
-vbool16_t __riscv_vmflt(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vbool16_t __riscv_vmflt(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                         size_t vl);
 vbool8_t __riscv_vmflt(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                        size_t vl);
-vbool8_t __riscv_vmflt(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmflt(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmflt(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                        size_t vl);
-vbool4_t __riscv_vmflt(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmflt(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmflt(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                        size_t vl);
-vbool2_t __riscv_vmflt(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmflt(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmflt(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                         size_t vl);
 vbool64_t __riscv_vmflt(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
@@ -5327,25 +5327,25 @@ vbool8_t __riscv_vmflt(vbool8_t vm, vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmflt(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfle(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                         size_t vl);
-vbool64_t __riscv_vmfle(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfle(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                         size_t vl);
 vbool32_t __riscv_vmfle(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                         size_t vl);
-vbool32_t __riscv_vmfle(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfle(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                         size_t vl);
 vbool16_t __riscv_vmfle(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                         size_t vl);
-vbool16_t __riscv_vmfle(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vbool16_t __riscv_vmfle(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                         size_t vl);
 vbool8_t __riscv_vmfle(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                        size_t vl);
-vbool8_t __riscv_vmfle(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfle(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfle(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                        size_t vl);
-vbool4_t __riscv_vmfle(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfle(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfle(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                        size_t vl);
-vbool2_t __riscv_vmfle(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfle(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfle(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                         size_t vl);
 vbool64_t __riscv_vmfle(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
@@ -5381,25 +5381,25 @@ vbool8_t __riscv_vmfle(vbool8_t vm, vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmfle(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfgt(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                         size_t vl);
-vbool64_t __riscv_vmfgt(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfgt(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                         size_t vl);
 vbool32_t __riscv_vmfgt(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                         size_t vl);
-vbool32_t __riscv_vmfgt(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfgt(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                         size_t vl);
 vbool16_t __riscv_vmfgt(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                         size_t vl);
-vbool16_t __riscv_vmfgt(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vbool16_t __riscv_vmfgt(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                         size_t vl);
 vbool8_t __riscv_vmfgt(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                        size_t vl);
-vbool8_t __riscv_vmfgt(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfgt(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfgt(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                        size_t vl);
-vbool4_t __riscv_vmfgt(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfgt(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfgt(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                        size_t vl);
-vbool2_t __riscv_vmfgt(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfgt(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfgt(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                         size_t vl);
 vbool64_t __riscv_vmfgt(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
@@ -5435,25 +5435,25 @@ vbool8_t __riscv_vmfgt(vbool8_t vm, vfloat64m8_t vs2, vfloat64m8_t vs1,
 vbool8_t __riscv_vmfgt(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vbool64_t __riscv_vmfge(vbool64_t vm, vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                         size_t vl);
-vbool64_t __riscv_vmfge(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vbool64_t __riscv_vmfge(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                         size_t vl);
 vbool32_t __riscv_vmfge(vbool32_t vm, vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                         size_t vl);
-vbool32_t __riscv_vmfge(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vbool32_t __riscv_vmfge(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                         size_t vl);
 vbool16_t __riscv_vmfge(vbool16_t vm, vfloat16m1_t vs2, vfloat16m1_t vs1,
                         size_t vl);
-vbool16_t __riscv_vmfge(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vbool16_t __riscv_vmfge(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                         size_t vl);
 vbool8_t __riscv_vmfge(vbool8_t vm, vfloat16m2_t vs2, vfloat16m2_t vs1,
                        size_t vl);
-vbool8_t __riscv_vmfge(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1, size_t vl);
+vbool8_t __riscv_vmfge(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfge(vbool4_t vm, vfloat16m4_t vs2, vfloat16m4_t vs1,
                        size_t vl);
-vbool4_t __riscv_vmfge(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1, size_t vl);
+vbool4_t __riscv_vmfge(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfge(vbool2_t vm, vfloat16m8_t vs2, vfloat16m8_t vs1,
                        size_t vl);
-vbool2_t __riscv_vmfge(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vbool2_t __riscv_vmfge(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfge(vbool64_t vm, vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                         size_t vl);
 vbool64_t __riscv_vmfge(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
@@ -5534,27 +5534,27 @@ vuint64m8_t __riscv_vfclass(vbool8_t vm, vfloat64m8_t vs2, size_t vl);
 ----
 vfloat16mf4_t __riscv_vmerge(vfloat16mf4_t vs2, vfloat16mf4_t vs1, vbool64_t v0,
                              size_t vl);
-vfloat16mf4_t __riscv_vfmerge(vfloat16mf4_t vs2, float16_t rs1, vbool64_t v0,
+vfloat16mf4_t __riscv_vfmerge(vfloat16mf4_t vs2, _Float16 rs1, vbool64_t v0,
                               size_t vl);
 vfloat16mf2_t __riscv_vmerge(vfloat16mf2_t vs2, vfloat16mf2_t vs1, vbool32_t v0,
                              size_t vl);
-vfloat16mf2_t __riscv_vfmerge(vfloat16mf2_t vs2, float16_t rs1, vbool32_t v0,
+vfloat16mf2_t __riscv_vfmerge(vfloat16mf2_t vs2, _Float16 rs1, vbool32_t v0,
                               size_t vl);
 vfloat16m1_t __riscv_vmerge(vfloat16m1_t vs2, vfloat16m1_t vs1, vbool16_t v0,
                             size_t vl);
-vfloat16m1_t __riscv_vfmerge(vfloat16m1_t vs2, float16_t rs1, vbool16_t v0,
+vfloat16m1_t __riscv_vfmerge(vfloat16m1_t vs2, _Float16 rs1, vbool16_t v0,
                              size_t vl);
 vfloat16m2_t __riscv_vmerge(vfloat16m2_t vs2, vfloat16m2_t vs1, vbool8_t v0,
                             size_t vl);
-vfloat16m2_t __riscv_vfmerge(vfloat16m2_t vs2, float16_t rs1, vbool8_t v0,
+vfloat16m2_t __riscv_vfmerge(vfloat16m2_t vs2, _Float16 rs1, vbool8_t v0,
                              size_t vl);
 vfloat16m4_t __riscv_vmerge(vfloat16m4_t vs2, vfloat16m4_t vs1, vbool4_t v0,
                             size_t vl);
-vfloat16m4_t __riscv_vfmerge(vfloat16m4_t vs2, float16_t rs1, vbool4_t v0,
+vfloat16m4_t __riscv_vfmerge(vfloat16m4_t vs2, _Float16 rs1, vbool4_t v0,
                              size_t vl);
 vfloat16m8_t __riscv_vmerge(vfloat16m8_t vs2, vfloat16m8_t vs1, vbool2_t v0,
                             size_t vl);
-vfloat16m8_t __riscv_vfmerge(vfloat16m8_t vs2, float16_t rs1, vbool2_t v0,
+vfloat16m8_t __riscv_vfmerge(vfloat16m8_t vs2, _Float16 rs1, vbool2_t v0,
                              size_t vl);
 vfloat32mf2_t __riscv_vmerge(vfloat32mf2_t vs2, vfloat32mf2_t vs1, vbool64_t v0,
                              size_t vl);

--- a/auto-generated/overloaded_intrinsic_funcs/06_vector_mask_instructions.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs/06_vector_mask_instructions.adoc
@@ -83,21 +83,21 @@ vbool64_t __riscv_vmnot(vbool64_t vs, size_t vl);
 
 [,c]
 ----
-unsigned long __riscv_vcpop(vbool1_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool2_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool4_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool8_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool16_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool32_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool64_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool1_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool2_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool4_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool8_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool16_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool32_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool64_t vs2, size_t vl);
 // masked functions
-unsigned long __riscv_vcpop(vbool1_t vm, vbool1_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool2_t vm, vbool2_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool4_t vm, vbool4_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool8_t vm, vbool8_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool16_t vm, vbool16_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool32_t vm, vbool32_t vs2, size_t vl);
-unsigned long __riscv_vcpop(vbool64_t vm, vbool64_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool1_t vm, vbool1_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool2_t vm, vbool2_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool4_t vm, vbool4_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool8_t vm, vbool8_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool16_t vm, vbool16_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool32_t vm, vbool32_t vs2, size_t vl);
+unsigned int __riscv_vcpop(vbool64_t vm, vbool64_t vs2, size_t vl);
 ----
 
 [[overloaded-vfirst-find-first-set-mask-bit]]
@@ -105,21 +105,21 @@ unsigned long __riscv_vcpop(vbool64_t vm, vbool64_t vs2, size_t vl);
 
 [,c]
 ----
-long __riscv_vfirst(vbool1_t vs2, size_t vl);
-long __riscv_vfirst(vbool2_t vs2, size_t vl);
-long __riscv_vfirst(vbool4_t vs2, size_t vl);
-long __riscv_vfirst(vbool8_t vs2, size_t vl);
-long __riscv_vfirst(vbool16_t vs2, size_t vl);
-long __riscv_vfirst(vbool32_t vs2, size_t vl);
-long __riscv_vfirst(vbool64_t vs2, size_t vl);
+int __riscv_vfirst(vbool1_t vs2, size_t vl);
+int __riscv_vfirst(vbool2_t vs2, size_t vl);
+int __riscv_vfirst(vbool4_t vs2, size_t vl);
+int __riscv_vfirst(vbool8_t vs2, size_t vl);
+int __riscv_vfirst(vbool16_t vs2, size_t vl);
+int __riscv_vfirst(vbool32_t vs2, size_t vl);
+int __riscv_vfirst(vbool64_t vs2, size_t vl);
 // masked functions
-long __riscv_vfirst(vbool1_t vm, vbool1_t vs2, size_t vl);
-long __riscv_vfirst(vbool2_t vm, vbool2_t vs2, size_t vl);
-long __riscv_vfirst(vbool4_t vm, vbool4_t vs2, size_t vl);
-long __riscv_vfirst(vbool8_t vm, vbool8_t vs2, size_t vl);
-long __riscv_vfirst(vbool16_t vm, vbool16_t vs2, size_t vl);
-long __riscv_vfirst(vbool32_t vm, vbool32_t vs2, size_t vl);
-long __riscv_vfirst(vbool64_t vm, vbool64_t vs2, size_t vl);
+int __riscv_vfirst(vbool1_t vm, vbool1_t vs2, size_t vl);
+int __riscv_vfirst(vbool2_t vm, vbool2_t vs2, size_t vl);
+int __riscv_vfirst(vbool4_t vm, vbool4_t vs2, size_t vl);
+int __riscv_vfirst(vbool8_t vm, vbool8_t vs2, size_t vl);
+int __riscv_vfirst(vbool16_t vm, vbool16_t vs2, size_t vl);
+int __riscv_vfirst(vbool32_t vm, vbool32_t vs2, size_t vl);
+int __riscv_vfirst(vbool64_t vm, vbool64_t vs2, size_t vl);
 ----
 
 [[overloaded-vmsbfm-set-before-first-mask-bit]]

--- a/auto-generated/overloaded_intrinsic_funcs/07_vector_permutation_instructions.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs/07_vector_permutation_instructions.adoc
@@ -6,12 +6,12 @@
 
 [,c]
 ----
-float16_t __riscv_vfmv_f(vfloat16mf4_t vs1);
-float16_t __riscv_vfmv_f(vfloat16mf2_t vs1);
-float16_t __riscv_vfmv_f(vfloat16m1_t vs1);
-float16_t __riscv_vfmv_f(vfloat16m2_t vs1);
-float16_t __riscv_vfmv_f(vfloat16m4_t vs1);
-float16_t __riscv_vfmv_f(vfloat16m8_t vs1);
+_Float16 __riscv_vfmv_f(vfloat16mf4_t vs1);
+_Float16 __riscv_vfmv_f(vfloat16mf2_t vs1);
+_Float16 __riscv_vfmv_f(vfloat16m1_t vs1);
+_Float16 __riscv_vfmv_f(vfloat16m2_t vs1);
+_Float16 __riscv_vfmv_f(vfloat16m4_t vs1);
+_Float16 __riscv_vfmv_f(vfloat16m8_t vs1);
 float32_t __riscv_vfmv_f(vfloat32mf2_t vs1);
 float32_t __riscv_vfmv_f(vfloat32m1_t vs1);
 float32_t __riscv_vfmv_f(vfloat32m2_t vs1);
@@ -493,12 +493,12 @@ vuint64m8_t __riscv_vslidedown(vbool8_t vm, vuint64m8_t vs2, size_t rs1,
 
 [,c]
 ----
-vfloat16mf4_t __riscv_vfslide1up(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
-vfloat16mf2_t __riscv_vfslide1up(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
-vfloat16m1_t __riscv_vfslide1up(vfloat16m1_t vs2, float16_t rs1, size_t vl);
-vfloat16m2_t __riscv_vfslide1up(vfloat16m2_t vs2, float16_t rs1, size_t vl);
-vfloat16m4_t __riscv_vfslide1up(vfloat16m4_t vs2, float16_t rs1, size_t vl);
-vfloat16m8_t __riscv_vfslide1up(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfslide1up(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
+vfloat16mf2_t __riscv_vfslide1up(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m1_t __riscv_vfslide1up(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
+vfloat16m2_t __riscv_vfslide1up(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m4_t __riscv_vfslide1up(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
+vfloat16m8_t __riscv_vfslide1up(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfslide1up(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfslide1up(vfloat32m1_t vs2, float32_t rs1, size_t vl);
 vfloat32m2_t __riscv_vfslide1up(vfloat32m2_t vs2, float32_t rs1, size_t vl);
@@ -508,12 +508,12 @@ vfloat64m1_t __riscv_vfslide1up(vfloat64m1_t vs2, float64_t rs1, size_t vl);
 vfloat64m2_t __riscv_vfslide1up(vfloat64m2_t vs2, float64_t rs1, size_t vl);
 vfloat64m4_t __riscv_vfslide1up(vfloat64m4_t vs2, float64_t rs1, size_t vl);
 vfloat64m8_t __riscv_vfslide1up(vfloat64m8_t vs2, float64_t rs1, size_t vl);
-vfloat16mf4_t __riscv_vfslide1down(vfloat16mf4_t vs2, float16_t rs1, size_t vl);
-vfloat16mf2_t __riscv_vfslide1down(vfloat16mf2_t vs2, float16_t rs1, size_t vl);
-vfloat16m1_t __riscv_vfslide1down(vfloat16m1_t vs2, float16_t rs1, size_t vl);
-vfloat16m2_t __riscv_vfslide1down(vfloat16m2_t vs2, float16_t rs1, size_t vl);
-vfloat16m4_t __riscv_vfslide1down(vfloat16m4_t vs2, float16_t rs1, size_t vl);
-vfloat16m8_t __riscv_vfslide1down(vfloat16m8_t vs2, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfslide1down(vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
+vfloat16mf2_t __riscv_vfslide1down(vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m1_t __riscv_vfslide1down(vfloat16m1_t vs2, _Float16 rs1, size_t vl);
+vfloat16m2_t __riscv_vfslide1down(vfloat16m2_t vs2, _Float16 rs1, size_t vl);
+vfloat16m4_t __riscv_vfslide1down(vfloat16m4_t vs2, _Float16 rs1, size_t vl);
+vfloat16m8_t __riscv_vfslide1down(vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfslide1down(vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfslide1down(vfloat32m1_t vs2, float32_t rs1, size_t vl);
 vfloat32m2_t __riscv_vfslide1down(vfloat32m2_t vs2, float32_t rs1, size_t vl);
@@ -612,17 +612,17 @@ vuint64m2_t __riscv_vslide1down(vuint64m2_t vs2, uint64_t rs1, size_t vl);
 vuint64m4_t __riscv_vslide1down(vuint64m4_t vs2, uint64_t rs1, size_t vl);
 vuint64m8_t __riscv_vslide1down(vuint64m8_t vs2, uint64_t rs1, size_t vl);
 // masked functions
-vfloat16mf4_t __riscv_vfslide1up(vbool64_t vm, vfloat16mf4_t vs2, float16_t rs1,
+vfloat16mf4_t __riscv_vfslide1up(vbool64_t vm, vfloat16mf4_t vs2, _Float16 rs1,
                                  size_t vl);
-vfloat16mf2_t __riscv_vfslide1up(vbool32_t vm, vfloat16mf2_t vs2, float16_t rs1,
+vfloat16mf2_t __riscv_vfslide1up(vbool32_t vm, vfloat16mf2_t vs2, _Float16 rs1,
                                  size_t vl);
-vfloat16m1_t __riscv_vfslide1up(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfslide1up(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                                 size_t vl);
-vfloat16m2_t __riscv_vfslide1up(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfslide1up(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                 size_t vl);
-vfloat16m4_t __riscv_vfslide1up(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfslide1up(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                 size_t vl);
-vfloat16m8_t __riscv_vfslide1up(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfslide1up(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                 size_t vl);
 vfloat32mf2_t __riscv_vfslide1up(vbool64_t vm, vfloat32mf2_t vs2, float32_t rs1,
                                  size_t vl);
@@ -643,16 +643,16 @@ vfloat64m4_t __riscv_vfslide1up(vbool16_t vm, vfloat64m4_t vs2, float64_t rs1,
 vfloat64m8_t __riscv_vfslide1up(vbool8_t vm, vfloat64m8_t vs2, float64_t rs1,
                                 size_t vl);
 vfloat16mf4_t __riscv_vfslide1down(vbool64_t vm, vfloat16mf4_t vs2,
-                                   float16_t rs1, size_t vl);
+                                   _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfslide1down(vbool32_t vm, vfloat16mf2_t vs2,
-                                   float16_t rs1, size_t vl);
-vfloat16m1_t __riscv_vfslide1down(vbool16_t vm, vfloat16m1_t vs2, float16_t rs1,
+                                   _Float16 rs1, size_t vl);
+vfloat16m1_t __riscv_vfslide1down(vbool16_t vm, vfloat16m1_t vs2, _Float16 rs1,
                                   size_t vl);
-vfloat16m2_t __riscv_vfslide1down(vbool8_t vm, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfslide1down(vbool8_t vm, vfloat16m2_t vs2, _Float16 rs1,
                                   size_t vl);
-vfloat16m4_t __riscv_vfslide1down(vbool4_t vm, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfslide1down(vbool4_t vm, vfloat16m4_t vs2, _Float16 rs1,
                                   size_t vl);
-vfloat16m8_t __riscv_vfslide1down(vbool2_t vm, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfslide1down(vbool2_t vm, vfloat16m8_t vs2, _Float16 rs1,
                                   size_t vl);
 vfloat32mf2_t __riscv_vfslide1down(vbool64_t vm, vfloat32mf2_t vs2,
                                    float32_t rs1, size_t vl);

--- a/auto-generated/policy_funcs/api-testing/vfadd.c
+++ b/auto-generated/policy_funcs/api-testing/vfadd.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfadd_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfadd_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfadd_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfadd_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfadd_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfadd_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfadd_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfadd_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfadd_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
+                                     vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfadd_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfadd_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfadd_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfadd_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfadd_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfadd_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfadd_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfadd_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfadd_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -546,8 +546,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                    vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -558,8 +557,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                    vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -570,8 +568,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                    vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -582,8 +579,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                    vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -701,7 +697,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -711,7 +707,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -721,7 +717,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfadd_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +727,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfadd_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -741,7 +737,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfadd_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -751,7 +747,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfadd_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -852,7 +848,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfadd_vf_f16mf4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +860,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfadd_vf_f16mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +872,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfadd_vf_f16m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +884,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfadd_vf_f16m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +896,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfadd_vf_f16m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +908,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfadd_vf_f16m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1028,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfadd_vf_f16mf4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1040,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfadd_vf_f16mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1052,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfadd_vf_f16m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1064,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfadd_vf_f16m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1076,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfadd_vf_f16m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1088,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfadd_vf_f16m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1212,7 +1208,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfadd_vf_f16mf4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1224,7 +1220,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfadd_vf_f16mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1236,7 +1232,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfadd_vf_f16m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1248,7 +1244,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfadd_vf_f16m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1256,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfadd_vf_f16m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1268,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfadd_vf_f16m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfdiv.c
+++ b/auto-generated/policy_funcs/api-testing/vfdiv.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfdiv_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfdiv_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfdiv_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfdiv_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfdiv_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfdiv_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfdiv_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfdiv_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfdiv_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfdiv_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfdiv_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
+                                     vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfdiv_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfdiv_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfdiv_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfdiv_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfdiv_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfdiv_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfdiv_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfdiv_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfdiv_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -546,8 +546,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfdiv_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                    vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -558,8 +557,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfdiv_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                    vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -570,8 +568,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfdiv_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                    vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -582,8 +579,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfdiv_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                    vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -701,7 +697,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -711,7 +707,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -721,7 +717,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfdiv_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +727,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfdiv_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -741,7 +737,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfdiv_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -751,7 +747,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfdiv_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -852,7 +848,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +860,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +872,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfdiv_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfdiv_vf_f16m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +884,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfdiv_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfdiv_vf_f16m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +896,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfdiv_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfdiv_vf_f16m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +908,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfdiv_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfdiv_vf_f16m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1028,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1040,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1052,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfdiv_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfdiv_vf_f16m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1064,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfdiv_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfdiv_vf_f16m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1076,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfdiv_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfdiv_vf_f16m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1088,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfdiv_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfdiv_vf_f16m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1212,7 +1208,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1224,7 +1220,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1236,7 +1232,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfdiv_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfdiv_vf_f16m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1248,7 +1244,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfdiv_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfdiv_vf_f16m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1256,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfdiv_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfdiv_vf_f16m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1268,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfdiv_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfdiv_vf_f16m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfmacc.c
+++ b/auto-generated/policy_funcs/api-testing/vfmacc.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmacc_vv_f16mf4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmacc_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_tu(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmacc_vv_f16mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmacc_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_tu(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmacc_vv_f16m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmacc_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m1_tu(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmacc_vv_f16m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmacc_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m2_tu(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmacc_vv_f16m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmacc_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m4_tu(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmacc_vv_f16m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmacc_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m8_tu(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmacc_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                        float16_t rs1, vfloat16mf4_t vs2,
+                                        _Float16 rs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_tum(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmacc_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                        float16_t rs1, vfloat16mf2_t vs2,
+                                        _Float16 rs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_tum(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmacc_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                      float16_t rs1, vfloat16m1_t vs2,
+                                      _Float16 rs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfmacc_vf_f16m1_tum(vm, vd, rs1, vs2, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmacc_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                      float16_t rs1, vfloat16m2_t vs2,
+                                      _Float16 rs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfmacc_vf_f16m2_tum(vm, vd, rs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmacc_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                      float16_t rs1, vfloat16m4_t vs2,
+                                      _Float16 rs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfmacc_vf_f16m4_tum(vm, vd, rs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmacc_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                      float16_t rs1, vfloat16m8_t vs2,
+                                      _Float16 rs1, vfloat16m8_t vs2,
                                       size_t vl) {
   return __riscv_vfmacc_vf_f16m8_tum(vm, vd, rs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmacc_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmacc_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmacc_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc_vf_f16m1_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmacc_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc_vf_f16m2_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmacc_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc_vf_f16m4_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmacc_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc_vf_f16m8_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmacc_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                       float16_t rs1, vfloat16mf4_t vs2,
+                                       _Float16 rs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_mu(vm, vd, rs1, vs2, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmacc_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                       float16_t rs1, vfloat16mf2_t vs2,
+                                       _Float16 rs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_mu(vm, vd, rs1, vs2, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmacc_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                     float16_t rs1, vfloat16m1_t vs2,
+                                     _Float16 rs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfmacc_vf_f16m1_mu(vm, vd, rs1, vs2, vl);
 }
@@ -557,9 +557,8 @@ vfloat16m2_t test_vfmacc_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfmacc_vv_f16m2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                     float16_t rs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -569,9 +568,8 @@ vfloat16m4_t test_vfmacc_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfmacc_vv_f16m4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                     float16_t rs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -581,9 +579,8 @@ vfloat16m8_t test_vfmacc_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfmacc_vv_f16m8_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                     float16_t rs1, vfloat16m8_t vs2,
-                                     size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
+                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m8_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -700,7 +697,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmacc_vv_f16mf4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -710,7 +707,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmacc_vv_f16mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -720,7 +717,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmacc_vv_f16m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m1_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -730,7 +727,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmacc_vv_f16m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -740,7 +737,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmacc_vv_f16m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -750,7 +747,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmacc_vv_f16m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m8_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -852,7 +849,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +861,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +873,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmacc_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfmacc_vf_f16m1_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +885,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmacc_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfmacc_vf_f16m2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +897,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmacc_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfmacc_vf_f16m4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +909,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmacc_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl) {
   return __riscv_vfmacc_vf_f16m8_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1033,7 +1030,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1047,7 +1044,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1060,7 +1057,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmacc_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfmacc_vf_f16m1_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1072,7 +1069,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmacc_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfmacc_vf_f16m2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1084,7 +1081,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmacc_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfmacc_vf_f16m4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1096,7 +1093,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmacc_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl) {
   return __riscv_vfmacc_vf_f16m8_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1218,7 +1215,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1230,7 +1227,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1242,7 +1239,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmacc_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfmacc_vf_f16m1_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1254,7 +1251,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmacc_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfmacc_vf_f16m2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1266,7 +1263,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmacc_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfmacc_vf_f16m4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1278,7 +1275,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmacc_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfmacc_vf_f16m8_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfmadd.c
+++ b/auto-generated/policy_funcs/api-testing/vfmadd.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmadd_vv_f16mf4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmadd_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_tu(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmadd_vv_f16mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmadd_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_tu(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmadd_vv_f16m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmadd_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m1_tu(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmadd_vv_f16m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmadd_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m2_tu(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmadd_vv_f16m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmadd_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m4_tu(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmadd_vv_f16m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmadd_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m8_tu(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                        float16_t rs1, vfloat16mf4_t vs2,
+                                        _Float16 rs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_tum(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                        float16_t rs1, vfloat16mf2_t vs2,
+                                        _Float16 rs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_tum(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                      float16_t rs1, vfloat16m1_t vs2,
+                                      _Float16 rs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfmadd_vf_f16m1_tum(vm, vd, rs1, vs2, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                      float16_t rs1, vfloat16m2_t vs2,
+                                      _Float16 rs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfmadd_vf_f16m2_tum(vm, vd, rs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                      float16_t rs1, vfloat16m4_t vs2,
+                                      _Float16 rs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfmadd_vf_f16m4_tum(vm, vd, rs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                      float16_t rs1, vfloat16m8_t vs2,
+                                      _Float16 rs1, vfloat16m8_t vs2,
                                       size_t vl) {
   return __riscv_vfmadd_vf_f16m8_tum(vm, vd, rs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd_vf_f16m1_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd_vf_f16m2_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd_vf_f16m4_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd_vf_f16m8_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                       float16_t rs1, vfloat16mf4_t vs2,
+                                       _Float16 rs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_mu(vm, vd, rs1, vs2, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                       float16_t rs1, vfloat16mf2_t vs2,
+                                       _Float16 rs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_mu(vm, vd, rs1, vs2, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                     float16_t rs1, vfloat16m1_t vs2,
+                                     _Float16 rs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfmadd_vf_f16m1_mu(vm, vd, rs1, vs2, vl);
 }
@@ -557,9 +557,8 @@ vfloat16m2_t test_vfmadd_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfmadd_vv_f16m2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                     float16_t rs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -569,9 +568,8 @@ vfloat16m4_t test_vfmadd_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfmadd_vv_f16m4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                     float16_t rs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -581,9 +579,8 @@ vfloat16m8_t test_vfmadd_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfmadd_vv_f16m8_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                     float16_t rs1, vfloat16m8_t vs2,
-                                     size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
+                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m8_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -700,7 +697,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmadd_vv_f16mf4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -710,7 +707,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmadd_vv_f16mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -720,7 +717,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmadd_vv_f16m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m1_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -730,7 +727,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmadd_vv_f16m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -740,7 +737,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmadd_vv_f16m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -750,7 +747,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmadd_vv_f16m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m8_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -852,7 +849,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +861,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +873,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfmadd_vf_f16m1_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +885,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfmadd_vf_f16m2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +897,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfmadd_vf_f16m4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +909,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl) {
   return __riscv_vfmadd_vf_f16m8_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1033,7 +1030,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1047,7 +1044,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1060,7 +1057,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfmadd_vf_f16m1_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1072,7 +1069,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfmadd_vf_f16m2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1084,7 +1081,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfmadd_vf_f16m4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1096,7 +1093,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl) {
   return __riscv_vfmadd_vf_f16m8_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1218,7 +1215,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1230,7 +1227,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1242,7 +1239,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfmadd_vf_f16m1_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1254,7 +1251,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfmadd_vf_f16m2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1266,7 +1263,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfmadd_vf_f16m4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1278,7 +1275,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfmadd_vf_f16m8_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfmax.c
+++ b/auto-generated/policy_funcs/api-testing/vfmax.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfmax_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfmax_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat16m1_t test_vfmax_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfmax_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfmax_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfmax_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfmax_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmax_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmax_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmax_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmax_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfmax_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmax_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmax_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmax_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmax_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmax_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmax_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmax_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
+                                     vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmax_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmax_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmax_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmax_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmax_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfmax_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmax_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmax_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmax_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmax_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmax_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmax_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmax_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmax_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmax_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmax_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmax_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmax_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -546,8 +546,7 @@ vfloat16m1_t test_vfmax_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmax_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                    vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -558,8 +557,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmax_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                    vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -570,8 +568,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmax_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                    vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -582,8 +579,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmax_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                    vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/api-testing/vfmerge.c
+++ b/auto-generated/policy_funcs/api-testing/vfmerge.c
@@ -6,34 +6,34 @@ typedef float float32_t;
 typedef double float64_t;
 
 vfloat16mf4_t test_vfmerge_vfm_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                         float16_t rs1, vbool64_t v0,
+                                         _Float16 rs1, vbool64_t v0,
                                          size_t vl) {
   return __riscv_vfmerge_vfm_f16mf4_tu(vd, vs2, rs1, v0, vl);
 }
 
 vfloat16mf2_t test_vfmerge_vfm_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                         float16_t rs1, vbool32_t v0,
+                                         _Float16 rs1, vbool32_t v0,
                                          size_t vl) {
   return __riscv_vfmerge_vfm_f16mf2_tu(vd, vs2, rs1, v0, vl);
 }
 
 vfloat16m1_t test_vfmerge_vfm_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                       float16_t rs1, vbool16_t v0, size_t vl) {
+                                       _Float16 rs1, vbool16_t v0, size_t vl) {
   return __riscv_vfmerge_vfm_f16m1_tu(vd, vs2, rs1, v0, vl);
 }
 
 vfloat16m2_t test_vfmerge_vfm_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                       float16_t rs1, vbool8_t v0, size_t vl) {
+                                       _Float16 rs1, vbool8_t v0, size_t vl) {
   return __riscv_vfmerge_vfm_f16m2_tu(vd, vs2, rs1, v0, vl);
 }
 
 vfloat16m4_t test_vfmerge_vfm_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                       float16_t rs1, vbool4_t v0, size_t vl) {
+                                       _Float16 rs1, vbool4_t v0, size_t vl) {
   return __riscv_vfmerge_vfm_f16m4_tu(vd, vs2, rs1, v0, vl);
 }
 
 vfloat16m8_t test_vfmerge_vfm_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                       float16_t rs1, vbool2_t v0, size_t vl) {
+                                       _Float16 rs1, vbool2_t v0, size_t vl) {
   return __riscv_vfmerge_vfm_f16m8_tu(vd, vs2, rs1, v0, vl);
 }
 

--- a/auto-generated/policy_funcs/api-testing/vfmin.c
+++ b/auto-generated/policy_funcs/api-testing/vfmin.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfmin_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfmin_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat16m1_t test_vfmin_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfmin_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfmin_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfmin_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfmin_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmin_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmin_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmin_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmin_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfmin_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmin_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmin_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmin_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmin_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmin_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmin_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmin_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
+                                     vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmin_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmin_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmin_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmin_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmin_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfmin_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmin_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmin_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmin_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmin_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmin_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmin_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmin_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmin_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmin_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmin_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmin_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmin_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -546,8 +546,7 @@ vfloat16m1_t test_vfmin_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmin_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                    vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -558,8 +557,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmin_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                    vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -570,8 +568,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmin_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                    vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -582,8 +579,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmin_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                    vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/api-testing/vfmsac.c
+++ b/auto-generated/policy_funcs/api-testing/vfmsac.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmsac_vv_f16mf4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmsac_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_tu(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmsac_vv_f16mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmsac_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_tu(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmsac_vv_f16m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmsac_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m1_tu(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmsac_vv_f16m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsac_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m2_tu(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmsac_vv_f16m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsac_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m4_tu(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmsac_vv_f16m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsac_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m8_tu(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsac_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                        float16_t rs1, vfloat16mf4_t vs2,
+                                        _Float16 rs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_tum(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsac_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                        float16_t rs1, vfloat16mf2_t vs2,
+                                        _Float16 rs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_tum(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsac_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                      float16_t rs1, vfloat16m1_t vs2,
+                                      _Float16 rs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfmsac_vf_f16m1_tum(vm, vd, rs1, vs2, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsac_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                      float16_t rs1, vfloat16m2_t vs2,
+                                      _Float16 rs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfmsac_vf_f16m2_tum(vm, vd, rs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsac_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                      float16_t rs1, vfloat16m4_t vs2,
+                                      _Float16 rs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfmsac_vf_f16m4_tum(vm, vd, rs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsac_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                      float16_t rs1, vfloat16m8_t vs2,
+                                      _Float16 rs1, vfloat16m8_t vs2,
                                       size_t vl) {
   return __riscv_vfmsac_vf_f16m8_tum(vm, vd, rs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsac_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsac_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsac_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac_vf_f16m1_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsac_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac_vf_f16m2_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsac_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac_vf_f16m4_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsac_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac_vf_f16m8_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsac_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                       float16_t rs1, vfloat16mf4_t vs2,
+                                       _Float16 rs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_mu(vm, vd, rs1, vs2, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsac_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                       float16_t rs1, vfloat16mf2_t vs2,
+                                       _Float16 rs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_mu(vm, vd, rs1, vs2, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsac_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                     float16_t rs1, vfloat16m1_t vs2,
+                                     _Float16 rs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfmsac_vf_f16m1_mu(vm, vd, rs1, vs2, vl);
 }
@@ -557,9 +557,8 @@ vfloat16m2_t test_vfmsac_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfmsac_vv_f16m2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                     float16_t rs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -569,9 +568,8 @@ vfloat16m4_t test_vfmsac_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfmsac_vv_f16m4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                     float16_t rs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -581,9 +579,8 @@ vfloat16m8_t test_vfmsac_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfmsac_vv_f16m8_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                     float16_t rs1, vfloat16m8_t vs2,
-                                     size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
+                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m8_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -700,7 +697,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmsac_vv_f16mf4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -710,7 +707,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmsac_vv_f16mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -720,7 +717,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmsac_vv_f16m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m1_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -730,7 +727,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmsac_vv_f16m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -740,7 +737,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmsac_vv_f16m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -750,7 +747,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmsac_vv_f16m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m8_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -852,7 +849,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +861,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +873,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsac_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfmsac_vf_f16m1_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +885,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsac_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfmsac_vf_f16m2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +897,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsac_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfmsac_vf_f16m4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +909,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsac_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl) {
   return __riscv_vfmsac_vf_f16m8_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1033,7 +1030,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1047,7 +1044,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1060,7 +1057,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsac_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfmsac_vf_f16m1_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1072,7 +1069,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsac_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfmsac_vf_f16m2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1084,7 +1081,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsac_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfmsac_vf_f16m4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1096,7 +1093,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsac_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl) {
   return __riscv_vfmsac_vf_f16m8_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1218,7 +1215,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1230,7 +1227,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1242,7 +1239,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsac_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfmsac_vf_f16m1_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1254,7 +1251,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsac_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfmsac_vf_f16m2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1266,7 +1263,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsac_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfmsac_vf_f16m4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1278,7 +1275,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsac_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfmsac_vf_f16m8_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfmsub.c
+++ b/auto-generated/policy_funcs/api-testing/vfmsub.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmsub_vv_f16mf4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmsub_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_tu(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmsub_vv_f16mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmsub_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_tu(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmsub_vv_f16m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmsub_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m1_tu(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmsub_vv_f16m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsub_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m2_tu(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmsub_vv_f16m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsub_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m4_tu(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmsub_vv_f16m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsub_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m8_tu(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                        float16_t rs1, vfloat16mf4_t vs2,
+                                        _Float16 rs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_tum(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                        float16_t rs1, vfloat16mf2_t vs2,
+                                        _Float16 rs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_tum(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                      float16_t rs1, vfloat16m1_t vs2,
+                                      _Float16 rs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfmsub_vf_f16m1_tum(vm, vd, rs1, vs2, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                      float16_t rs1, vfloat16m2_t vs2,
+                                      _Float16 rs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfmsub_vf_f16m2_tum(vm, vd, rs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                      float16_t rs1, vfloat16m4_t vs2,
+                                      _Float16 rs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfmsub_vf_f16m4_tum(vm, vd, rs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                      float16_t rs1, vfloat16m8_t vs2,
+                                      _Float16 rs1, vfloat16m8_t vs2,
                                       size_t vl) {
   return __riscv_vfmsub_vf_f16m8_tum(vm, vd, rs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub_vf_f16m1_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub_vf_f16m2_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub_vf_f16m4_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub_vf_f16m8_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                       float16_t rs1, vfloat16mf4_t vs2,
+                                       _Float16 rs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_mu(vm, vd, rs1, vs2, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                       float16_t rs1, vfloat16mf2_t vs2,
+                                       _Float16 rs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_mu(vm, vd, rs1, vs2, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                     float16_t rs1, vfloat16m1_t vs2,
+                                     _Float16 rs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfmsub_vf_f16m1_mu(vm, vd, rs1, vs2, vl);
 }
@@ -557,9 +557,8 @@ vfloat16m2_t test_vfmsub_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfmsub_vv_f16m2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                     float16_t rs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -569,9 +568,8 @@ vfloat16m4_t test_vfmsub_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfmsub_vv_f16m4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                     float16_t rs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -581,9 +579,8 @@ vfloat16m8_t test_vfmsub_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfmsub_vv_f16m8_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                     float16_t rs1, vfloat16m8_t vs2,
-                                     size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
+                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m8_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -700,7 +697,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmsub_vv_f16mf4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -710,7 +707,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmsub_vv_f16mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -720,7 +717,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmsub_vv_f16m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m1_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -730,7 +727,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmsub_vv_f16m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -740,7 +737,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmsub_vv_f16m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -750,7 +747,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmsub_vv_f16m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m8_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -852,7 +849,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +861,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +873,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfmsub_vf_f16m1_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +885,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfmsub_vf_f16m2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +897,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfmsub_vf_f16m4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +909,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl) {
   return __riscv_vfmsub_vf_f16m8_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1033,7 +1030,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1047,7 +1044,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1060,7 +1057,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfmsub_vf_f16m1_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1072,7 +1069,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfmsub_vf_f16m2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1084,7 +1081,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfmsub_vf_f16m4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1096,7 +1093,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl) {
   return __riscv_vfmsub_vf_f16m8_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1218,7 +1215,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1230,7 +1227,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1242,7 +1239,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfmsub_vf_f16m1_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1254,7 +1251,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfmsub_vf_f16m2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1266,7 +1263,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfmsub_vf_f16m4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1278,7 +1275,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfmsub_vf_f16m8_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfmul.c
+++ b/auto-generated/policy_funcs/api-testing/vfmul.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfmul_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfmul_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfmul_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfmul_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmul_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmul_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmul_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmul_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmul_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmul_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmul_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmul_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmul_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
+                                     vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmul_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmul_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmul_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmul_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmul_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmul_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmul_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmul_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmul_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmul_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmul_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmul_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmul_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -546,8 +546,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmul_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                    vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -558,8 +557,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmul_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                    vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -570,8 +568,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmul_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                    vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -582,8 +579,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmul_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                    vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -701,7 +697,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -711,7 +707,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -721,7 +717,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfmul_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +727,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfmul_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -741,7 +737,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfmul_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -751,7 +747,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfmul_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -852,7 +848,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfmul_vf_f16mf4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +860,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfmul_vf_f16mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +872,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmul_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmul_vf_f16m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +884,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmul_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmul_vf_f16m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +896,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmul_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmul_vf_f16m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +908,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmul_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmul_vf_f16m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1028,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfmul_vf_f16mf4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1040,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfmul_vf_f16mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1052,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmul_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfmul_vf_f16m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1064,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmul_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfmul_vf_f16m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1076,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmul_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfmul_vf_f16m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1088,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmul_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfmul_vf_f16m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1212,7 +1208,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfmul_vf_f16mf4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1224,7 +1220,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfmul_vf_f16mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1236,7 +1232,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmul_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmul_vf_f16m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1248,7 +1244,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmul_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmul_vf_f16m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1256,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmul_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmul_vf_f16m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1268,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmul_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmul_vf_f16m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfmv.c
+++ b/auto-generated/policy_funcs/api-testing/vfmv.c
@@ -5,29 +5,29 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfmv_v_f_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmv_v_f_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmv_v_f_f16mf4_tu(vd, rs1, vl);
 }
 
-vfloat16mf2_t test_vfmv_v_f_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmv_v_f_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmv_v_f_f16mf2_tu(vd, rs1, vl);
 }
 
-vfloat16m1_t test_vfmv_v_f_f16m1_tu(vfloat16m1_t vd, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmv_v_f_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16m1_tu(vd, rs1, vl);
 }
 
-vfloat16m2_t test_vfmv_v_f_f16m2_tu(vfloat16m2_t vd, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmv_v_f_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16m2_tu(vd, rs1, vl);
 }
 
-vfloat16m4_t test_vfmv_v_f_f16m4_tu(vfloat16m4_t vd, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmv_v_f_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16m4_tu(vd, rs1, vl);
 }
 
-vfloat16m8_t test_vfmv_v_f_f16m8_tu(vfloat16m8_t vd, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmv_v_f_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16m8_tu(vd, rs1, vl);
 }
 
@@ -68,29 +68,29 @@ vfloat64m8_t test_vfmv_v_f_f64m8_tu(vfloat64m8_t vd, float64_t rs1, size_t vl) {
   return __riscv_vfmv_v_f_f64m8_tu(vd, rs1, vl);
 }
 
-vfloat16mf4_t test_vfmv_s_f_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmv_s_f_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmv_s_f_f16mf4_tu(vd, rs1, vl);
 }
 
-vfloat16mf2_t test_vfmv_s_f_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmv_s_f_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmv_s_f_f16mf2_tu(vd, rs1, vl);
 }
 
-vfloat16m1_t test_vfmv_s_f_f16m1_tu(vfloat16m1_t vd, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmv_s_f_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16m1_tu(vd, rs1, vl);
 }
 
-vfloat16m2_t test_vfmv_s_f_f16m2_tu(vfloat16m2_t vd, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmv_s_f_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16m2_tu(vd, rs1, vl);
 }
 
-vfloat16m4_t test_vfmv_s_f_f16m4_tu(vfloat16m4_t vd, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmv_s_f_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16m4_tu(vd, rs1, vl);
 }
 
-vfloat16m8_t test_vfmv_s_f_f16m8_tu(vfloat16m8_t vd, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmv_s_f_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16m8_tu(vd, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/api-testing/vfnmacc.c
+++ b/auto-generated/policy_funcs/api-testing/vfnmacc.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmacc_vv_f16mf4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_tu(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmacc_vv_f16mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_tu(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmacc_vv_f16m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmacc_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_tu(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmacc_vv_f16m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmacc_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_tu(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmacc_vv_f16m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmacc_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_tu(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmacc_vv_f16m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmacc_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_tu(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmacc_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_tum(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmacc_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_tum(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmacc_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_tum(vm, vd, rs1, vs2, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmacc_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_tum(vm, vd, rs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmacc_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_tum(vm, vd, rs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmacc_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_tum(vm, vd, rs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmacc_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmacc_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmacc_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmacc_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmacc_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmacc_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmacc_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                        float16_t rs1, vfloat16mf4_t vs2,
+                                        _Float16 rs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_mu(vm, vd, rs1, vs2, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmacc_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                        float16_t rs1, vfloat16mf2_t vs2,
+                                        _Float16 rs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_mu(vm, vd, rs1, vs2, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmacc_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                      float16_t rs1, vfloat16m1_t vs2,
+                                      _Float16 rs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_mu(vm, vd, rs1, vs2, vl);
 }
@@ -558,7 +558,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmacc_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                      float16_t rs1, vfloat16m2_t vs2,
+                                      _Float16 rs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_mu(vm, vd, rs1, vs2, vl);
 }
@@ -570,7 +570,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmacc_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                      float16_t rs1, vfloat16m4_t vs2,
+                                      _Float16 rs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_mu(vm, vd, rs1, vs2, vl);
 }
@@ -582,7 +582,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmacc_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                      float16_t rs1, vfloat16m8_t vs2,
+                                      _Float16 rs1, vfloat16m8_t vs2,
                                       size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_mu(vm, vd, rs1, vs2, vl);
 }
@@ -700,7 +700,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmacc_vv_f16mf4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -710,7 +710,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmacc_vv_f16mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -720,7 +720,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmacc_vv_f16m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -730,7 +730,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmacc_vv_f16m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -740,7 +740,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmacc_vv_f16m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -750,7 +750,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmacc_vv_f16m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -853,7 +853,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -867,7 +867,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -880,7 +880,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -892,7 +892,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -904,7 +904,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -916,7 +916,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1039,7 +1039,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -1053,7 +1053,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -1067,7 +1067,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1081,7 +1081,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1095,7 +1095,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1109,7 +1109,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1248,7 +1248,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1260,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1272,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmacc_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1284,7 +1284,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmacc_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1296,7 +1296,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmacc_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1308,7 +1308,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmacc_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfnmadd.c
+++ b/auto-generated/policy_funcs/api-testing/vfnmadd.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmadd_vv_f16mf4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_tu(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmadd_vv_f16mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_tu(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmadd_vv_f16m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmadd_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_tu(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmadd_vv_f16m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmadd_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_tu(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmadd_vv_f16m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmadd_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_tu(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmadd_vv_f16m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmadd_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_tu(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_tum(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_tum(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_tum(vm, vd, rs1, vs2, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_tum(vm, vd, rs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_tum(vm, vd, rs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_tum(vm, vd, rs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                        float16_t rs1, vfloat16mf4_t vs2,
+                                        _Float16 rs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_mu(vm, vd, rs1, vs2, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                        float16_t rs1, vfloat16mf2_t vs2,
+                                        _Float16 rs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_mu(vm, vd, rs1, vs2, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                      float16_t rs1, vfloat16m1_t vs2,
+                                      _Float16 rs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_mu(vm, vd, rs1, vs2, vl);
 }
@@ -558,7 +558,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                      float16_t rs1, vfloat16m2_t vs2,
+                                      _Float16 rs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_mu(vm, vd, rs1, vs2, vl);
 }
@@ -570,7 +570,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                      float16_t rs1, vfloat16m4_t vs2,
+                                      _Float16 rs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_mu(vm, vd, rs1, vs2, vl);
 }
@@ -582,7 +582,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                      float16_t rs1, vfloat16m8_t vs2,
+                                      _Float16 rs1, vfloat16m8_t vs2,
                                       size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_mu(vm, vd, rs1, vs2, vl);
 }
@@ -700,7 +700,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmadd_vv_f16mf4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -710,7 +710,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmadd_vv_f16mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -720,7 +720,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmadd_vv_f16m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -730,7 +730,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmadd_vv_f16m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -740,7 +740,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmadd_vv_f16m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -750,7 +750,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmadd_vv_f16m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -853,7 +853,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -867,7 +867,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -880,7 +880,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -892,7 +892,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -904,7 +904,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -916,7 +916,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1039,7 +1039,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -1053,7 +1053,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -1067,7 +1067,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1081,7 +1081,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1095,7 +1095,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1109,7 +1109,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1248,7 +1248,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1260,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1272,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1284,7 +1284,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1296,7 +1296,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1308,7 +1308,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfnmsac.c
+++ b/auto-generated/policy_funcs/api-testing/vfnmsac.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmsac_vv_f16mf4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_tu(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmsac_vv_f16mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_tu(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmsac_vv_f16m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmsac_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_tu(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmsac_vv_f16m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmsac_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_tu(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmsac_vv_f16m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmsac_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_tu(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmsac_vv_f16m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmsac_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_tu(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsac_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_tum(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsac_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_tum(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsac_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_tum(vm, vd, rs1, vs2, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsac_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_tum(vm, vd, rs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsac_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_tum(vm, vd, rs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsac_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_tum(vm, vd, rs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsac_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsac_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsac_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsac_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsac_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsac_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsac_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                        float16_t rs1, vfloat16mf4_t vs2,
+                                        _Float16 rs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_mu(vm, vd, rs1, vs2, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsac_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                        float16_t rs1, vfloat16mf2_t vs2,
+                                        _Float16 rs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_mu(vm, vd, rs1, vs2, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsac_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                      float16_t rs1, vfloat16m1_t vs2,
+                                      _Float16 rs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_mu(vm, vd, rs1, vs2, vl);
 }
@@ -558,7 +558,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsac_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                      float16_t rs1, vfloat16m2_t vs2,
+                                      _Float16 rs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_mu(vm, vd, rs1, vs2, vl);
 }
@@ -570,7 +570,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsac_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                      float16_t rs1, vfloat16m4_t vs2,
+                                      _Float16 rs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_mu(vm, vd, rs1, vs2, vl);
 }
@@ -582,7 +582,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsac_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                      float16_t rs1, vfloat16m8_t vs2,
+                                      _Float16 rs1, vfloat16m8_t vs2,
                                       size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_mu(vm, vd, rs1, vs2, vl);
 }
@@ -700,7 +700,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmsac_vv_f16mf4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -710,7 +710,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmsac_vv_f16mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -720,7 +720,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmsac_vv_f16m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -730,7 +730,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmsac_vv_f16m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -740,7 +740,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmsac_vv_f16m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -750,7 +750,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmsac_vv_f16m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -853,7 +853,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -867,7 +867,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -880,7 +880,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -892,7 +892,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -904,7 +904,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -916,7 +916,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1039,7 +1039,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -1053,7 +1053,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -1067,7 +1067,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1081,7 +1081,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1095,7 +1095,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1109,7 +1109,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1248,7 +1248,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1260,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1272,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsac_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1284,7 +1284,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsac_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1296,7 +1296,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsac_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1308,7 +1308,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsac_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfnmsub.c
+++ b/auto-generated/policy_funcs/api-testing/vfnmsub.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmsub_vv_f16mf4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_tu(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmsub_vv_f16mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_tu(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmsub_vv_f16m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmsub_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_tu(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmsub_vv_f16m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmsub_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_tu(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmsub_vv_f16m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmsub_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_tu(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmsub_vv_f16m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmsub_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_tu(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_tum(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_tum(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_tum(vm, vd, rs1, vs2, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_tum(vm, vd, rs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_tum(vm, vd, rs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_tum(vm, vd, rs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                        float16_t rs1, vfloat16mf4_t vs2,
+                                        _Float16 rs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_mu(vm, vd, rs1, vs2, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                        float16_t rs1, vfloat16mf2_t vs2,
+                                        _Float16 rs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_mu(vm, vd, rs1, vs2, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                      float16_t rs1, vfloat16m1_t vs2,
+                                      _Float16 rs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_mu(vm, vd, rs1, vs2, vl);
 }
@@ -558,7 +558,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                      float16_t rs1, vfloat16m2_t vs2,
+                                      _Float16 rs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_mu(vm, vd, rs1, vs2, vl);
 }
@@ -570,7 +570,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                      float16_t rs1, vfloat16m4_t vs2,
+                                      _Float16 rs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_mu(vm, vd, rs1, vs2, vl);
 }
@@ -582,7 +582,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                      float16_t rs1, vfloat16m8_t vs2,
+                                      _Float16 rs1, vfloat16m8_t vs2,
                                       size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_mu(vm, vd, rs1, vs2, vl);
 }
@@ -700,7 +700,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmsub_vv_f16mf4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -710,7 +710,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmsub_vv_f16mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -720,7 +720,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmsub_vv_f16m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -730,7 +730,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmsub_vv_f16m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -740,7 +740,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmsub_vv_f16m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -750,7 +750,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmsub_vv_f16m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -853,7 +853,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -867,7 +867,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -880,7 +880,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -892,7 +892,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -904,7 +904,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -916,7 +916,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1039,7 +1039,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -1053,7 +1053,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -1067,7 +1067,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1081,7 +1081,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1095,7 +1095,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1109,7 +1109,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -1248,7 +1248,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1260,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1272,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1284,7 +1284,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1296,7 +1296,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1308,7 +1308,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfrdiv.c
+++ b/auto-generated/policy_funcs/api-testing/vfrdiv.c
@@ -6,32 +6,32 @@ typedef float float32_t;
 typedef double float64_t;
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfrdiv_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfrdiv_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfrdiv_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -81,37 +81,37 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 }
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfrdiv_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfrdiv_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfrdiv_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
@@ -171,37 +171,37 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_tum(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfrdiv_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfrdiv_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfrdiv_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -261,37 +261,37 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_tumu(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfrdiv_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfrdiv_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfrdiv_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
+                                     vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
@@ -351,32 +351,32 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_mu(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrdiv_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrdiv_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrdiv_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -426,37 +426,37 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_rm_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 }
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrdiv_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrdiv_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrdiv_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -516,39 +516,39 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_rm_tum(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE,
                                           vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                            vfloat16mf2_t vs2, float16_t rs1,
+                                            vfloat16mf2_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE,
                                           vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrdiv_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrdiv_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrdiv_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                          vfloat16m8_t vs2, float16_t rs1,
+                                          vfloat16m8_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -609,37 +609,37 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_rm_tumu(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrdiv_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrdiv_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrdiv_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfrsub.c
+++ b/auto-generated/policy_funcs/api-testing/vfrsub.c
@@ -6,32 +6,32 @@ typedef float float32_t;
 typedef double float64_t;
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfrsub_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfrsub_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfrsub_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -81,37 +81,37 @@ vfloat64m8_t test_vfrsub_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 }
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfrsub_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfrsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfrsub_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfrsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfrsub_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfrsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfrsub_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
@@ -171,37 +171,37 @@ vfloat64m8_t test_vfrsub_vf_f64m8_tum(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrsub_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfrsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrsub_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfrsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrsub_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfrsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrsub_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -261,37 +261,37 @@ vfloat64m8_t test_vfrsub_vf_f64m8_tumu(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrsub_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfrsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrsub_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfrsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrsub_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfrsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
+                                     vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrsub_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
@@ -351,32 +351,32 @@ vfloat64m8_t test_vfrsub_vf_f64m8_mu(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrsub_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrsub_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrsub_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -426,37 +426,37 @@ vfloat64m8_t test_vfrsub_vf_f64m8_rm_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 }
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrsub_vf_f16m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrsub_vf_f16m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrsub_vf_f16m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrsub_vf_f16m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -516,39 +516,39 @@ vfloat64m8_t test_vfrsub_vf_f64m8_rm_tum(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE,
                                           vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                            vfloat16mf2_t vs2, float16_t rs1,
+                                            vfloat16mf2_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE,
                                           vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrsub_vf_f16m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrsub_vf_f16m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrsub_vf_f16m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                          vfloat16m8_t vs2, float16_t rs1,
+                                          vfloat16m8_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrsub_vf_f16m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -609,37 +609,37 @@ vfloat64m8_t test_vfrsub_vf_f64m8_rm_tumu(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrsub_vf_f16m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrsub_vf_f16m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrsub_vf_f16m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrsub_vf_f16m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfsgnj.c
+++ b/auto-generated/policy_funcs/api-testing/vfsgnj.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsgnj_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsgnj_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfsgnj_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfsgnj_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfsgnj_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfsgnj_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsgnj_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnj_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsgnj_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnj_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsgnj_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnj_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsgnj_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnj_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsgnj_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnj_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsgnj_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnj_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsgnj_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsgnj_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsgnj_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsgnj_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsgnj_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnj_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsgnj_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnj_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsgnj_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnj_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsgnj_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnj_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsgnj_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnj_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsgnj_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnj_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsgnj_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsgnj_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
@@ -558,7 +558,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsgnj_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsgnj_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -570,7 +570,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsgnj_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsgnj_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
@@ -582,7 +582,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsgnj_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
+                                     vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsgnj_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfsgnjn.c
+++ b/auto-generated/policy_funcs/api-testing/vfsgnjn.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsgnjn_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsgnjn_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfsgnjn_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfsgnjn_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfsgnjn_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfsgnjn_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsgnjn_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsgnjn_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsgnjn_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnjn_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsgnjn_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnjn_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsgnjn_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnjn_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsgnjn_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnjn_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsgnjn_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsgnjn_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsgnjn_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjn_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsgnjn_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjn_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsgnjn_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjn_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsgnjn_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjn_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsgnjn_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsgnjn_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsgnjn_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnjn_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
@@ -558,7 +558,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsgnjn_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnjn_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -570,7 +570,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsgnjn_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnjn_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
@@ -582,7 +582,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsgnjn_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnjn_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfsgnjx.c
+++ b/auto-generated/policy_funcs/api-testing/vfsgnjx.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsgnjx_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsgnjx_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfsgnjx_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfsgnjx_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfsgnjx_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfsgnjx_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsgnjx_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsgnjx_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsgnjx_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnjx_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsgnjx_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnjx_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsgnjx_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnjx_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsgnjx_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnjx_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsgnjx_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsgnjx_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsgnjx_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjx_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsgnjx_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjx_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsgnjx_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjx_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsgnjx_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjx_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsgnjx_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsgnjx_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsgnjx_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnjx_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
@@ -558,7 +558,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsgnjx_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnjx_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -570,7 +570,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsgnjx_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnjx_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
@@ -582,7 +582,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsgnjx_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnjx_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfslide1down.c
+++ b/auto-generated/policy_funcs/api-testing/vfslide1down.c
@@ -6,34 +6,34 @@ typedef float float32_t;
 typedef double float64_t;
 
 vfloat16mf4_t test_vfslide1down_vf_f16mf4_tu(vfloat16mf4_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1down_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1down_vf_f16mf2_tu(vfloat16mf2_t vd,
-                                             vfloat16mf2_t vs2, float16_t rs1,
+                                             vfloat16mf2_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1down_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1down_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                           float16_t rs1, size_t vl) {
+                                           _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1down_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                           float16_t rs1, size_t vl) {
+                                           _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1down_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                           float16_t rs1, size_t vl) {
+                                           _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1down_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                           float16_t rs1, size_t vl) {
+                                           _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -84,37 +84,37 @@ vfloat64m8_t test_vfslide1down_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 }
 
 vfloat16mf4_t test_vfslide1down_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                              vfloat16mf4_t vs2, float16_t rs1,
+                                              vfloat16mf4_t vs2, _Float16 rs1,
                                               size_t vl) {
   return __riscv_vfslide1down_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1down_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                              vfloat16mf2_t vs2, float16_t rs1,
+                                              vfloat16mf2_t vs2, _Float16 rs1,
                                               size_t vl) {
   return __riscv_vfslide1down_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1down_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                            vfloat16m1_t vs2, float16_t rs1,
+                                            vfloat16m1_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfslide1down_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1down_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                            vfloat16m2_t vs2, float16_t rs1,
+                                            vfloat16m2_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfslide1down_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1down_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                            vfloat16m4_t vs2, float16_t rs1,
+                                            vfloat16m4_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfslide1down_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1down_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                            vfloat16m8_t vs2, float16_t rs1,
+                                            vfloat16m8_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfslide1down_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,37 +174,37 @@ vfloat64m8_t test_vfslide1down_vf_f64m8_tum(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfslide1down_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                               vfloat16mf4_t vs2, float16_t rs1,
+                                               vfloat16mf4_t vs2, _Float16 rs1,
                                                size_t vl) {
   return __riscv_vfslide1down_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1down_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                               vfloat16mf2_t vs2, float16_t rs1,
+                                               vfloat16mf2_t vs2, _Float16 rs1,
                                                size_t vl) {
   return __riscv_vfslide1down_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1down_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                             vfloat16m1_t vs2, float16_t rs1,
+                                             vfloat16m1_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1down_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1down_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                             vfloat16m2_t vs2, float16_t rs1,
+                                             vfloat16m2_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1down_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1down_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                             vfloat16m4_t vs2, float16_t rs1,
+                                             vfloat16m4_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1down_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1down_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                             vfloat16m8_t vs2, float16_t rs1,
+                                             vfloat16m8_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1down_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -264,37 +264,37 @@ vfloat64m8_t test_vfslide1down_vf_f64m8_tumu(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfslide1down_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1down_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1down_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                             vfloat16mf2_t vs2, float16_t rs1,
+                                             vfloat16mf2_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1down_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1down_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                           vfloat16m1_t vs2, float16_t rs1,
+                                           vfloat16m1_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1down_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1down_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                           vfloat16m2_t vs2, float16_t rs1,
+                                           vfloat16m2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1down_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1down_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                           vfloat16m4_t vs2, float16_t rs1,
+                                           vfloat16m4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1down_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1down_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                           vfloat16m8_t vs2, float16_t rs1,
+                                           vfloat16m8_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1down_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfslide1up.c
+++ b/auto-generated/policy_funcs/api-testing/vfslide1up.c
@@ -6,32 +6,32 @@ typedef float float32_t;
 typedef double float64_t;
 
 vfloat16mf4_t test_vfslide1up_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                           float16_t rs1, size_t vl) {
+                                           _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1up_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                           float16_t rs1, size_t vl) {
+                                           _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1up_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1up_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1up_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1up_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -81,37 +81,37 @@ vfloat64m8_t test_vfslide1up_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 }
 
 vfloat16mf4_t test_vfslide1up_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfslide1up_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1up_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                            vfloat16mf2_t vs2, float16_t rs1,
+                                            vfloat16mf2_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfslide1up_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1up_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfslide1up_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1up_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfslide1up_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1up_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfslide1up_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1up_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                          vfloat16m8_t vs2, float16_t rs1,
+                                          vfloat16m8_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfslide1up_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
@@ -171,37 +171,37 @@ vfloat64m8_t test_vfslide1up_vf_f64m8_tum(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfslide1up_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1up_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1up_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                             vfloat16mf2_t vs2, float16_t rs1,
+                                             vfloat16mf2_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1up_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1up_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                           vfloat16m1_t vs2, float16_t rs1,
+                                           vfloat16m1_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1up_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1up_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                           vfloat16m2_t vs2, float16_t rs1,
+                                           vfloat16m2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1up_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1up_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                           vfloat16m4_t vs2, float16_t rs1,
+                                           vfloat16m4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1up_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1up_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                           vfloat16m8_t vs2, float16_t rs1,
+                                           vfloat16m8_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1up_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -261,37 +261,37 @@ vfloat64m8_t test_vfslide1up_vf_f64m8_tumu(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfslide1up_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1up_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1up_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1up_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1up_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfslide1up_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1up_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfslide1up_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1up_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfslide1up_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1up_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfslide1up_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfsub.c
+++ b/auto-generated/policy_funcs/api-testing/vfsub.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfsub_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfsub_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfsub_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfsub_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsub_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsub_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsub_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsub_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsub_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
+                                     vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsub_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsub_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsub_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsub_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsub_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsub_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsub_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsub_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsub_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -546,8 +546,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                    vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -558,8 +557,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                    vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -570,8 +568,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                    vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -582,8 +579,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                    vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -701,7 +697,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -711,7 +707,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -721,7 +717,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfsub_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +727,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfsub_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -741,7 +737,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfsub_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -751,7 +747,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfsub_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -852,7 +848,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfsub_vf_f16mf4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +860,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfsub_vf_f16mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +872,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsub_vf_f16m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +884,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsub_vf_f16m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +896,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsub_vf_f16m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +908,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsub_vf_f16m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1028,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfsub_vf_f16mf4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1040,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfsub_vf_f16mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1052,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsub_vf_f16m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1064,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsub_vf_f16m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1076,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsub_vf_f16m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1088,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsub_vf_f16m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1212,7 +1208,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsub_vf_f16mf4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1224,7 +1220,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsub_vf_f16mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1236,7 +1232,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsub_vf_f16m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1248,7 +1244,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsub_vf_f16m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1256,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsub_vf_f16m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1268,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsub_vf_f16m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfwadd.c
+++ b/auto-generated/policy_funcs/api-testing/vfwadd.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -71,7 +71,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
 }
 
 vfloat32m4_t test_vfwadd_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -81,7 +81,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
 }
 
 vfloat32m4_t test_vfwadd_wf_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
 }
 
 vfloat32m8_t test_vfwadd_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -101,7 +101,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
 }
 
 vfloat32m8_t test_vfwadd_wf_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -192,7 +192,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -204,7 +204,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                        vfloat32mf2_t vs2, float16_t rs1,
+                                        vfloat32mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -216,7 +216,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwadd_vf_f32m1_tum(vm, vd, vs2, rs1, vl);
 }
@@ -228,7 +228,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                      vfloat32m1_t vs2, float16_t rs1,
+                                      vfloat32m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwadd_wf_f32m1_tum(vm, vd, vs2, rs1, vl);
 }
@@ -240,7 +240,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwadd_vf_f32m2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -252,7 +252,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                      vfloat32m2_t vs2, float16_t rs1,
+                                      vfloat32m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwadd_wf_f32m2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -264,7 +264,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwadd_vf_f32m4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -276,7 +276,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_wf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                      vfloat32m4_t vs2, float16_t rs1,
+                                      vfloat32m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwadd_wf_f32m4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -288,7 +288,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwadd_vf_f32m8_tum(vm, vd, vs2, rs1, vl);
 }
@@ -300,7 +300,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_wf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                      vfloat32m8_t vs2, float16_t rs1,
+                                      vfloat32m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwadd_wf_f32m8_tum(vm, vd, vs2, rs1, vl);
 }
@@ -408,7 +408,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -420,7 +420,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                         vfloat32mf2_t vs2, float16_t rs1,
+                                         vfloat32mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -432,7 +432,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_vf_f32m1_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -444,7 +444,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                       vfloat32m1_t vs2, float16_t rs1,
+                                       vfloat32m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_wf_f32m1_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -456,7 +456,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_vf_f32m2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -468,7 +468,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                       vfloat32m2_t vs2, float16_t rs1,
+                                       vfloat32m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_wf_f32m2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -480,7 +480,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_vf_f32m4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -492,7 +492,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_wf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                       vfloat32m4_t vs2, float16_t rs1,
+                                       vfloat32m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_wf_f32m4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -504,7 +504,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_vf_f32m8_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -516,7 +516,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_wf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                       vfloat32m8_t vs2, float16_t rs1,
+                                       vfloat32m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_wf_f32m8_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -624,7 +624,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -636,7 +636,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                       vfloat32mf2_t vs2, float16_t rs1,
+                                       vfloat32mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -648,7 +648,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                     vfloat16mf2_t vs2, float16_t rs1,
+                                     vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_vf_f32m1_mu(vm, vd, vs2, rs1, vl);
 }
@@ -660,7 +660,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                     vfloat32m1_t vs2, float16_t rs1,
+                                     vfloat32m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_wf_f32m1_mu(vm, vd, vs2, rs1, vl);
 }
@@ -672,7 +672,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_vf_f32m2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -684,7 +684,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                     vfloat32m2_t vs2, float16_t rs1,
+                                     vfloat32m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_wf_f32m2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -696,7 +696,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_vf_f32m4_mu(vm, vd, vs2, rs1, vl);
 }
@@ -708,7 +708,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_wf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                     vfloat32m4_t vs2, float16_t rs1,
+                                     vfloat32m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_wf_f32m4_mu(vm, vd, vs2, rs1, vl);
 }
@@ -720,7 +720,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_vf_f32m8_mu(vm, vd, vs2, rs1, vl);
 }
@@ -732,7 +732,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_wf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                     vfloat32m8_t vs2, float16_t rs1,
+                                     vfloat32m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_wf_f32m8_mu(vm, vd, vs2, rs1, vl);
 }
@@ -839,7 +839,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -849,7 +849,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -869,7 +869,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -879,7 +879,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -889,7 +889,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -899,7 +899,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
 }
 
 vfloat32m4_t test_vfwadd_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -909,7 +909,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
 }
 
 vfloat32m4_t test_vfwadd_wf_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -919,7 +919,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
 }
 
 vfloat32m8_t test_vfwadd_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -929,7 +929,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
 }
 
 vfloat32m8_t test_vfwadd_wf_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1020,7 +1020,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1032,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                           vfloat32mf2_t vs2, float16_t rs1,
+                                           vfloat32mf2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1044,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_vf_f32m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1056,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                         vfloat32m1_t vs2, float16_t rs1,
+                                         vfloat32m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_wf_f32m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1068,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_vf_f32m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1080,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                         vfloat32m2_t vs2, float16_t rs1,
+                                         vfloat32m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_wf_f32m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1092,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_vf_f32m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1104,7 +1104,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_wf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                         vfloat32m4_t vs2, float16_t rs1,
+                                         vfloat32m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_wf_f32m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1116,7 +1116,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_vf_f32m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1128,7 +1128,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_wf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                         vfloat32m8_t vs2, float16_t rs1,
+                                         vfloat32m8_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_wf_f32m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1237,7 +1237,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE,
                                           vl);
@@ -1251,7 +1251,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                            vfloat32mf2_t vs2, float16_t rs1,
+                                            vfloat32mf2_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE,
                                           vl);
@@ -1264,7 +1264,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_vf_f32m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1276,7 +1276,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                          vfloat32m1_t vs2, float16_t rs1,
+                                          vfloat32m1_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_wf_f32m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1288,7 +1288,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_vf_f32m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1300,7 +1300,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                          vfloat32m2_t vs2, float16_t rs1,
+                                          vfloat32m2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_wf_f32m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1312,7 +1312,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_vf_f32m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1324,7 +1324,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_wf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                          vfloat32m4_t vs2, float16_t rs1,
+                                          vfloat32m4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_wf_f32m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1336,7 +1336,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_vf_f32m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1348,7 +1348,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_wf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                          vfloat32m8_t vs2, float16_t rs1,
+                                          vfloat32m8_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_wf_f32m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1456,7 +1456,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1468,7 +1468,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                          vfloat32mf2_t vs2, float16_t rs1,
+                                          vfloat32mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1480,7 +1480,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_vf_f32m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1492,7 +1492,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                        vfloat32m1_t vs2, float16_t rs1,
+                                        vfloat32m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_wf_f32m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1504,7 +1504,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_vf_f32m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1516,7 +1516,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                        vfloat32m2_t vs2, float16_t rs1,
+                                        vfloat32m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_wf_f32m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1528,7 +1528,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_vf_f32m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1540,7 +1540,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_wf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                        vfloat32m4_t vs2, float16_t rs1,
+                                        vfloat32m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_wf_f32m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1552,7 +1552,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_vf_f32m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1564,7 +1564,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_wf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                        vfloat32m8_t vs2, float16_t rs1,
+                                        vfloat32m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_wf_f32m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfwmacc.c
+++ b/auto-generated/policy_funcs/api-testing/vfwmacc.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwmacc_vv_f32mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_tu(vd, vs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwmacc_vv_f32m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwmacc_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1,
                                       vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_tu(vd, vs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwmacc_vv_f32m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwmacc_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_tu(vd, vs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwmacc_vv_f32m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwmacc_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_tu(vd, vs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwmacc_vv_f32m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwmacc_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_tu(vd, vs1, vs2, vl);
 }
@@ -102,7 +102,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmacc_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                         float16_t vs1, vfloat16mf4_t vs2,
+                                         _Float16 vs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_tum(vm, vd, vs1, vs2, vl);
 }
@@ -114,7 +114,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmacc_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                       float16_t vs1, vfloat16mf2_t vs2,
+                                       _Float16 vs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_tum(vm, vd, vs1, vs2, vl);
 }
@@ -126,7 +126,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmacc_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                       float16_t vs1, vfloat16m1_t vs2,
+                                       _Float16 vs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_tum(vm, vd, vs1, vs2, vl);
 }
@@ -138,7 +138,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmacc_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                       float16_t vs1, vfloat16m2_t vs2,
+                                       _Float16 vs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_tum(vm, vd, vs1, vs2, vl);
 }
@@ -150,7 +150,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmacc_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                       float16_t vs1, vfloat16m4_t vs2,
+                                       _Float16 vs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_tum(vm, vd, vs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmacc_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                          float16_t vs1, vfloat16mf4_t vs2,
+                                          _Float16 vs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmacc_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                        float16_t vs1, vfloat16mf2_t vs2,
+                                        _Float16 vs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -234,7 +234,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmacc_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                        float16_t vs1, vfloat16m1_t vs2,
+                                        _Float16 vs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -246,7 +246,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmacc_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                        float16_t vs1, vfloat16m2_t vs2,
+                                        _Float16 vs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -258,7 +258,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmacc_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                        float16_t vs1, vfloat16m4_t vs2,
+                                        _Float16 vs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -318,7 +318,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmacc_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                        float16_t vs1, vfloat16mf4_t vs2,
+                                        _Float16 vs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_mu(vm, vd, vs1, vs2, vl);
 }
@@ -330,7 +330,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmacc_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                      float16_t vs1, vfloat16mf2_t vs2,
+                                      _Float16 vs1, vfloat16mf2_t vs2,
                                       size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_mu(vm, vd, vs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmacc_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                      float16_t vs1, vfloat16m1_t vs2,
+                                      _Float16 vs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_mu(vm, vd, vs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmacc_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                      float16_t vs1, vfloat16m2_t vs2,
+                                      _Float16 vs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_mu(vm, vd, vs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmacc_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                      float16_t vs1, vfloat16m4_t vs2,
+                                      _Float16 vs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_mu(vm, vd, vs1, vs2, vl);
 }
@@ -424,7 +424,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwmacc_vv_f32mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1,
                                            vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -434,7 +434,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwmacc_vv_f32m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1,
                                          vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -444,7 +444,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwmacc_vv_f32m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1,
                                          vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -454,7 +454,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwmacc_vv_f32m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1,
                                          vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -464,7 +464,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwmacc_vv_f32m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1,
                                          vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -517,7 +517,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                            float16_t vs1, vfloat16mf4_t vs2,
+                                            _Float16 vs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -530,7 +530,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                          float16_t vs1, vfloat16mf2_t vs2,
+                                          _Float16 vs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -542,7 +542,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                          float16_t vs1, vfloat16m1_t vs2,
+                                          _Float16 vs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -554,7 +554,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                          float16_t vs1, vfloat16m2_t vs2,
+                                          _Float16 vs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -566,7 +566,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                          float16_t vs1, vfloat16m4_t vs2,
+                                          _Float16 vs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -627,7 +627,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                             float16_t vs1, vfloat16mf4_t vs2,
+                                             _Float16 vs1, vfloat16mf4_t vs2,
                                              size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -641,7 +641,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                           float16_t vs1, vfloat16mf2_t vs2,
+                                           _Float16 vs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -655,7 +655,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                           float16_t vs1, vfloat16m1_t vs2,
+                                           _Float16 vs1, vfloat16m1_t vs2,
                                            size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -669,7 +669,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                           float16_t vs1, vfloat16m2_t vs2,
+                                           _Float16 vs1, vfloat16m2_t vs2,
                                            size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -683,7 +683,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                           float16_t vs1, vfloat16m4_t vs2,
+                                           _Float16 vs1, vfloat16m4_t vs2,
                                            size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -752,7 +752,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                           float16_t vs1, vfloat16mf4_t vs2,
+                                           _Float16 vs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -764,7 +764,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmacc_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                         float16_t vs1, vfloat16mf2_t vs2,
+                                         _Float16 vs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -776,7 +776,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmacc_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                         float16_t vs1, vfloat16m1_t vs2,
+                                         _Float16 vs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -788,7 +788,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmacc_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                         float16_t vs1, vfloat16m2_t vs2,
+                                         _Float16 vs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -800,7 +800,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmacc_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                         float16_t vs1, vfloat16m4_t vs2,
+                                         _Float16 vs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfwmsac.c
+++ b/auto-generated/policy_funcs/api-testing/vfwmsac.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwmsac_vv_f32mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_tu(vd, vs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwmsac_vv_f32m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwmsac_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1,
                                       vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_tu(vd, vs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwmsac_vv_f32m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwmsac_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_tu(vd, vs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwmsac_vv_f32m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwmsac_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_tu(vd, vs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwmsac_vv_f32m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwmsac_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_tu(vd, vs1, vs2, vl);
 }
@@ -102,7 +102,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmsac_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                         float16_t vs1, vfloat16mf4_t vs2,
+                                         _Float16 vs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_tum(vm, vd, vs1, vs2, vl);
 }
@@ -114,7 +114,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmsac_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                       float16_t vs1, vfloat16mf2_t vs2,
+                                       _Float16 vs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_tum(vm, vd, vs1, vs2, vl);
 }
@@ -126,7 +126,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmsac_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                       float16_t vs1, vfloat16m1_t vs2,
+                                       _Float16 vs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_tum(vm, vd, vs1, vs2, vl);
 }
@@ -138,7 +138,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmsac_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                       float16_t vs1, vfloat16m2_t vs2,
+                                       _Float16 vs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_tum(vm, vd, vs1, vs2, vl);
 }
@@ -150,7 +150,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmsac_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                       float16_t vs1, vfloat16m4_t vs2,
+                                       _Float16 vs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_tum(vm, vd, vs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmsac_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                          float16_t vs1, vfloat16mf4_t vs2,
+                                          _Float16 vs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmsac_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                        float16_t vs1, vfloat16mf2_t vs2,
+                                        _Float16 vs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -234,7 +234,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmsac_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                        float16_t vs1, vfloat16m1_t vs2,
+                                        _Float16 vs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -246,7 +246,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmsac_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                        float16_t vs1, vfloat16m2_t vs2,
+                                        _Float16 vs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -258,7 +258,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmsac_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                        float16_t vs1, vfloat16m4_t vs2,
+                                        _Float16 vs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -318,7 +318,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmsac_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                        float16_t vs1, vfloat16mf4_t vs2,
+                                        _Float16 vs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_mu(vm, vd, vs1, vs2, vl);
 }
@@ -330,7 +330,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmsac_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                      float16_t vs1, vfloat16mf2_t vs2,
+                                      _Float16 vs1, vfloat16mf2_t vs2,
                                       size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_mu(vm, vd, vs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmsac_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                      float16_t vs1, vfloat16m1_t vs2,
+                                      _Float16 vs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_mu(vm, vd, vs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmsac_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                      float16_t vs1, vfloat16m2_t vs2,
+                                      _Float16 vs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_mu(vm, vd, vs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmsac_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                      float16_t vs1, vfloat16m4_t vs2,
+                                      _Float16 vs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_mu(vm, vd, vs1, vs2, vl);
 }
@@ -424,7 +424,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwmsac_vv_f32mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1,
                                            vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -434,7 +434,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwmsac_vv_f32m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1,
                                          vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -444,7 +444,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwmsac_vv_f32m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1,
                                          vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -454,7 +454,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwmsac_vv_f32m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1,
                                          vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -464,7 +464,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwmsac_vv_f32m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1,
                                          vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -517,7 +517,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                            float16_t vs1, vfloat16mf4_t vs2,
+                                            _Float16 vs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -530,7 +530,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                          float16_t vs1, vfloat16mf2_t vs2,
+                                          _Float16 vs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -542,7 +542,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                          float16_t vs1, vfloat16m1_t vs2,
+                                          _Float16 vs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -554,7 +554,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                          float16_t vs1, vfloat16m2_t vs2,
+                                          _Float16 vs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -566,7 +566,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                          float16_t vs1, vfloat16m4_t vs2,
+                                          _Float16 vs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -627,7 +627,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                             float16_t vs1, vfloat16mf4_t vs2,
+                                             _Float16 vs1, vfloat16mf4_t vs2,
                                              size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -641,7 +641,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                           float16_t vs1, vfloat16mf2_t vs2,
+                                           _Float16 vs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -655,7 +655,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                           float16_t vs1, vfloat16m1_t vs2,
+                                           _Float16 vs1, vfloat16m1_t vs2,
                                            size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -669,7 +669,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                           float16_t vs1, vfloat16m2_t vs2,
+                                           _Float16 vs1, vfloat16m2_t vs2,
                                            size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -683,7 +683,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                           float16_t vs1, vfloat16m4_t vs2,
+                                           _Float16 vs1, vfloat16m4_t vs2,
                                            size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -752,7 +752,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                           float16_t vs1, vfloat16mf4_t vs2,
+                                           _Float16 vs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -764,7 +764,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmsac_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                         float16_t vs1, vfloat16mf2_t vs2,
+                                         _Float16 vs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -776,7 +776,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmsac_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                         float16_t vs1, vfloat16m1_t vs2,
+                                         _Float16 vs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -788,7 +788,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmsac_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                         float16_t vs1, vfloat16m2_t vs2,
+                                         _Float16 vs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -800,7 +800,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmsac_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                         float16_t vs1, vfloat16m4_t vs2,
+                                         _Float16 vs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfwmul.c
+++ b/auto-generated/policy_funcs/api-testing/vfwmul.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
 }
 
 vfloat32m4_t test_vfwmul_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
 }
 
 vfloat32m8_t test_vfwmul_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -102,7 +102,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -114,7 +114,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwmul_vf_f32m1_tum(vm, vd, vs2, rs1, vl);
 }
@@ -126,7 +126,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwmul_vf_f32m2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -138,7 +138,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmul_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwmul_vf_f32m4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -150,7 +150,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmul_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwmul_vf_f32m8_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwmul_vf_f32m1_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -234,7 +234,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwmul_vf_f32m2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -246,7 +246,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmul_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwmul_vf_f32m4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -258,7 +258,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmul_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwmul_vf_f32m8_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -318,7 +318,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -330,7 +330,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                     vfloat16mf2_t vs2, float16_t rs1,
+                                     vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwmul_vf_f32m1_mu(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwmul_vf_f32m2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmul_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwmul_vf_f32m4_mu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmul_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwmul_vf_f32m8_mu(vm, vd, vs2, rs1, vl);
 }
@@ -425,7 +425,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -435,7 +435,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -445,7 +445,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -455,7 +455,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
 }
 
 vfloat32m4_t test_vfwmul_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -465,7 +465,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
 }
 
 vfloat32m8_t test_vfwmul_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -516,7 +516,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -528,7 +528,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwmul_vf_f32m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -540,7 +540,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwmul_vf_f32m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -552,7 +552,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmul_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwmul_vf_f32m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -564,7 +564,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmul_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwmul_vf_f32m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -625,7 +625,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE,
                                           vl);
@@ -638,7 +638,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwmul_vf_f32m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -650,7 +650,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwmul_vf_f32m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -662,7 +662,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmul_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwmul_vf_f32m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -674,7 +674,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmul_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwmul_vf_f32m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -734,7 +734,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -746,7 +746,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwmul_vf_f32m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -758,7 +758,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwmul_vf_f32m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -770,7 +770,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmul_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwmul_vf_f32m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -782,7 +782,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmul_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwmul_vf_f32m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfwnmacc.c
+++ b/auto-generated/policy_funcs/api-testing/vfwnmacc.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmacc_vv_f32mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1,
                                          vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_tu(vd, vs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwnmacc_vv_f32m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwnmacc_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_tu(vd, vs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwnmacc_vv_f32m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwnmacc_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1,
                                        vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_tu(vd, vs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwnmacc_vv_f32m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwnmacc_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1,
                                        vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_tu(vd, vs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwnmacc_vv_f32m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwnmacc_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1,
                                        vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_tu(vd, vs1, vs2, vl);
 }
@@ -102,7 +102,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                          float16_t vs1, vfloat16mf4_t vs2,
+                                          _Float16 vs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_tum(vm, vd, vs1, vs2, vl);
 }
@@ -114,7 +114,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmacc_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                        float16_t vs1, vfloat16mf2_t vs2,
+                                        _Float16 vs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_tum(vm, vd, vs1, vs2, vl);
 }
@@ -126,7 +126,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmacc_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                        float16_t vs1, vfloat16m1_t vs2,
+                                        _Float16 vs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_tum(vm, vd, vs1, vs2, vl);
 }
@@ -138,7 +138,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmacc_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                        float16_t vs1, vfloat16m2_t vs2,
+                                        _Float16 vs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_tum(vm, vd, vs1, vs2, vl);
 }
@@ -150,7 +150,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmacc_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                        float16_t vs1, vfloat16m4_t vs2,
+                                        _Float16 vs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_tum(vm, vd, vs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                           float16_t vs1, vfloat16mf4_t vs2,
+                                           _Float16 vs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmacc_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                         float16_t vs1, vfloat16mf2_t vs2,
+                                         _Float16 vs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -234,7 +234,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmacc_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                         float16_t vs1, vfloat16m1_t vs2,
+                                         _Float16 vs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -246,7 +246,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmacc_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                         float16_t vs1, vfloat16m2_t vs2,
+                                         _Float16 vs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -258,7 +258,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmacc_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                         float16_t vs1, vfloat16m4_t vs2,
+                                         _Float16 vs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -318,7 +318,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmacc_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                         float16_t vs1, vfloat16mf4_t vs2,
+                                         _Float16 vs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_mu(vm, vd, vs1, vs2, vl);
 }
@@ -330,7 +330,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmacc_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                       float16_t vs1, vfloat16mf2_t vs2,
+                                       _Float16 vs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_mu(vm, vd, vs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmacc_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                       float16_t vs1, vfloat16m1_t vs2,
+                                       _Float16 vs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_mu(vm, vd, vs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmacc_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                       float16_t vs1, vfloat16m2_t vs2,
+                                       _Float16 vs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_mu(vm, vd, vs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmacc_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                       float16_t vs1, vfloat16m4_t vs2,
+                                       _Float16 vs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_mu(vm, vd, vs1, vs2, vl);
 }
@@ -424,7 +424,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmacc_vv_f32mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1,
                                             vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -434,7 +434,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwnmacc_vv_f32m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1,
                                           vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -444,7 +444,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwnmacc_vv_f32m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1,
                                           vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -454,7 +454,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwnmacc_vv_f32m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1,
                                           vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -464,7 +464,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwnmacc_vv_f32m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1,
                                           vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -517,7 +517,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                             float16_t vs1, vfloat16mf4_t vs2,
+                                             _Float16 vs1, vfloat16mf4_t vs2,
                                              size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -531,7 +531,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                           float16_t vs1, vfloat16mf2_t vs2,
+                                           _Float16 vs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -545,7 +545,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                           float16_t vs1, vfloat16m1_t vs2,
+                                           _Float16 vs1, vfloat16m1_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -559,7 +559,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                           float16_t vs1, vfloat16m2_t vs2,
+                                           _Float16 vs1, vfloat16m2_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -573,7 +573,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                           float16_t vs1, vfloat16m4_t vs2,
+                                           _Float16 vs1, vfloat16m4_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -643,7 +643,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                              float16_t vs1, vfloat16mf4_t vs2,
+                                              _Float16 vs1, vfloat16mf4_t vs2,
                                               size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                             vl);
@@ -657,7 +657,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                            float16_t vs1, vfloat16mf2_t vs2,
+                                            _Float16 vs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -671,7 +671,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                            float16_t vs1, vfloat16m1_t vs2,
+                                            _Float16 vs1, vfloat16m1_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -685,7 +685,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                            float16_t vs1, vfloat16m2_t vs2,
+                                            _Float16 vs1, vfloat16m2_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -699,7 +699,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                            float16_t vs1, vfloat16m4_t vs2,
+                                            _Float16 vs1, vfloat16m4_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -769,7 +769,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                            float16_t vs1, vfloat16mf4_t vs2,
+                                            _Float16 vs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -782,7 +782,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                          float16_t vs1, vfloat16mf2_t vs2,
+                                          _Float16 vs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -794,7 +794,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                          float16_t vs1, vfloat16m1_t vs2,
+                                          _Float16 vs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -806,7 +806,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                          float16_t vs1, vfloat16m2_t vs2,
+                                          _Float16 vs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -818,7 +818,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                          float16_t vs1, vfloat16m4_t vs2,
+                                          _Float16 vs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfwnmsac.c
+++ b/auto-generated/policy_funcs/api-testing/vfwnmsac.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmsac_vv_f32mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1,
                                          vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_tu(vd, vs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwnmsac_vv_f32m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwnmsac_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_tu(vd, vs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwnmsac_vv_f32m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwnmsac_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1,
                                        vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_tu(vd, vs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwnmsac_vv_f32m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwnmsac_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1,
                                        vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_tu(vd, vs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwnmsac_vv_f32m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwnmsac_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1,
                                        vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_tu(vd, vs1, vs2, vl);
 }
@@ -102,7 +102,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                          float16_t vs1, vfloat16mf4_t vs2,
+                                          _Float16 vs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_tum(vm, vd, vs1, vs2, vl);
 }
@@ -114,7 +114,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmsac_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                        float16_t vs1, vfloat16mf2_t vs2,
+                                        _Float16 vs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_tum(vm, vd, vs1, vs2, vl);
 }
@@ -126,7 +126,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmsac_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                        float16_t vs1, vfloat16m1_t vs2,
+                                        _Float16 vs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_tum(vm, vd, vs1, vs2, vl);
 }
@@ -138,7 +138,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmsac_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                        float16_t vs1, vfloat16m2_t vs2,
+                                        _Float16 vs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_tum(vm, vd, vs1, vs2, vl);
 }
@@ -150,7 +150,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmsac_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                        float16_t vs1, vfloat16m4_t vs2,
+                                        _Float16 vs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_tum(vm, vd, vs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                           float16_t vs1, vfloat16mf4_t vs2,
+                                           _Float16 vs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmsac_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                         float16_t vs1, vfloat16mf2_t vs2,
+                                         _Float16 vs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -234,7 +234,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmsac_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                         float16_t vs1, vfloat16m1_t vs2,
+                                         _Float16 vs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -246,7 +246,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmsac_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                         float16_t vs1, vfloat16m2_t vs2,
+                                         _Float16 vs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -258,7 +258,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmsac_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                         float16_t vs1, vfloat16m4_t vs2,
+                                         _Float16 vs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -318,7 +318,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmsac_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                         float16_t vs1, vfloat16mf4_t vs2,
+                                         _Float16 vs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_mu(vm, vd, vs1, vs2, vl);
 }
@@ -330,7 +330,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmsac_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                       float16_t vs1, vfloat16mf2_t vs2,
+                                       _Float16 vs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_mu(vm, vd, vs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmsac_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                       float16_t vs1, vfloat16m1_t vs2,
+                                       _Float16 vs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_mu(vm, vd, vs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmsac_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                       float16_t vs1, vfloat16m2_t vs2,
+                                       _Float16 vs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_mu(vm, vd, vs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmsac_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                       float16_t vs1, vfloat16m4_t vs2,
+                                       _Float16 vs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_mu(vm, vd, vs1, vs2, vl);
 }
@@ -424,7 +424,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmsac_vv_f32mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1,
                                             vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -434,7 +434,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwnmsac_vv_f32m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1,
                                           vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -444,7 +444,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwnmsac_vv_f32m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1,
                                           vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -454,7 +454,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwnmsac_vv_f32m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1,
                                           vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -464,7 +464,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwnmsac_vv_f32m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1,
                                           vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -517,7 +517,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                             float16_t vs1, vfloat16mf4_t vs2,
+                                             _Float16 vs1, vfloat16mf4_t vs2,
                                              size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -531,7 +531,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                           float16_t vs1, vfloat16mf2_t vs2,
+                                           _Float16 vs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -545,7 +545,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                           float16_t vs1, vfloat16m1_t vs2,
+                                           _Float16 vs1, vfloat16m1_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -559,7 +559,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                           float16_t vs1, vfloat16m2_t vs2,
+                                           _Float16 vs1, vfloat16m2_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -573,7 +573,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                           float16_t vs1, vfloat16m4_t vs2,
+                                           _Float16 vs1, vfloat16m4_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -643,7 +643,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                              float16_t vs1, vfloat16mf4_t vs2,
+                                              _Float16 vs1, vfloat16mf4_t vs2,
                                               size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                             vl);
@@ -657,7 +657,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                            float16_t vs1, vfloat16mf2_t vs2,
+                                            _Float16 vs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -671,7 +671,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                            float16_t vs1, vfloat16m1_t vs2,
+                                            _Float16 vs1, vfloat16m1_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -685,7 +685,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                            float16_t vs1, vfloat16m2_t vs2,
+                                            _Float16 vs1, vfloat16m2_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -699,7 +699,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                            float16_t vs1, vfloat16m4_t vs2,
+                                            _Float16 vs1, vfloat16m4_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                            vl);
@@ -769,7 +769,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                            float16_t vs1, vfloat16mf4_t vs2,
+                                            _Float16 vs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE,
                                           vl);
@@ -782,7 +782,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                          float16_t vs1, vfloat16mf2_t vs2,
+                                          _Float16 vs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -794,7 +794,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                          float16_t vs1, vfloat16m1_t vs2,
+                                          _Float16 vs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -806,7 +806,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                          float16_t vs1, vfloat16m2_t vs2,
+                                          _Float16 vs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -818,7 +818,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                          float16_t vs1, vfloat16m4_t vs2,
+                                          _Float16 vs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfwsub.c
+++ b/auto-generated/policy_funcs/api-testing/vfwsub.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -71,7 +71,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
 }
 
 vfloat32m4_t test_vfwsub_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -81,7 +81,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
 }
 
 vfloat32m4_t test_vfwsub_wf_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
 }
 
 vfloat32m8_t test_vfwsub_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -101,7 +101,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
 }
 
 vfloat32m8_t test_vfwsub_wf_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -192,7 +192,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -204,7 +204,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                        vfloat32mf2_t vs2, float16_t rs1,
+                                        vfloat32mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -216,7 +216,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwsub_vf_f32m1_tum(vm, vd, vs2, rs1, vl);
 }
@@ -228,7 +228,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                      vfloat32m1_t vs2, float16_t rs1,
+                                      vfloat32m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwsub_wf_f32m1_tum(vm, vd, vs2, rs1, vl);
 }
@@ -240,7 +240,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwsub_vf_f32m2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -252,7 +252,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                      vfloat32m2_t vs2, float16_t rs1,
+                                      vfloat32m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwsub_wf_f32m2_tum(vm, vd, vs2, rs1, vl);
 }
@@ -264,7 +264,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwsub_vf_f32m4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -276,7 +276,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_wf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                      vfloat32m4_t vs2, float16_t rs1,
+                                      vfloat32m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwsub_wf_f32m4_tum(vm, vd, vs2, rs1, vl);
 }
@@ -288,7 +288,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwsub_vf_f32m8_tum(vm, vd, vs2, rs1, vl);
 }
@@ -300,7 +300,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_wf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                      vfloat32m8_t vs2, float16_t rs1,
+                                      vfloat32m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwsub_wf_f32m8_tum(vm, vd, vs2, rs1, vl);
 }
@@ -408,7 +408,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -420,7 +420,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                         vfloat32mf2_t vs2, float16_t rs1,
+                                         vfloat32mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -432,7 +432,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_vf_f32m1_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -444,7 +444,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                       vfloat32m1_t vs2, float16_t rs1,
+                                       vfloat32m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_wf_f32m1_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -456,7 +456,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_vf_f32m2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -468,7 +468,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                       vfloat32m2_t vs2, float16_t rs1,
+                                       vfloat32m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_wf_f32m2_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -480,7 +480,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_vf_f32m4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -492,7 +492,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_wf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                       vfloat32m4_t vs2, float16_t rs1,
+                                       vfloat32m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_wf_f32m4_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -504,7 +504,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_vf_f32m8_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -516,7 +516,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_wf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                       vfloat32m8_t vs2, float16_t rs1,
+                                       vfloat32m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_wf_f32m8_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -624,7 +624,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -636,7 +636,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                       vfloat32mf2_t vs2, float16_t rs1,
+                                       vfloat32mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -648,7 +648,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                     vfloat16mf2_t vs2, float16_t rs1,
+                                     vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_vf_f32m1_mu(vm, vd, vs2, rs1, vl);
 }
@@ -660,7 +660,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                     vfloat32m1_t vs2, float16_t rs1,
+                                     vfloat32m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_wf_f32m1_mu(vm, vd, vs2, rs1, vl);
 }
@@ -672,7 +672,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_vf_f32m2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -684,7 +684,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                     vfloat32m2_t vs2, float16_t rs1,
+                                     vfloat32m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_wf_f32m2_mu(vm, vd, vs2, rs1, vl);
 }
@@ -696,7 +696,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_vf_f32m4_mu(vm, vd, vs2, rs1, vl);
 }
@@ -708,7 +708,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_wf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                     vfloat32m4_t vs2, float16_t rs1,
+                                     vfloat32m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_wf_f32m4_mu(vm, vd, vs2, rs1, vl);
 }
@@ -720,7 +720,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_vf_f32m8_mu(vm, vd, vs2, rs1, vl);
 }
@@ -732,7 +732,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_wf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                     vfloat32m8_t vs2, float16_t rs1,
+                                     vfloat32m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_wf_f32m8_mu(vm, vd, vs2, rs1, vl);
 }
@@ -839,7 +839,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -849,7 +849,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -869,7 +869,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -879,7 +879,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -889,7 +889,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -899,7 +899,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
 }
 
 vfloat32m4_t test_vfwsub_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -909,7 +909,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
 }
 
 vfloat32m4_t test_vfwsub_wf_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -919,7 +919,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
 }
 
 vfloat32m8_t test_vfwsub_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -929,7 +929,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
 }
 
 vfloat32m8_t test_vfwsub_wf_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1020,7 +1020,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1032,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                           vfloat32mf2_t vs2, float16_t rs1,
+                                           vfloat32mf2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1044,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_vf_f32m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1056,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                         vfloat32m1_t vs2, float16_t rs1,
+                                         vfloat32m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_wf_f32m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1068,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_vf_f32m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1080,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                         vfloat32m2_t vs2, float16_t rs1,
+                                         vfloat32m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_wf_f32m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1092,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_vf_f32m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1104,7 +1104,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_wf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                         vfloat32m4_t vs2, float16_t rs1,
+                                         vfloat32m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_wf_f32m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1116,7 +1116,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_vf_f32m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1128,7 +1128,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_wf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                         vfloat32m8_t vs2, float16_t rs1,
+                                         vfloat32m8_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_wf_f32m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1237,7 +1237,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE,
                                           vl);
@@ -1251,7 +1251,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                            vfloat32mf2_t vs2, float16_t rs1,
+                                            vfloat32mf2_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE,
                                           vl);
@@ -1264,7 +1264,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_vf_f32m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1276,7 +1276,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                          vfloat32m1_t vs2, float16_t rs1,
+                                          vfloat32m1_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_wf_f32m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1288,7 +1288,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_vf_f32m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1300,7 +1300,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                          vfloat32m2_t vs2, float16_t rs1,
+                                          vfloat32m2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_wf_f32m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1312,7 +1312,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_vf_f32m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1324,7 +1324,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_wf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                          vfloat32m4_t vs2, float16_t rs1,
+                                          vfloat32m4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_wf_f32m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1336,7 +1336,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_vf_f32m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1348,7 +1348,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_wf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                          vfloat32m8_t vs2, float16_t rs1,
+                                          vfloat32m8_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_wf_f32m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1456,7 +1456,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1468,7 +1468,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                          vfloat32mf2_t vs2, float16_t rs1,
+                                          vfloat32mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1480,7 +1480,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_vf_f32m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1492,7 +1492,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                        vfloat32m1_t vs2, float16_t rs1,
+                                        vfloat32m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_wf_f32m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1504,7 +1504,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_vf_f32m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1516,7 +1516,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                        vfloat32m2_t vs2, float16_t rs1,
+                                        vfloat32m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_wf_f32m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1528,7 +1528,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_vf_f32m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1540,7 +1540,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_wf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                        vfloat32m4_t vs2, float16_t rs1,
+                                        vfloat32m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_wf_f32m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1552,7 +1552,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_vf_f32m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1564,7 +1564,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_wf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                        vfloat32m8_t vs2, float16_t rs1,
+                                        vfloat32m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_wf_f32m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vmfeq.c
+++ b/auto-generated/policy_funcs/api-testing/vmfeq.c
@@ -12,7 +12,7 @@ vbool64_t test_vmfeq_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
 }
 
 vbool64_t test_vmfeq_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfeq_vf_f16mf4_b64_mu(vm, vd, vs2, rs1, vl);
 }
@@ -24,7 +24,7 @@ vbool32_t test_vmfeq_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
 }
 
 vbool32_t test_vmfeq_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfeq_vf_f16mf2_b32_mu(vm, vd, vs2, rs1, vl);
 }
@@ -36,7 +36,7 @@ vbool16_t test_vmfeq_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
 }
 
 vbool16_t test_vmfeq_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vmfeq_vf_f16m1_b16_mu(vm, vd, vs2, rs1, vl);
 }
@@ -47,7 +47,7 @@ vbool8_t test_vmfeq_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
 }
 
 vbool8_t test_vmfeq_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m2_b8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vbool4_t test_vmfeq_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
 }
 
 vbool4_t test_vmfeq_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m4_b4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vbool2_t test_vmfeq_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
 }
 
 vbool2_t test_vmfeq_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m8_b2_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/api-testing/vmfge.c
+++ b/auto-generated/policy_funcs/api-testing/vmfge.c
@@ -12,7 +12,7 @@ vbool64_t test_vmfge_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
 }
 
 vbool64_t test_vmfge_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfge_vf_f16mf4_b64_mu(vm, vd, vs2, rs1, vl);
 }
@@ -24,7 +24,7 @@ vbool32_t test_vmfge_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
 }
 
 vbool32_t test_vmfge_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfge_vf_f16mf2_b32_mu(vm, vd, vs2, rs1, vl);
 }
@@ -36,7 +36,7 @@ vbool16_t test_vmfge_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
 }
 
 vbool16_t test_vmfge_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vmfge_vf_f16m1_b16_mu(vm, vd, vs2, rs1, vl);
 }
@@ -47,7 +47,7 @@ vbool8_t test_vmfge_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
 }
 
 vbool8_t test_vmfge_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m2_b8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vbool4_t test_vmfge_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
 }
 
 vbool4_t test_vmfge_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m4_b4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vbool2_t test_vmfge_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
 }
 
 vbool2_t test_vmfge_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m8_b2_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/api-testing/vmfgt.c
+++ b/auto-generated/policy_funcs/api-testing/vmfgt.c
@@ -12,7 +12,7 @@ vbool64_t test_vmfgt_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
 }
 
 vbool64_t test_vmfgt_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfgt_vf_f16mf4_b64_mu(vm, vd, vs2, rs1, vl);
 }
@@ -24,7 +24,7 @@ vbool32_t test_vmfgt_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
 }
 
 vbool32_t test_vmfgt_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfgt_vf_f16mf2_b32_mu(vm, vd, vs2, rs1, vl);
 }
@@ -36,7 +36,7 @@ vbool16_t test_vmfgt_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
 }
 
 vbool16_t test_vmfgt_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vmfgt_vf_f16m1_b16_mu(vm, vd, vs2, rs1, vl);
 }
@@ -47,7 +47,7 @@ vbool8_t test_vmfgt_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
 }
 
 vbool8_t test_vmfgt_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m2_b8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vbool4_t test_vmfgt_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
 }
 
 vbool4_t test_vmfgt_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m4_b4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vbool2_t test_vmfgt_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
 }
 
 vbool2_t test_vmfgt_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m8_b2_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/api-testing/vmfle.c
+++ b/auto-generated/policy_funcs/api-testing/vmfle.c
@@ -12,7 +12,7 @@ vbool64_t test_vmfle_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
 }
 
 vbool64_t test_vmfle_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfle_vf_f16mf4_b64_mu(vm, vd, vs2, rs1, vl);
 }
@@ -24,7 +24,7 @@ vbool32_t test_vmfle_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
 }
 
 vbool32_t test_vmfle_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfle_vf_f16mf2_b32_mu(vm, vd, vs2, rs1, vl);
 }
@@ -36,7 +36,7 @@ vbool16_t test_vmfle_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
 }
 
 vbool16_t test_vmfle_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vmfle_vf_f16m1_b16_mu(vm, vd, vs2, rs1, vl);
 }
@@ -47,7 +47,7 @@ vbool8_t test_vmfle_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
 }
 
 vbool8_t test_vmfle_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m2_b8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vbool4_t test_vmfle_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
 }
 
 vbool4_t test_vmfle_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m4_b4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vbool2_t test_vmfle_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
 }
 
 vbool2_t test_vmfle_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m8_b2_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/api-testing/vmflt.c
+++ b/auto-generated/policy_funcs/api-testing/vmflt.c
@@ -12,7 +12,7 @@ vbool64_t test_vmflt_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
 }
 
 vbool64_t test_vmflt_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmflt_vf_f16mf4_b64_mu(vm, vd, vs2, rs1, vl);
 }
@@ -24,7 +24,7 @@ vbool32_t test_vmflt_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
 }
 
 vbool32_t test_vmflt_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmflt_vf_f16mf2_b32_mu(vm, vd, vs2, rs1, vl);
 }
@@ -36,7 +36,7 @@ vbool16_t test_vmflt_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
 }
 
 vbool16_t test_vmflt_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vmflt_vf_f16m1_b16_mu(vm, vd, vs2, rs1, vl);
 }
@@ -47,7 +47,7 @@ vbool8_t test_vmflt_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
 }
 
 vbool8_t test_vmflt_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m2_b8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vbool4_t test_vmflt_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
 }
 
 vbool4_t test_vmflt_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m4_b4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vbool2_t test_vmflt_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
 }
 
 vbool2_t test_vmflt_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m8_b2_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/api-testing/vmfne.c
+++ b/auto-generated/policy_funcs/api-testing/vmfne.c
@@ -12,7 +12,7 @@ vbool64_t test_vmfne_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
 }
 
 vbool64_t test_vmfne_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfne_vf_f16mf4_b64_mu(vm, vd, vs2, rs1, vl);
 }
@@ -24,7 +24,7 @@ vbool32_t test_vmfne_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
 }
 
 vbool32_t test_vmfne_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfne_vf_f16mf2_b32_mu(vm, vd, vs2, rs1, vl);
 }
@@ -36,7 +36,7 @@ vbool16_t test_vmfne_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
 }
 
 vbool16_t test_vmfne_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vmfne_vf_f16m1_b16_mu(vm, vd, vs2, rs1, vl);
 }
@@ -47,7 +47,7 @@ vbool8_t test_vmfne_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
 }
 
 vbool8_t test_vmfne_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m2_b8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vbool4_t test_vmfne_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
 }
 
 vbool4_t test_vmfne_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m4_b4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vbool2_t test_vmfne_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
 }
 
 vbool2_t test_vmfne_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m8_b2_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfadd.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfadd.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vfloa
   return __riscv_vfadd_vv_f16mf4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vfloa
   return __riscv_vfadd_vv_f16mf2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat16m
   return __riscv_vfadd_vv_f16m1_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat16m
   return __riscv_vfadd_vv_f16m2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat16m
   return __riscv_vfadd_vv_f16m4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat16m
   return __riscv_vfadd_vv_f16m8_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfadd_vv_f16mf4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfadd_vv_f16mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfadd_vv_f16m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfadd_vv_f16m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfadd_vv_f16m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfadd_vv_f16m8_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfadd_vv_f16mf4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfadd_vv_f16mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfadd_vv_f16m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfadd_vv_f16m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfadd_vv_f16m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfadd_vv_f16m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfadd_vv_f16mf4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfadd_vv_f16mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfadd_vv_f16m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfadd_vv_f16m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfadd_vv_f16m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfadd_vv_f16m8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vf
   return __riscv_vfadd_vv_f16mf4_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vf
   return __riscv_vfadd_vv_f16mf2_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat
   return __riscv_vfadd_vv_f16m1_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat
   return __riscv_vfadd_vv_f16m2_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat
   return __riscv_vfadd_vv_f16m4_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat
   return __riscv_vfadd_vv_f16m8_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfadd_vv_f16mf4_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfadd_vv_f16mf2_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfadd_vv_f16m1_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfadd_vv_f16m2_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfadd_vv_f16m4_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfadd_vv_f16m8_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfadd_vv_f16mf4_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfadd_vv_f16mf2_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfadd_vv_f16m1_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfadd_vv_f16m2_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfadd_vv_f16m4_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfadd_vv_f16m8_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfadd_vv_f16mf4_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfadd_vv_f16mf2_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfadd_vv_f16m1_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfadd_vv_f16m2_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfadd_vv_f16m4_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfadd_vv_f16m8_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_vf_f16m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfdiv.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfdiv.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vfloa
   return __riscv_vfdiv_vv_f16mf4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vfloa
   return __riscv_vfdiv_vv_f16mf2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat16m
   return __riscv_vfdiv_vv_f16m1_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat16m
   return __riscv_vfdiv_vv_f16m2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat16m
   return __riscv_vfdiv_vv_f16m4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat16m
   return __riscv_vfdiv_vv_f16m8_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfdiv_vv_f16mf4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfdiv_vv_f16mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfdiv_vv_f16m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfdiv_vv_f16m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfdiv_vv_f16m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfdiv_vv_f16m8_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfdiv_vv_f16mf4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfdiv_vv_f16mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfdiv_vv_f16m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfdiv_vv_f16m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfdiv_vv_f16m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfdiv_vv_f16m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfdiv_vv_f16mf4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfdiv_vv_f16mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfdiv_vv_f16m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfdiv_vv_f16m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfdiv_vv_f16m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfdiv_vv_f16m8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vf
   return __riscv_vfdiv_vv_f16mf4_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vf
   return __riscv_vfdiv_vv_f16mf2_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat
   return __riscv_vfdiv_vv_f16m1_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat
   return __riscv_vfdiv_vv_f16m2_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat
   return __riscv_vfdiv_vv_f16m4_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat
   return __riscv_vfdiv_vv_f16m8_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfdiv_vv_f16mf4_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfdiv_vv_f16mf2_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfdiv_vv_f16m1_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfdiv_vv_f16m2_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfdiv_vv_f16m4_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfdiv_vv_f16m8_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfdiv_vv_f16mf4_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfdiv_vv_f16mf2_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfdiv_vv_f16m1_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfdiv_vv_f16m2_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfdiv_vv_f16m4_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfdiv_vv_f16m8_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfdiv_vv_f16mf4_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfdiv_vv_f16mf2_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfdiv_vv_f16m1_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfdiv_vv_f16m2_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfdiv_vv_f16m4_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfdiv_vv_f16m8_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_vf_f16m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfmacc.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfmacc.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, vflo
   return __riscv_vfmacc_vv_f16mf4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_tu(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, vflo
   return __riscv_vfmacc_vv_f16mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_tu(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16
   return __riscv_vfmacc_vv_f16m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m1_tu(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16
   return __riscv_vfmacc_vv_f16m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m2_tu(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16
   return __riscv_vfmacc_vv_f16m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m4_tu(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16
   return __riscv_vfmacc_vv_f16m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m8_tu(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfmacc_vv_f16mf4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfmacc_vv_f16mf2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfmacc_vv_f16m1_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m1_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfmacc_vv_f16m2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m2_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfmacc_vv_f16m4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m4_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfmacc_vv_f16m8_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m8_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfmacc_vv_f16mf4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfmacc_vv_f16mf2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfmacc_vv_f16m1_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m1_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfmacc_vv_f16m2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m2_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfmacc_vv_f16m4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m4_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfmacc_vv_f16m8_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m8_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfmacc_vv_f16mf4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfmacc_vv_f16mf2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfmacc_vv_f16m1_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m1_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfmacc_vv_f16m2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfmacc_vv_f16m4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfmacc_vv_f16m8_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m8_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, v
   return __riscv_vfmacc_vv_f16mf4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, v
   return __riscv_vfmacc_vv_f16mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloa
   return __riscv_vfmacc_vv_f16m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m1_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloa
   return __riscv_vfmacc_vv_f16m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloa
   return __riscv_vfmacc_vv_f16m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloa
   return __riscv_vfmacc_vv_f16m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m8_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfmacc_vv_f16mf4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfmacc_vv_f16mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfmacc_vv_f16m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m1_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfmacc_vv_f16m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfmacc_vv_f16m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfmacc_vv_f16m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m8_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vflo
   return __riscv_vfmacc_vv_f16mf4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vflo
   return __riscv_vfmacc_vv_f16mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat1
   return __riscv_vfmacc_vv_f16m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m1_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16
   return __riscv_vfmacc_vv_f16m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16
   return __riscv_vfmacc_vv_f16m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16
   return __riscv_vfmacc_vv_f16m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m8_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfmacc_vv_f16mf4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfmacc_vv_f16mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16mf2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfmacc_vv_f16m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m1_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfmacc_vv_f16m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfmacc_vv_f16m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfmacc_vv_f16m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_vf_f16m8_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfmadd.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfmadd.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, vflo
   return __riscv_vfmadd_vv_f16mf4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_tu(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, vflo
   return __riscv_vfmadd_vv_f16mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_tu(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16
   return __riscv_vfmadd_vv_f16m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m1_tu(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16
   return __riscv_vfmadd_vv_f16m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m2_tu(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16
   return __riscv_vfmadd_vv_f16m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m4_tu(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16
   return __riscv_vfmadd_vv_f16m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m8_tu(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfmadd_vv_f16mf4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfmadd_vv_f16mf2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfmadd_vv_f16m1_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m1_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfmadd_vv_f16m2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m2_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfmadd_vv_f16m4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m4_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfmadd_vv_f16m8_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m8_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfmadd_vv_f16mf4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfmadd_vv_f16mf2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfmadd_vv_f16m1_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m1_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfmadd_vv_f16m2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m2_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfmadd_vv_f16m4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m4_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfmadd_vv_f16m8_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m8_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfmadd_vv_f16mf4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfmadd_vv_f16mf2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfmadd_vv_f16m1_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m1_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfmadd_vv_f16m2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfmadd_vv_f16m4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfmadd_vv_f16m8_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m8_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, v
   return __riscv_vfmadd_vv_f16mf4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, v
   return __riscv_vfmadd_vv_f16mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloa
   return __riscv_vfmadd_vv_f16m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m1_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloa
   return __riscv_vfmadd_vv_f16m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloa
   return __riscv_vfmadd_vv_f16m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloa
   return __riscv_vfmadd_vv_f16m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m8_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfmadd_vv_f16mf4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfmadd_vv_f16mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfmadd_vv_f16m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m1_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfmadd_vv_f16m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfmadd_vv_f16m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfmadd_vv_f16m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m8_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vflo
   return __riscv_vfmadd_vv_f16mf4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vflo
   return __riscv_vfmadd_vv_f16mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat1
   return __riscv_vfmadd_vv_f16m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m1_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16
   return __riscv_vfmadd_vv_f16m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16
   return __riscv_vfmadd_vv_f16m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16
   return __riscv_vfmadd_vv_f16m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m8_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfmadd_vv_f16mf4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfmadd_vv_f16mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16mf2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfmadd_vv_f16m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m1_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfmadd_vv_f16m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfmadd_vv_f16m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfmadd_vv_f16m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_vf_f16m8_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfmax.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfmax.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vfloa
   return __riscv_vfmax_vv_f16mf4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmax_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmax_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vfloa
   return __riscv_vfmax_vv_f16mf2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmax_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmax_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmax_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat16m
   return __riscv_vfmax_vv_f16m1_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmax_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmax_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat16m
   return __riscv_vfmax_vv_f16m2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmax_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmax_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat16m
   return __riscv_vfmax_vv_f16m4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmax_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmax_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat16m
   return __riscv_vfmax_vv_f16m8_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmax_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmax_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfmax_vv_f16mf4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmax_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmax_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfmax_vv_f16mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmax_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmax_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmax_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfmax_vv_f16m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmax_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmax_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfmax_vv_f16m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmax_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmax_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfmax_vv_f16m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmax_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmax_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfmax_vv_f16m8_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmax_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmax_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfmax_vv_f16mf4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmax_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmax_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfmax_vv_f16mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmax_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmax_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmax_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfmax_vv_f16m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmax_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmax_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfmax_vv_f16m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmax_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmax_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfmax_vv_f16m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmax_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmax_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfmax_vv_f16m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmax_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmax_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfmax_vv_f16mf4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmax_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmax_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfmax_vv_f16mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmax_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmax_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmax_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfmax_vv_f16m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmax_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmax_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfmax_vv_f16m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmax_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmax_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfmax_vv_f16m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmax_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmax_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfmax_vv_f16m8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmax_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmax_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfmerge.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfmerge.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfmerge_vfm_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, vbool64_t v0, size_t vl) {
+vfloat16mf4_t test_vfmerge_vfm_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, vbool64_t v0, size_t vl) {
   return __riscv_vfmerge_vfm_f16mf4_tu(vd, vs2, rs1, v0, vl);
 }
 
-vfloat16mf2_t test_vfmerge_vfm_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, vbool32_t v0, size_t vl) {
+vfloat16mf2_t test_vfmerge_vfm_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, vbool32_t v0, size_t vl) {
   return __riscv_vfmerge_vfm_f16mf2_tu(vd, vs2, rs1, v0, vl);
 }
 
-vfloat16m1_t test_vfmerge_vfm_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, vbool16_t v0, size_t vl) {
+vfloat16m1_t test_vfmerge_vfm_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, vbool16_t v0, size_t vl) {
   return __riscv_vfmerge_vfm_f16m1_tu(vd, vs2, rs1, v0, vl);
 }
 
-vfloat16m2_t test_vfmerge_vfm_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, vbool8_t v0, size_t vl) {
+vfloat16m2_t test_vfmerge_vfm_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, vbool8_t v0, size_t vl) {
   return __riscv_vfmerge_vfm_f16m2_tu(vd, vs2, rs1, v0, vl);
 }
 
-vfloat16m4_t test_vfmerge_vfm_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, vbool4_t v0, size_t vl) {
+vfloat16m4_t test_vfmerge_vfm_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, vbool4_t v0, size_t vl) {
   return __riscv_vfmerge_vfm_f16m4_tu(vd, vs2, rs1, v0, vl);
 }
 
-vfloat16m8_t test_vfmerge_vfm_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, vbool2_t v0, size_t vl) {
+vfloat16m8_t test_vfmerge_vfm_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, vbool2_t v0, size_t vl) {
   return __riscv_vfmerge_vfm_f16m8_tu(vd, vs2, rs1, v0, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfmin.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfmin.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vfloa
   return __riscv_vfmin_vv_f16mf4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmin_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmin_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vfloa
   return __riscv_vfmin_vv_f16mf2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmin_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmin_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmin_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat16m
   return __riscv_vfmin_vv_f16m1_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmin_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmin_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat16m
   return __riscv_vfmin_vv_f16m2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmin_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmin_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat16m
   return __riscv_vfmin_vv_f16m4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmin_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmin_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat16m
   return __riscv_vfmin_vv_f16m8_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmin_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmin_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfmin_vv_f16mf4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmin_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmin_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfmin_vv_f16mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmin_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmin_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmin_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfmin_vv_f16m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmin_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmin_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfmin_vv_f16m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmin_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmin_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfmin_vv_f16m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmin_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmin_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfmin_vv_f16m8_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmin_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmin_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfmin_vv_f16mf4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmin_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmin_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfmin_vv_f16mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmin_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmin_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmin_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfmin_vv_f16m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmin_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmin_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfmin_vv_f16m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmin_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmin_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfmin_vv_f16m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmin_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmin_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfmin_vv_f16m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmin_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmin_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfmin_vv_f16mf4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmin_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmin_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfmin_vv_f16mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmin_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmin_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmin_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfmin_vv_f16m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmin_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmin_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfmin_vv_f16m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmin_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmin_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfmin_vv_f16m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmin_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmin_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfmin_vv_f16m8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmin_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmin_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfmsac.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfmsac.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, vflo
   return __riscv_vfmsac_vv_f16mf4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_tu(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, vflo
   return __riscv_vfmsac_vv_f16mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_tu(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16
   return __riscv_vfmsac_vv_f16m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m1_tu(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16
   return __riscv_vfmsac_vv_f16m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m2_tu(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16
   return __riscv_vfmsac_vv_f16m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m4_tu(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16
   return __riscv_vfmsac_vv_f16m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m8_tu(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfmsac_vv_f16mf4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfmsac_vv_f16mf2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfmsac_vv_f16m1_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m1_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfmsac_vv_f16m2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m2_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfmsac_vv_f16m4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m4_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfmsac_vv_f16m8_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m8_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfmsac_vv_f16mf4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfmsac_vv_f16mf2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfmsac_vv_f16m1_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m1_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfmsac_vv_f16m2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m2_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfmsac_vv_f16m4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m4_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfmsac_vv_f16m8_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m8_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfmsac_vv_f16mf4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfmsac_vv_f16mf2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfmsac_vv_f16m1_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m1_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfmsac_vv_f16m2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfmsac_vv_f16m4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfmsac_vv_f16m8_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m8_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, v
   return __riscv_vfmsac_vv_f16mf4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, v
   return __riscv_vfmsac_vv_f16mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloa
   return __riscv_vfmsac_vv_f16m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m1_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloa
   return __riscv_vfmsac_vv_f16m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloa
   return __riscv_vfmsac_vv_f16m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloa
   return __riscv_vfmsac_vv_f16m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m8_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfmsac_vv_f16mf4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfmsac_vv_f16mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfmsac_vv_f16m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m1_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfmsac_vv_f16m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfmsac_vv_f16m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfmsac_vv_f16m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m8_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vflo
   return __riscv_vfmsac_vv_f16mf4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vflo
   return __riscv_vfmsac_vv_f16mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat1
   return __riscv_vfmsac_vv_f16m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m1_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16
   return __riscv_vfmsac_vv_f16m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16
   return __riscv_vfmsac_vv_f16m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16
   return __riscv_vfmsac_vv_f16m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m8_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfmsac_vv_f16mf4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfmsac_vv_f16mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16mf2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfmsac_vv_f16m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m1_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfmsac_vv_f16m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfmsac_vv_f16m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfmsac_vv_f16m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_vf_f16m8_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfmsub.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfmsub.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, vflo
   return __riscv_vfmsub_vv_f16mf4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_tu(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, vflo
   return __riscv_vfmsub_vv_f16mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_tu(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16
   return __riscv_vfmsub_vv_f16m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m1_tu(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16
   return __riscv_vfmsub_vv_f16m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m2_tu(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16
   return __riscv_vfmsub_vv_f16m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m4_tu(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16
   return __riscv_vfmsub_vv_f16m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m8_tu(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfmsub_vv_f16mf4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfmsub_vv_f16mf2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfmsub_vv_f16m1_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m1_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfmsub_vv_f16m2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m2_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfmsub_vv_f16m4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m4_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfmsub_vv_f16m8_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m8_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfmsub_vv_f16mf4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfmsub_vv_f16mf2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfmsub_vv_f16m1_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m1_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfmsub_vv_f16m2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m2_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfmsub_vv_f16m4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m4_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfmsub_vv_f16m8_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m8_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfmsub_vv_f16mf4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfmsub_vv_f16mf2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfmsub_vv_f16m1_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m1_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfmsub_vv_f16m2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfmsub_vv_f16m4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfmsub_vv_f16m8_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m8_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, v
   return __riscv_vfmsub_vv_f16mf4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, v
   return __riscv_vfmsub_vv_f16mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloa
   return __riscv_vfmsub_vv_f16m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m1_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloa
   return __riscv_vfmsub_vv_f16m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloa
   return __riscv_vfmsub_vv_f16m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloa
   return __riscv_vfmsub_vv_f16m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m8_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfmsub_vv_f16mf4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfmsub_vv_f16mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfmsub_vv_f16m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m1_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfmsub_vv_f16m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfmsub_vv_f16m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfmsub_vv_f16m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m8_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vflo
   return __riscv_vfmsub_vv_f16mf4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vflo
   return __riscv_vfmsub_vv_f16mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat1
   return __riscv_vfmsub_vv_f16m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m1_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16
   return __riscv_vfmsub_vv_f16m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16
   return __riscv_vfmsub_vv_f16m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16
   return __riscv_vfmsub_vv_f16m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m8_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfmsub_vv_f16mf4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfmsub_vv_f16mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16mf2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfmsub_vv_f16m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m1_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfmsub_vv_f16m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfmsub_vv_f16m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfmsub_vv_f16m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_vf_f16m8_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfmul.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfmul.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vfloa
   return __riscv_vfmul_vv_f16mf4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vfloa
   return __riscv_vfmul_vv_f16mf2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat16m
   return __riscv_vfmul_vv_f16m1_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat16m
   return __riscv_vfmul_vv_f16m2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat16m
   return __riscv_vfmul_vv_f16m4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat16m
   return __riscv_vfmul_vv_f16m8_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfmul_vv_f16mf4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfmul_vv_f16mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfmul_vv_f16m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfmul_vv_f16m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfmul_vv_f16m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfmul_vv_f16m8_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfmul_vv_f16mf4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfmul_vv_f16mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfmul_vv_f16m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfmul_vv_f16m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfmul_vv_f16m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfmul_vv_f16m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfmul_vv_f16mf4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfmul_vv_f16mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfmul_vv_f16m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfmul_vv_f16m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfmul_vv_f16m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfmul_vv_f16m8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vf
   return __riscv_vfmul_vv_f16mf4_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vf
   return __riscv_vfmul_vv_f16mf2_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat
   return __riscv_vfmul_vv_f16m1_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat
   return __riscv_vfmul_vv_f16m2_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat
   return __riscv_vfmul_vv_f16m4_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat
   return __riscv_vfmul_vv_f16m8_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfmul_vv_f16mf4_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfmul_vv_f16mf2_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfmul_vv_f16m1_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfmul_vv_f16m2_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfmul_vv_f16m4_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfmul_vv_f16m8_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfmul_vv_f16mf4_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfmul_vv_f16mf2_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfmul_vv_f16m1_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfmul_vv_f16m2_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfmul_vv_f16m4_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfmul_vv_f16m8_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfmul_vv_f16mf4_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfmul_vv_f16mf2_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfmul_vv_f16m1_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfmul_vv_f16m2_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfmul_vv_f16m4_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfmul_vv_f16m8_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_vf_f16m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfmv.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfmv.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfmv_v_f_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmv_v_f_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16mf4_tu(vd, rs1, vl);
 }
 
-vfloat16mf2_t test_vfmv_v_f_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmv_v_f_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16mf2_tu(vd, rs1, vl);
 }
 
-vfloat16m1_t test_vfmv_v_f_f16m1_tu(vfloat16m1_t vd, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmv_v_f_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16m1_tu(vd, rs1, vl);
 }
 
-vfloat16m2_t test_vfmv_v_f_f16m2_tu(vfloat16m2_t vd, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmv_v_f_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16m2_tu(vd, rs1, vl);
 }
 
-vfloat16m4_t test_vfmv_v_f_f16m4_tu(vfloat16m4_t vd, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmv_v_f_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16m4_tu(vd, rs1, vl);
 }
 
-vfloat16m8_t test_vfmv_v_f_f16m8_tu(vfloat16m8_t vd, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmv_v_f_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_f_f16m8_tu(vd, rs1, vl);
 }
 
@@ -67,27 +67,27 @@ vfloat64m8_t test_vfmv_v_f_f64m8_tu(vfloat64m8_t vd, float64_t rs1, size_t vl) {
   return __riscv_vfmv_v_f_f64m8_tu(vd, rs1, vl);
 }
 
-vfloat16mf4_t test_vfmv_s_f_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmv_s_f_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16mf4_tu(vd, rs1, vl);
 }
 
-vfloat16mf2_t test_vfmv_s_f_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmv_s_f_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16mf2_tu(vd, rs1, vl);
 }
 
-vfloat16m1_t test_vfmv_s_f_f16m1_tu(vfloat16m1_t vd, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmv_s_f_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16m1_tu(vd, rs1, vl);
 }
 
-vfloat16m2_t test_vfmv_s_f_f16m2_tu(vfloat16m2_t vd, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmv_s_f_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16m2_tu(vd, rs1, vl);
 }
 
-vfloat16m4_t test_vfmv_s_f_f16m4_tu(vfloat16m4_t vd, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmv_s_f_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16m4_tu(vd, rs1, vl);
 }
 
-vfloat16m8_t test_vfmv_s_f_f16m8_tu(vfloat16m8_t vd, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmv_s_f_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_f_f16m8_tu(vd, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfnmacc.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfnmacc.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfnmacc_vv_f16mf4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_tu(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfnmacc_vv_f16mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_tu(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfnmacc_vv_f16m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_tu(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfnmacc_vv_f16m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_tu(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfnmacc_vv_f16m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_tu(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat1
   return __riscv_vfnmacc_vv_f16m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_tu(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfnmacc_vv_f16mf4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfnmacc_vv_f16mf2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfnmacc_vv_f16m1_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfnmacc_vv_f16m2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfnmacc_vv_f16m4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfnmacc_vv_f16m8_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfnmacc_vv_f16mf4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfnmacc_vv_f16mf2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfnmacc_vv_f16m1_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfnmacc_vv_f16m2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfnmacc_vv_f16m4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfnmacc_vv_f16m8_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfnmacc_vv_f16mf4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfnmacc_vv_f16mf2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfnmacc_vv_f16m1_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfnmacc_vv_f16m2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfnmacc_vv_f16m4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfnmacc_vv_f16m8_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, 
   return __riscv_vfnmacc_vv_f16mf4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, 
   return __riscv_vfnmacc_vv_f16mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vflo
   return __riscv_vfnmacc_vv_f16m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vflo
   return __riscv_vfnmacc_vv_f16m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vflo
   return __riscv_vfnmacc_vv_f16m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vflo
   return __riscv_vfnmacc_vv_f16m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vflo
   return __riscv_vfnmacc_vv_f16mf4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vflo
   return __riscv_vfnmacc_vv_f16mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat1
   return __riscv_vfnmacc_vv_f16m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16
   return __riscv_vfnmacc_vv_f16m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16
   return __riscv_vfnmacc_vv_f16m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16
   return __riscv_vfnmacc_vv_f16m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfl
   return __riscv_vfnmacc_vv_f16mf4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfl
   return __riscv_vfnmacc_vv_f16mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat
   return __riscv_vfnmacc_vv_f16m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat1
   return __riscv_vfnmacc_vv_f16m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat1
   return __riscv_vfnmacc_vv_f16m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat1
   return __riscv_vfnmacc_vv_f16m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfnmacc_vv_f16mf4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfnmacc_vv_f16mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16mf2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfnmacc_vv_f16m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m1_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfnmacc_vv_f16m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfnmacc_vv_f16m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfnmacc_vv_f16m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_vf_f16m8_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfnmadd.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfnmadd.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfnmadd_vv_f16mf4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_tu(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfnmadd_vv_f16mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_tu(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfnmadd_vv_f16m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_tu(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfnmadd_vv_f16m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_tu(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfnmadd_vv_f16m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_tu(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat1
   return __riscv_vfnmadd_vv_f16m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_tu(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfnmadd_vv_f16mf4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfnmadd_vv_f16mf2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfnmadd_vv_f16m1_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfnmadd_vv_f16m2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfnmadd_vv_f16m4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfnmadd_vv_f16m8_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfnmadd_vv_f16mf4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfnmadd_vv_f16mf2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfnmadd_vv_f16m1_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfnmadd_vv_f16m2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfnmadd_vv_f16m4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfnmadd_vv_f16m8_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfnmadd_vv_f16mf4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfnmadd_vv_f16mf2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfnmadd_vv_f16m1_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfnmadd_vv_f16m2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfnmadd_vv_f16m4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfnmadd_vv_f16m8_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, 
   return __riscv_vfnmadd_vv_f16mf4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, 
   return __riscv_vfnmadd_vv_f16mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vflo
   return __riscv_vfnmadd_vv_f16m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vflo
   return __riscv_vfnmadd_vv_f16m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vflo
   return __riscv_vfnmadd_vv_f16m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vflo
   return __riscv_vfnmadd_vv_f16m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vflo
   return __riscv_vfnmadd_vv_f16mf4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vflo
   return __riscv_vfnmadd_vv_f16mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat1
   return __riscv_vfnmadd_vv_f16m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16
   return __riscv_vfnmadd_vv_f16m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16
   return __riscv_vfnmadd_vv_f16m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16
   return __riscv_vfnmadd_vv_f16m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfl
   return __riscv_vfnmadd_vv_f16mf4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfl
   return __riscv_vfnmadd_vv_f16mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat
   return __riscv_vfnmadd_vv_f16m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat1
   return __riscv_vfnmadd_vv_f16m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat1
   return __riscv_vfnmadd_vv_f16m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat1
   return __riscv_vfnmadd_vv_f16m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfnmadd_vv_f16mf4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfnmadd_vv_f16mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16mf2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfnmadd_vv_f16m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m1_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfnmadd_vv_f16m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfnmadd_vv_f16m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfnmadd_vv_f16m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_vf_f16m8_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfnmsac.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfnmsac.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfnmsac_vv_f16mf4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_tu(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfnmsac_vv_f16mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_tu(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfnmsac_vv_f16m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_tu(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfnmsac_vv_f16m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_tu(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfnmsac_vv_f16m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_tu(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat1
   return __riscv_vfnmsac_vv_f16m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_tu(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfnmsac_vv_f16mf4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfnmsac_vv_f16mf2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfnmsac_vv_f16m1_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfnmsac_vv_f16m2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfnmsac_vv_f16m4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfnmsac_vv_f16m8_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfnmsac_vv_f16mf4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfnmsac_vv_f16mf2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfnmsac_vv_f16m1_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfnmsac_vv_f16m2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfnmsac_vv_f16m4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfnmsac_vv_f16m8_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfnmsac_vv_f16mf4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfnmsac_vv_f16mf2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfnmsac_vv_f16m1_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfnmsac_vv_f16m2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfnmsac_vv_f16m4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfnmsac_vv_f16m8_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, 
   return __riscv_vfnmsac_vv_f16mf4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, 
   return __riscv_vfnmsac_vv_f16mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vflo
   return __riscv_vfnmsac_vv_f16m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vflo
   return __riscv_vfnmsac_vv_f16m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vflo
   return __riscv_vfnmsac_vv_f16m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vflo
   return __riscv_vfnmsac_vv_f16m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vflo
   return __riscv_vfnmsac_vv_f16mf4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vflo
   return __riscv_vfnmsac_vv_f16mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat1
   return __riscv_vfnmsac_vv_f16m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16
   return __riscv_vfnmsac_vv_f16m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16
   return __riscv_vfnmsac_vv_f16m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16
   return __riscv_vfnmsac_vv_f16m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfl
   return __riscv_vfnmsac_vv_f16mf4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfl
   return __riscv_vfnmsac_vv_f16mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat
   return __riscv_vfnmsac_vv_f16m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat1
   return __riscv_vfnmsac_vv_f16m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat1
   return __riscv_vfnmsac_vv_f16m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat1
   return __riscv_vfnmsac_vv_f16m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfnmsac_vv_f16mf4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfnmsac_vv_f16mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16mf2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfnmsac_vv_f16m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m1_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfnmsac_vv_f16m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfnmsac_vv_f16m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfnmsac_vv_f16m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_vf_f16m8_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfnmsub.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfnmsub.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfnmsub_vv_f16mf4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_tu(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfnmsub_vv_f16mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_tu(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfnmsub_vv_f16m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_tu(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfnmsub_vv_f16m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_tu(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfnmsub_vv_f16m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_tu(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat1
   return __riscv_vfnmsub_vv_f16m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_tu(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfnmsub_vv_f16mf4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfnmsub_vv_f16mf2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfnmsub_vv_f16m1_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfnmsub_vv_f16m2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfnmsub_vv_f16m4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfnmsub_vv_f16m8_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfnmsub_vv_f16mf4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfnmsub_vv_f16mf2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfnmsub_vv_f16m1_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfnmsub_vv_f16m2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfnmsub_vv_f16m4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfnmsub_vv_f16m8_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfnmsub_vv_f16mf4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfnmsub_vv_f16mf2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfnmsub_vv_f16m1_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfnmsub_vv_f16m2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfnmsub_vv_f16m4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfnmsub_vv_f16m8_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, 
   return __riscv_vfnmsub_vv_f16mf4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, 
   return __riscv_vfnmsub_vv_f16mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vflo
   return __riscv_vfnmsub_vv_f16m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vflo
   return __riscv_vfnmsub_vv_f16m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vflo
   return __riscv_vfnmsub_vv_f16m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vflo
   return __riscv_vfnmsub_vv_f16m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_rm_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vflo
   return __riscv_vfnmsub_vv_f16mf4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vflo
   return __riscv_vfnmsub_vv_f16mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat1
   return __riscv_vfnmsub_vv_f16m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16
   return __riscv_vfnmsub_vv_f16m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16
   return __riscv_vfnmsub_vv_f16m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16
   return __riscv_vfnmsub_vv_f16m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_rm_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfl
   return __riscv_vfnmsub_vv_f16mf4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfl
   return __riscv_vfnmsub_vv_f16mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat
   return __riscv_vfnmsub_vv_f16m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat1
   return __riscv_vfnmsub_vv_f16m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat1
   return __riscv_vfnmsub_vv_f16m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat1
   return __riscv_vfnmsub_vv_f16m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_rm_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfnmsub_vv_f16mf4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfnmsub_vv_f16mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16mf2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfnmsub_vv_f16m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m1_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfnmsub_vv_f16m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m2_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfnmsub_vv_f16m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m4_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfnmsub_vv_f16m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_vf_f16m8_rm_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfrdiv.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfrdiv.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -67,27 +67,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2, float64_
   return __riscv_vfrdiv_vf_f64m8_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -127,27 +127,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_tum(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t
   return __riscv_vfrdiv_vf_f64m8_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -187,27 +187,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_
   return __riscv_vfrdiv_vf_f64m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -247,27 +247,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t 
   return __riscv_vfrdiv_vf_f64m8_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -307,27 +307,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_rm_tu(vfloat64m8_t vd, vfloat64m8_t vs2, float
   return __riscv_vfrdiv_vf_f64m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -367,27 +367,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_rm_tum(vbool8_t vm, vfloat64m8_t vd, vfloat64m
   return __riscv_vfrdiv_vf_f64m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -427,27 +427,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_rm_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat64
   return __riscv_vfrdiv_vf_f64m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_vf_f16m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfrsub.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfrsub.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -67,27 +67,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2, float64_
   return __riscv_vfrsub_vf_f64m8_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -127,27 +127,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8_tum(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t
   return __riscv_vfrsub_vf_f64m8_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -187,27 +187,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_
   return __riscv_vfrsub_vf_f64m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -247,27 +247,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t 
   return __riscv_vfrsub_vf_f64m8_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -307,27 +307,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8_rm_tu(vfloat64m8_t vd, vfloat64m8_t vs2, float
   return __riscv_vfrsub_vf_f64m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -367,27 +367,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8_rm_tum(vbool8_t vm, vfloat64m8_t vd, vfloat64m
   return __riscv_vfrsub_vf_f64m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -427,27 +427,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8_rm_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat64
   return __riscv_vfrsub_vf_f64m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_vf_f16m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfsgnj.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfsgnj.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vflo
   return __riscv_vfsgnj_vv_f16mf4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnj_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnj_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vflo
   return __riscv_vfsgnj_vv_f16mf2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnj_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnj_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat16
   return __riscv_vfsgnj_vv_f16m1_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnj_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnj_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat16
   return __riscv_vfsgnj_vv_f16m2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnj_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnj_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat16
   return __riscv_vfsgnj_vv_f16m4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnj_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnj_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat16
   return __riscv_vfsgnj_vv_f16m8_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnj_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnj_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfsgnj_vv_f16mf4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnj_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnj_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfsgnj_vv_f16mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnj_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnj_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfsgnj_vv_f16m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnj_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnj_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfsgnj_vv_f16m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnj_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnj_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfsgnj_vv_f16m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnj_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnj_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfsgnj_vv_f16m8_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnj_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnj_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfsgnj_vv_f16mf4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnj_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnj_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfsgnj_vv_f16mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnj_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnj_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfsgnj_vv_f16m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnj_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnj_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfsgnj_vv_f16m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnj_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnj_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfsgnj_vv_f16m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnj_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnj_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfsgnj_vv_f16m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnj_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnj_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfsgnj_vv_f16mf4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnj_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnj_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfsgnj_vv_f16mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnj_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnj_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfsgnj_vv_f16m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnj_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnj_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfsgnj_vv_f16m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnj_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnj_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfsgnj_vv_f16m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnj_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnj_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfsgnj_vv_f16m8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnj_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnj_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfsgnjn.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfsgnjn.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vfl
   return __riscv_vfsgnjn_vv_f16mf4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjn_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjn_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vfl
   return __riscv_vfsgnjn_vv_f16mf2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjn_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjn_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat1
   return __riscv_vfsgnjn_vv_f16m1_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjn_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjn_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat1
   return __riscv_vfsgnjn_vv_f16m2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjn_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjn_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat1
   return __riscv_vfsgnjn_vv_f16m4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjn_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjn_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat1
   return __riscv_vfsgnjn_vv_f16m8_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjn_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjn_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfsgnjn_vv_f16mf4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjn_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjn_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfsgnjn_vv_f16mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjn_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjn_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfsgnjn_vv_f16m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjn_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjn_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfsgnjn_vv_f16m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjn_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjn_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfsgnjn_vv_f16m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjn_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjn_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfsgnjn_vv_f16m8_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjn_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjn_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfsgnjn_vv_f16mf4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjn_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjn_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfsgnjn_vv_f16mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjn_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjn_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfsgnjn_vv_f16m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjn_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjn_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfsgnjn_vv_f16m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjn_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjn_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfsgnjn_vv_f16m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjn_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjn_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfsgnjn_vv_f16m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjn_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjn_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfsgnjn_vv_f16mf4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjn_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjn_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfsgnjn_vv_f16mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjn_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjn_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfsgnjn_vv_f16m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjn_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjn_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfsgnjn_vv_f16m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjn_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjn_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfsgnjn_vv_f16m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjn_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjn_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfsgnjn_vv_f16m8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjn_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjn_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfsgnjx.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfsgnjx.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vfl
   return __riscv_vfsgnjx_vv_f16mf4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjx_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjx_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vfl
   return __riscv_vfsgnjx_vv_f16mf2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjx_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjx_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat1
   return __riscv_vfsgnjx_vv_f16m1_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjx_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjx_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat1
   return __riscv_vfsgnjx_vv_f16m2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjx_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjx_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat1
   return __riscv_vfsgnjx_vv_f16m4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjx_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjx_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat1
   return __riscv_vfsgnjx_vv_f16m8_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjx_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjx_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfsgnjx_vv_f16mf4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjx_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjx_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfsgnjx_vv_f16mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjx_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjx_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfsgnjx_vv_f16m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjx_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjx_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfsgnjx_vv_f16m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjx_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjx_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfsgnjx_vv_f16m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjx_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjx_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfsgnjx_vv_f16m8_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjx_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjx_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfsgnjx_vv_f16mf4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjx_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjx_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfsgnjx_vv_f16mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjx_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjx_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfsgnjx_vv_f16m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjx_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjx_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfsgnjx_vv_f16m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjx_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjx_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfsgnjx_vv_f16m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjx_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjx_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfsgnjx_vv_f16m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjx_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjx_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfsgnjx_vv_f16mf4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjx_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjx_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfsgnjx_vv_f16mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjx_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjx_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfsgnjx_vv_f16m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjx_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjx_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfsgnjx_vv_f16m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjx_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjx_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfsgnjx_vv_f16m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjx_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjx_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfsgnjx_vv_f16m8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjx_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjx_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfslide1down.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfslide1down.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfslide1down_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1down_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1down_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1down_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1down_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1down_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1down_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1down_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1down_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1down_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1down_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1down_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -67,27 +67,27 @@ vfloat64m8_t test_vfslide1down_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2, fl
   return __riscv_vfslide1down_vf_f64m8_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfslide1down_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1down_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1down_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1down_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1down_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1down_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1down_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1down_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1down_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1down_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1down_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1down_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -127,27 +127,27 @@ vfloat64m8_t test_vfslide1down_vf_f64m8_tum(vbool8_t vm, vfloat64m8_t vd, vfloat
   return __riscv_vfslide1down_vf_f64m8_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfslide1down_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1down_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1down_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1down_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1down_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1down_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1down_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1down_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1down_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1down_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1down_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1down_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -187,27 +187,27 @@ vfloat64m8_t test_vfslide1down_vf_f64m8_tumu(vbool8_t vm, vfloat64m8_t vd, vfloa
   return __riscv_vfslide1down_vf_f64m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfslide1down_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1down_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1down_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1down_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1down_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1down_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1down_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1down_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1down_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1down_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1down_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1down_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfslide1up.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfslide1up.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfslide1up_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1up_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1up_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1up_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1up_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1up_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1up_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1up_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1up_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1up_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1up_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1up_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -67,27 +67,27 @@ vfloat64m8_t test_vfslide1up_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2, floa
   return __riscv_vfslide1up_vf_f64m8_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfslide1up_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1up_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1up_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1up_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1up_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1up_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1up_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1up_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1up_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1up_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1up_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1up_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -127,27 +127,27 @@ vfloat64m8_t test_vfslide1up_vf_f64m8_tum(vbool8_t vm, vfloat64m8_t vd, vfloat64
   return __riscv_vfslide1up_vf_f64m8_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfslide1up_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1up_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1up_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1up_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1up_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1up_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1up_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1up_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1up_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1up_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1up_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1up_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -187,27 +187,27 @@ vfloat64m8_t test_vfslide1up_vf_f64m8_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat6
   return __riscv_vfslide1up_vf_f64m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfslide1up_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1up_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1up_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1up_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1up_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1up_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1up_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1up_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1up_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1up_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1up_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1up_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfsub.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfsub.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vfloa
   return __riscv_vfsub_vv_f16mf4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf4_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vfloa
   return __riscv_vfsub_vv_f16mf2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat16m
   return __riscv_vfsub_vv_f16m1_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat16m
   return __riscv_vfsub_vv_f16m2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat16m
   return __riscv_vfsub_vv_f16m4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat16m
   return __riscv_vfsub_vv_f16m8_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfsub_vv_f16mf4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfsub_vv_f16mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfsub_vv_f16m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m1_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfsub_vv_f16m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfsub_vv_f16m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfsub_vv_f16m8_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m8_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfsub_vv_f16mf4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfsub_vv_f16mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfsub_vv_f16m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfsub_vv_f16m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfsub_vv_f16m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfsub_vv_f16m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfsub_vv_f16mf4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfsub_vv_f16mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfsub_vv_f16m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfsub_vv_f16m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfsub_vv_f16m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfsub_vv_f16m8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vf
   return __riscv_vfsub_vv_f16mf4_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vf
   return __riscv_vfsub_vv_f16mf2_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat
   return __riscv_vfsub_vv_f16m1_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat
   return __riscv_vfsub_vv_f16m2_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat
   return __riscv_vfsub_vv_f16m4_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat
   return __riscv_vfsub_vv_f16m8_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfsub_vv_f16mf4_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfsub_vv_f16mf2_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfsub_vv_f16m1_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfsub_vv_f16m2_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfsub_vv_f16m4_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfsub_vv_f16m8_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfsub_vv_f16mf4_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfsub_vv_f16mf2_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfsub_vv_f16m1_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfsub_vv_f16m2_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfsub_vv_f16m4_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfsub_vv_f16m8_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfsub_vv_f16mf4_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfsub_vv_f16mf2_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfsub_vv_f16m1_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfsub_vv_f16m2_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfsub_vv_f16m4_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfsub_vv_f16m8_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_vf_f16m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfwadd.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfwadd.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, vflo
   return __riscv_vfwadd_vv_f32mf2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, vflo
   return __riscv_vfwadd_wv_f32mf2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, vfloat1
   return __riscv_vfwadd_vv_f32m1_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2, vfloat16
   return __riscv_vfwadd_wv_f32m1_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2, vfloat16
   return __riscv_vfwadd_vv_f32m2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2, vfloat16
   return __riscv_vfwadd_wv_f32m2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -59,7 +59,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2, vfloat16
   return __riscv_vfwadd_vv_f32m4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2, vfloat16
   return __riscv_vfwadd_wv_f32m4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -75,7 +75,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2, vfloat16
   return __riscv_vfwadd_vv_f32m8_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2, vfloat16
   return __riscv_vfwadd_wv_f32m8_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16
   return __riscv_vfwadd_vv_f32mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32
   return __riscv_vfwadd_wv_f32mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2
   return __riscv_vfwadd_vv_f32m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m1_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_
   return __riscv_vfwadd_wv_f32m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m1_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_
   return __riscv_vfwadd_vv_f32m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -195,7 +195,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_
   return __riscv_vfwadd_wv_f32m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -203,7 +203,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t
   return __riscv_vfwadd_vv_f32m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -211,7 +211,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t
   return __riscv_vfwadd_wv_f32m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -219,7 +219,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t
   return __riscv_vfwadd_vv_f32m8_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m8_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t
   return __riscv_vfwadd_wv_f32m8_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m8_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -299,7 +299,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat1
   return __riscv_vfwadd_vv_f32mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -307,7 +307,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat3
   return __riscv_vfwadd_wv_f32mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -315,7 +315,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf
   return __riscv_vfwadd_vv_f32m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -323,7 +323,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1
   return __riscv_vfwadd_wv_f32m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -331,7 +331,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1
   return __riscv_vfwadd_vv_f32m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -339,7 +339,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2
   return __riscv_vfwadd_wv_f32m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -347,7 +347,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_
   return __riscv_vfwadd_vv_f32m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -355,7 +355,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_
   return __riscv_vfwadd_wv_f32m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -363,7 +363,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_
   return __riscv_vfwadd_vv_f32m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_
   return __riscv_vfwadd_wv_f32m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -443,7 +443,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16m
   return __riscv_vfwadd_vv_f32mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -451,7 +451,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32m
   return __riscv_vfwadd_wv_f32mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -459,7 +459,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_
   return __riscv_vfwadd_vv_f32m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -467,7 +467,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t
   return __riscv_vfwadd_wv_f32m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -475,7 +475,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t
   return __riscv_vfwadd_vv_f32m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -483,7 +483,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t
   return __riscv_vfwadd_wv_f32m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t 
   return __riscv_vfwadd_vv_f32m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t 
   return __riscv_vfwadd_wv_f32m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t 
   return __riscv_vfwadd_vv_f32m8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t 
   return __riscv_vfwadd_wv_f32m8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -587,7 +587,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, v
   return __riscv_vfwadd_vv_f32mf2_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -595,7 +595,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, v
   return __riscv_vfwadd_wv_f32mf2_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -603,7 +603,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, vflo
   return __riscv_vfwadd_vv_f32m1_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2, vfloa
   return __riscv_vfwadd_wv_f32m1_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2, vfloa
   return __riscv_vfwadd_vv_f32m2_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2, vfloa
   return __riscv_vfwadd_wv_f32m2_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2, vfloa
   return __riscv_vfwadd_vv_f32m4_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2, vfloa
   return __riscv_vfwadd_wv_f32m4_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2, vfloa
   return __riscv_vfwadd_vv_f32m8_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -659,7 +659,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2, vfloa
   return __riscv_vfwadd_wv_f32m8_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwadd_vv_f32mf2_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwadd_wv_f32mf2_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16
   return __riscv_vfwadd_vv_f32m1_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32
   return __riscv_vfwadd_wv_f32m1_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16
   return __riscv_vfwadd_vv_f32m2_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32
   return __riscv_vfwadd_wv_f32m2_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -779,7 +779,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m
   return __riscv_vfwadd_vv_f32m4_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -787,7 +787,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m
   return __riscv_vfwadd_wv_f32m4_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -795,7 +795,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m
   return __riscv_vfwadd_vv_f32m8_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -803,7 +803,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m
   return __riscv_vfwadd_wv_f32m8_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vflo
   return __riscv_vfwadd_vv_f32mf2_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vflo
   return __riscv_vfwadd_wv_f32mf2_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat1
   return __riscv_vfwadd_vv_f32m1_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -899,7 +899,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat3
   return __riscv_vfwadd_wv_f32m1_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -907,7 +907,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat1
   return __riscv_vfwadd_vv_f32m2_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -915,7 +915,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat3
   return __riscv_vfwadd_wv_f32m2_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -923,7 +923,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16
   return __riscv_vfwadd_vv_f32m4_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -931,7 +931,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32
   return __riscv_vfwadd_wv_f32m4_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -939,7 +939,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16
   return __riscv_vfwadd_vv_f32m8_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -947,7 +947,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32
   return __riscv_vfwadd_wv_f32m8_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1019,7 +1019,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwadd_vv_f32mf2_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1027,7 +1027,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwadd_wv_f32mf2_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1035,7 +1035,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16m
   return __riscv_vfwadd_vv_f32m1_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1043,7 +1043,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m
   return __riscv_vfwadd_wv_f32m1_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1051,7 +1051,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m
   return __riscv_vfwadd_vv_f32m2_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1059,7 +1059,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m
   return __riscv_vfwadd_wv_f32m2_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1067,7 +1067,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2
   return __riscv_vfwadd_vv_f32m4_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1075,7 +1075,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4
   return __riscv_vfwadd_wv_f32m4_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1083,7 +1083,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4
   return __riscv_vfwadd_vv_f32m8_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_f32m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1091,7 +1091,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8
   return __riscv_vfwadd_wv_f32m8_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_f32m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfwmacc.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfwmacc.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfwmacc_vv_f32mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_tu(vd, vs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloat
   return __riscv_vfwmacc_vv_f32m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_tu(vd, vs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfwmacc_vv_f32m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_tu(vd, vs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfwmacc_vv_f32m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_tu(vd, vs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfwmacc_vv_f32m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_tu(vd, vs1, vs2, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat1
   return __riscv_vfwmacc_vv_f32mf2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf
   return __riscv_vfwmacc_vv_f32m1_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1
   return __riscv_vfwmacc_vv_f32m2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_
   return __riscv_vfwmacc_vv_f32m4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_
   return __riscv_vfwmacc_vv_f32m8_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwmacc_vv_f32mf2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16m
   return __riscv_vfwmacc_vv_f32m1_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m
   return __riscv_vfwmacc_vv_f32m2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2
   return __riscv_vfwmacc_vv_f32m4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4
   return __riscv_vfwmacc_vv_f32m8_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16
   return __riscv_vfwmacc_vv_f32mf2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2
   return __riscv_vfwmacc_vv_f32m1_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_
   return __riscv_vfwmacc_vv_f32m2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t
   return __riscv_vfwmacc_vv_f32m4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t
   return __riscv_vfwmacc_vv_f32m8_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -299,7 +299,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1, 
   return __riscv_vfwmacc_vv_f32mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -307,7 +307,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfwmacc_vv_f32m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -315,7 +315,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1, vflo
   return __riscv_vfwmacc_vv_f32m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -323,7 +323,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1, vflo
   return __riscv_vfwmacc_vv_f32m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -331,7 +331,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1, vflo
   return __riscv_vfwmacc_vv_f32m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vflo
   return __riscv_vfwmacc_vv_f32mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat1
   return __riscv_vfwmacc_vv_f32m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat1
   return __riscv_vfwmacc_vv_f32m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16
   return __riscv_vfwmacc_vv_f32m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16
   return __riscv_vfwmacc_vv_f32m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -443,7 +443,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfl
   return __riscv_vfwmacc_vv_f32mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -451,7 +451,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat
   return __riscv_vfwmacc_vv_f32m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +459,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat
   return __riscv_vfwmacc_vv_f32m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -467,7 +467,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat1
   return __riscv_vfwmacc_vv_f32m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -475,7 +475,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat1
   return __riscv_vfwmacc_vv_f32m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwmacc_vv_f32mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16
   return __riscv_vfwmacc_vv_f32m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16
   return __riscv_vfwmacc_vv_f32m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -539,7 +539,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m
   return __riscv_vfwmacc_vv_f32m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -547,7 +547,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m
   return __riscv_vfwmacc_vv_f32m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_vf_f32m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfwmsac.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfwmsac.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfwmsac_vv_f32mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_tu(vd, vs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloat
   return __riscv_vfwmsac_vv_f32m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_tu(vd, vs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfwmsac_vv_f32m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_tu(vd, vs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfwmsac_vv_f32m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_tu(vd, vs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfwmsac_vv_f32m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_tu(vd, vs1, vs2, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat1
   return __riscv_vfwmsac_vv_f32mf2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf
   return __riscv_vfwmsac_vv_f32m1_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1
   return __riscv_vfwmsac_vv_f32m2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_
   return __riscv_vfwmsac_vv_f32m4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_
   return __riscv_vfwmsac_vv_f32m8_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwmsac_vv_f32mf2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16m
   return __riscv_vfwmsac_vv_f32m1_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m
   return __riscv_vfwmsac_vv_f32m2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2
   return __riscv_vfwmsac_vv_f32m4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4
   return __riscv_vfwmsac_vv_f32m8_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16
   return __riscv_vfwmsac_vv_f32mf2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2
   return __riscv_vfwmsac_vv_f32m1_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_
   return __riscv_vfwmsac_vv_f32m2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t
   return __riscv_vfwmsac_vv_f32m4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t
   return __riscv_vfwmsac_vv_f32m8_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -299,7 +299,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1, 
   return __riscv_vfwmsac_vv_f32mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -307,7 +307,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfwmsac_vv_f32m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -315,7 +315,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1, vflo
   return __riscv_vfwmsac_vv_f32m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -323,7 +323,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1, vflo
   return __riscv_vfwmsac_vv_f32m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -331,7 +331,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1, vflo
   return __riscv_vfwmsac_vv_f32m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vflo
   return __riscv_vfwmsac_vv_f32mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat1
   return __riscv_vfwmsac_vv_f32m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat1
   return __riscv_vfwmsac_vv_f32m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16
   return __riscv_vfwmsac_vv_f32m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16
   return __riscv_vfwmsac_vv_f32m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -443,7 +443,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfl
   return __riscv_vfwmsac_vv_f32mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -451,7 +451,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat
   return __riscv_vfwmsac_vv_f32m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +459,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat
   return __riscv_vfwmsac_vv_f32m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -467,7 +467,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat1
   return __riscv_vfwmsac_vv_f32m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -475,7 +475,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat1
   return __riscv_vfwmsac_vv_f32m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwmsac_vv_f32mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16
   return __riscv_vfwmsac_vv_f32m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16
   return __riscv_vfwmsac_vv_f32m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -539,7 +539,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m
   return __riscv_vfwmsac_vv_f32m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -547,7 +547,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m
   return __riscv_vfwmsac_vv_f32m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_vf_f32m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfwmul.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfwmul.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, vflo
   return __riscv_vfwmul_vv_f32mf2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, vfloat1
   return __riscv_vfwmul_vv_f32m1_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2, vfloat16
   return __riscv_vfwmul_vv_f32m2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2, vfloat16
   return __riscv_vfwmul_vv_f32m4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2, vfloat16
   return __riscv_vfwmul_vv_f32m8_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16
   return __riscv_vfwmul_vv_f32mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2
   return __riscv_vfwmul_vv_f32m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m1_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_
   return __riscv_vfwmul_vv_f32m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t
   return __riscv_vfwmul_vv_f32m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t
   return __riscv_vfwmul_vv_f32m8_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m8_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat1
   return __riscv_vfwmul_vv_f32mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf
   return __riscv_vfwmul_vv_f32m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1
   return __riscv_vfwmul_vv_f32m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_
   return __riscv_vfwmul_vv_f32m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_
   return __riscv_vfwmul_vv_f32m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16m
   return __riscv_vfwmul_vv_f32mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_
   return __riscv_vfwmul_vv_f32m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t
   return __riscv_vfwmul_vv_f32m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t 
   return __riscv_vfwmul_vv_f32m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t 
   return __riscv_vfwmul_vv_f32m8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -299,7 +299,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, v
   return __riscv_vfwmul_vv_f32mf2_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -307,7 +307,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, vflo
   return __riscv_vfwmul_vv_f32m1_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -315,7 +315,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2, vfloa
   return __riscv_vfwmul_vv_f32m2_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -323,7 +323,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2, vfloa
   return __riscv_vfwmul_vv_f32m4_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -331,7 +331,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2, vfloa
   return __riscv_vfwmul_vv_f32m8_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwmul_vv_f32mf2_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16
   return __riscv_vfwmul_vv_f32m1_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16
   return __riscv_vfwmul_vv_f32m2_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m
   return __riscv_vfwmul_vv_f32m4_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m
   return __riscv_vfwmul_vv_f32m8_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -443,7 +443,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vflo
   return __riscv_vfwmul_vv_f32mf2_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -451,7 +451,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat1
   return __riscv_vfwmul_vv_f32m1_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +459,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat1
   return __riscv_vfwmul_vv_f32m2_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -467,7 +467,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16
   return __riscv_vfwmul_vv_f32m4_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -475,7 +475,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16
   return __riscv_vfwmul_vv_f32m8_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwmul_vv_f32mf2_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16m
   return __riscv_vfwmul_vv_f32m1_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m
   return __riscv_vfwmul_vv_f32m2_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -539,7 +539,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2
   return __riscv_vfwmul_vv_f32m4_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -547,7 +547,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4
   return __riscv_vfwmul_vv_f32m8_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_vf_f32m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfwnmacc.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfwnmacc.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1, vf
   return __riscv_vfwnmacc_vv_f32mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_tu(vd, vs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloa
   return __riscv_vfwnmacc_vv_f32m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_tu(vd, vs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat
   return __riscv_vfwnmacc_vv_f32m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_tu(vd, vs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat
   return __riscv_vfwnmacc_vv_f32m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_tu(vd, vs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat
   return __riscv_vfwnmacc_vv_f32m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_tu(vd, vs1, vs2, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwnmacc_vv_f32mf2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16m
   return __riscv_vfwnmacc_vv_f32m1_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m
   return __riscv_vfwnmacc_vv_f32m2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2
   return __riscv_vfwnmacc_vv_f32m4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4
   return __riscv_vfwnmacc_vv_f32m8_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwnmacc_vv_f32mf2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16
   return __riscv_vfwnmacc_vv_f32m1_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16
   return __riscv_vfwnmacc_vv_f32m2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m
   return __riscv_vfwnmacc_vv_f32m4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m
   return __riscv_vfwnmacc_vv_f32m8_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat1
   return __riscv_vfwnmacc_vv_f32mf2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf
   return __riscv_vfwnmacc_vv_f32m1_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1
   return __riscv_vfwnmacc_vv_f32m2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_
   return __riscv_vfwnmacc_vv_f32m4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_
   return __riscv_vfwnmacc_vv_f32m8_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -299,7 +299,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmacc_vv_f32mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -307,7 +307,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1, vf
   return __riscv_vfwnmacc_vv_f32m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -315,7 +315,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1, vfl
   return __riscv_vfwnmacc_vv_f32m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -323,7 +323,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1, vfl
   return __riscv_vfwnmacc_vv_f32m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -331,7 +331,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1, vfl
   return __riscv_vfwnmacc_vv_f32m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfl
   return __riscv_vfwnmacc_vv_f32mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat
   return __riscv_vfwnmacc_vv_f32m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat
   return __riscv_vfwnmacc_vv_f32m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat1
   return __riscv_vfwnmacc_vv_f32m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat1
   return __riscv_vfwnmacc_vv_f32m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -443,7 +443,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vf
   return __riscv_vfwnmacc_vv_f32mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -451,7 +451,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloa
   return __riscv_vfwnmacc_vv_f32m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +459,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloa
   return __riscv_vfwnmacc_vv_f32m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -467,7 +467,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat
   return __riscv_vfwnmacc_vv_f32m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -475,7 +475,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat
   return __riscv_vfwnmacc_vv_f32m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vflo
   return __riscv_vfwnmacc_vv_f32mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat1
   return __riscv_vfwnmacc_vv_f32m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat1
   return __riscv_vfwnmacc_vv_f32m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -539,7 +539,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16
   return __riscv_vfwnmacc_vv_f32m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -547,7 +547,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16
   return __riscv_vfwnmacc_vv_f32m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_vf_f32m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfwnmsac.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfwnmsac.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1, vf
   return __riscv_vfwnmsac_vv_f32mf2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_tu(vd, vs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloa
   return __riscv_vfwnmsac_vv_f32m1_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_tu(vd, vs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat
   return __riscv_vfwnmsac_vv_f32m2_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_tu(vd, vs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat
   return __riscv_vfwnmsac_vv_f32m4_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_tu(vd, vs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat
   return __riscv_vfwnmsac_vv_f32m8_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_tu(vd, vs1, vs2, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwnmsac_vv_f32mf2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16m
   return __riscv_vfwnmsac_vv_f32m1_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m
   return __riscv_vfwnmsac_vv_f32m2_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2
   return __riscv_vfwnmsac_vv_f32m4_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4
   return __riscv_vfwnmsac_vv_f32m8_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwnmsac_vv_f32mf2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16
   return __riscv_vfwnmsac_vv_f32m1_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16
   return __riscv_vfwnmsac_vv_f32m2_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m
   return __riscv_vfwnmsac_vv_f32m4_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m
   return __riscv_vfwnmsac_vv_f32m8_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat1
   return __riscv_vfwnmsac_vv_f32mf2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf
   return __riscv_vfwnmsac_vv_f32m1_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1
   return __riscv_vfwnmsac_vv_f32m2_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_
   return __riscv_vfwnmsac_vv_f32m4_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_
   return __riscv_vfwnmsac_vv_f32m8_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -299,7 +299,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmsac_vv_f32mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -307,7 +307,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1, vf
   return __riscv_vfwnmsac_vv_f32m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -315,7 +315,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1, vfl
   return __riscv_vfwnmsac_vv_f32m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -323,7 +323,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1, vfl
   return __riscv_vfwnmsac_vv_f32m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -331,7 +331,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1, vfl
   return __riscv_vfwnmsac_vv_f32m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_rm_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfl
   return __riscv_vfwnmsac_vv_f32mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat
   return __riscv_vfwnmsac_vv_f32m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat
   return __riscv_vfwnmsac_vv_f32m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat1
   return __riscv_vfwnmsac_vv_f32m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat1
   return __riscv_vfwnmsac_vv_f32m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_rm_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -443,7 +443,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vf
   return __riscv_vfwnmsac_vv_f32mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -451,7 +451,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloa
   return __riscv_vfwnmsac_vv_f32m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +459,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloa
   return __riscv_vfwnmsac_vv_f32m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -467,7 +467,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat
   return __riscv_vfwnmsac_vv_f32m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -475,7 +475,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat
   return __riscv_vfwnmsac_vv_f32m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_rm_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vflo
   return __riscv_vfwnmsac_vv_f32mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32mf2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat1
   return __riscv_vfwnmsac_vv_f32m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m1_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat1
   return __riscv_vfwnmsac_vv_f32m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m2_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -539,7 +539,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16
   return __riscv_vfwnmsac_vv_f32m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m4_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -547,7 +547,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16
   return __riscv_vfwnmsac_vv_f32m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_vf_f32m8_rm_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vfwsub.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfwsub.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, vflo
   return __riscv_vfwsub_vv_f32mf2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, vflo
   return __riscv_vfwsub_wv_f32mf2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, vfloat1
   return __riscv_vfwsub_vv_f32m1_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2, vfloat16
   return __riscv_vfwsub_wv_f32m1_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m1_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2, vfloat16
   return __riscv_vfwsub_vv_f32m2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2, vfloat16
   return __riscv_vfwsub_wv_f32m2_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m2_tu(vd, vs2, rs1, vl);
 }
 
@@ -59,7 +59,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2, vfloat16
   return __riscv_vfwsub_vv_f32m4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2, vfloat16
   return __riscv_vfwsub_wv_f32m4_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m4_tu(vd, vs2, rs1, vl);
 }
 
@@ -75,7 +75,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2, vfloat16
   return __riscv_vfwsub_vv_f32m8_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2, vfloat16
   return __riscv_vfwsub_wv_f32m8_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m8_tu(vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16
   return __riscv_vfwsub_vv_f32mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32
   return __riscv_vfwsub_wv_f32mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2
   return __riscv_vfwsub_vv_f32m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m1_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_
   return __riscv_vfwsub_wv_f32m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m1_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_
   return __riscv_vfwsub_vv_f32m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -195,7 +195,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_
   return __riscv_vfwsub_wv_f32m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m2_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -203,7 +203,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t
   return __riscv_vfwsub_vv_f32m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -211,7 +211,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t
   return __riscv_vfwsub_wv_f32m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m4_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -219,7 +219,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t
   return __riscv_vfwsub_vv_f32m8_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m8_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t
   return __riscv_vfwsub_wv_f32m8_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m8_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -299,7 +299,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat1
   return __riscv_vfwsub_vv_f32mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -307,7 +307,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat3
   return __riscv_vfwsub_wv_f32mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -315,7 +315,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf
   return __riscv_vfwsub_vv_f32m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -323,7 +323,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1
   return __riscv_vfwsub_wv_f32m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -331,7 +331,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1
   return __riscv_vfwsub_vv_f32m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -339,7 +339,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2
   return __riscv_vfwsub_wv_f32m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -347,7 +347,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_
   return __riscv_vfwsub_vv_f32m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -355,7 +355,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_
   return __riscv_vfwsub_wv_f32m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -363,7 +363,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_
   return __riscv_vfwsub_vv_f32m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_
   return __riscv_vfwsub_wv_f32m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -443,7 +443,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16m
   return __riscv_vfwsub_vv_f32mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -451,7 +451,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32m
   return __riscv_vfwsub_wv_f32mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -459,7 +459,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_
   return __riscv_vfwsub_vv_f32m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -467,7 +467,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t
   return __riscv_vfwsub_wv_f32m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m1_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -475,7 +475,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t
   return __riscv_vfwsub_vv_f32m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -483,7 +483,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t
   return __riscv_vfwsub_wv_f32m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m2_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t 
   return __riscv_vfwsub_vv_f32m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t 
   return __riscv_vfwsub_wv_f32m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t 
   return __riscv_vfwsub_vv_f32m8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t 
   return __riscv_vfwsub_wv_f32m8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -587,7 +587,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, v
   return __riscv_vfwsub_vv_f32mf2_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -595,7 +595,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, v
   return __riscv_vfwsub_wv_f32mf2_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -603,7 +603,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, vflo
   return __riscv_vfwsub_vv_f32m1_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2, vfloa
   return __riscv_vfwsub_wv_f32m1_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m1_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2, vfloa
   return __riscv_vfwsub_vv_f32m2_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2, vfloa
   return __riscv_vfwsub_wv_f32m2_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m2_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2, vfloa
   return __riscv_vfwsub_vv_f32m4_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2, vfloa
   return __riscv_vfwsub_wv_f32m4_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m4_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2, vfloa
   return __riscv_vfwsub_vv_f32m8_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -659,7 +659,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2, vfloa
   return __riscv_vfwsub_wv_f32m8_rm_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m8_rm_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwsub_vv_f32mf2_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwsub_wv_f32mf2_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16
   return __riscv_vfwsub_vv_f32m1_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32
   return __riscv_vfwsub_wv_f32m1_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m1_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16
   return __riscv_vfwsub_vv_f32m2_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32
   return __riscv_vfwsub_wv_f32m2_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m2_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -779,7 +779,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m
   return __riscv_vfwsub_vv_f32m4_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -787,7 +787,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m
   return __riscv_vfwsub_wv_f32m4_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m4_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -795,7 +795,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m
   return __riscv_vfwsub_vv_f32m8_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -803,7 +803,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m
   return __riscv_vfwsub_wv_f32m8_rm_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m8_rm_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vflo
   return __riscv_vfwsub_vv_f32mf2_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vflo
   return __riscv_vfwsub_wv_f32mf2_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat1
   return __riscv_vfwsub_vv_f32m1_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -899,7 +899,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat3
   return __riscv_vfwsub_wv_f32m1_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m1_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -907,7 +907,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat1
   return __riscv_vfwsub_vv_f32m2_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -915,7 +915,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat3
   return __riscv_vfwsub_wv_f32m2_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m2_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -923,7 +923,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16
   return __riscv_vfwsub_vv_f32m4_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -931,7 +931,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32
   return __riscv_vfwsub_wv_f32m4_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m4_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -939,7 +939,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16
   return __riscv_vfwsub_vv_f32m8_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -947,7 +947,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32
   return __riscv_vfwsub_wv_f32m8_rm_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m8_rm_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1019,7 +1019,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwsub_vv_f32mf2_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1027,7 +1027,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwsub_wv_f32mf2_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32mf2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1035,7 +1035,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16m
   return __riscv_vfwsub_vv_f32m1_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1043,7 +1043,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m
   return __riscv_vfwsub_wv_f32m1_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m1_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1051,7 +1051,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m
   return __riscv_vfwsub_vv_f32m2_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1059,7 +1059,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m
   return __riscv_vfwsub_wv_f32m2_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m2_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1067,7 +1067,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2
   return __riscv_vfwsub_vv_f32m4_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1075,7 +1075,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4
   return __riscv_vfwsub_wv_f32m4_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m4_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1083,7 +1083,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4
   return __riscv_vfwsub_vv_f32m8_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_f32m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1091,7 +1091,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8
   return __riscv_vfwsub_wv_f32m8_rm_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_f32m8_rm_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vmfeq.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vmfeq.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfeq_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t 
   return __riscv_vmfeq_vv_f16mf4_b64_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfeq_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfeq_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16mf4_b64_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfeq_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t 
   return __riscv_vmfeq_vv_f16mf2_b32_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfeq_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfeq_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16mf2_b32_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfeq_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs
   return __riscv_vmfeq_vv_f16m1_b16_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfeq_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfeq_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m1_b16_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfeq_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, v
   return __riscv_vmfeq_vv_f16m2_b8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfeq_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfeq_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m2_b8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfeq_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, v
   return __riscv_vmfeq_vv_f16m4_b4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfeq_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfeq_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m4_b4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfeq_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, v
   return __riscv_vmfeq_vv_f16m8_b2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfeq_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfeq_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_vf_f16m8_b2_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vmfge.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vmfge.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfge_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t 
   return __riscv_vmfge_vv_f16mf4_b64_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfge_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfge_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16mf4_b64_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfge_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t 
   return __riscv_vmfge_vv_f16mf2_b32_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfge_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfge_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16mf2_b32_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfge_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs
   return __riscv_vmfge_vv_f16m1_b16_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfge_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfge_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m1_b16_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfge_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, v
   return __riscv_vmfge_vv_f16m2_b8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfge_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfge_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m2_b8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfge_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, v
   return __riscv_vmfge_vv_f16m4_b4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfge_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfge_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m4_b4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfge_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, v
   return __riscv_vmfge_vv_f16m8_b2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfge_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfge_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_vf_f16m8_b2_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vmfgt.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vmfgt.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfgt_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t 
   return __riscv_vmfgt_vv_f16mf4_b64_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfgt_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfgt_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16mf4_b64_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfgt_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t 
   return __riscv_vmfgt_vv_f16mf2_b32_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfgt_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfgt_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16mf2_b32_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfgt_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs
   return __riscv_vmfgt_vv_f16m1_b16_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfgt_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfgt_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m1_b16_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfgt_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, v
   return __riscv_vmfgt_vv_f16m2_b8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfgt_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfgt_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m2_b8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfgt_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, v
   return __riscv_vmfgt_vv_f16m4_b4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfgt_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfgt_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m4_b4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfgt_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, v
   return __riscv_vmfgt_vv_f16m8_b2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfgt_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfgt_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_vf_f16m8_b2_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vmfle.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vmfle.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfle_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t 
   return __riscv_vmfle_vv_f16mf4_b64_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfle_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfle_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16mf4_b64_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfle_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t 
   return __riscv_vmfle_vv_f16mf2_b32_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfle_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfle_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16mf2_b32_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfle_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs
   return __riscv_vmfle_vv_f16m1_b16_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfle_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfle_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m1_b16_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfle_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, v
   return __riscv_vmfle_vv_f16m2_b8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfle_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfle_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m2_b8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfle_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, v
   return __riscv_vmfle_vv_f16m4_b4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfle_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfle_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m4_b4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfle_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, v
   return __riscv_vmfle_vv_f16m8_b2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfle_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfle_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_vf_f16m8_b2_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vmflt.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vmflt.c
@@ -11,7 +11,7 @@ vbool64_t test_vmflt_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t 
   return __riscv_vmflt_vv_f16mf4_b64_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool64_t test_vmflt_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmflt_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16mf4_b64_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmflt_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t 
   return __riscv_vmflt_vv_f16mf2_b32_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool32_t test_vmflt_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmflt_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16mf2_b32_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmflt_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs
   return __riscv_vmflt_vv_f16m1_b16_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool16_t test_vmflt_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmflt_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m1_b16_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmflt_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, v
   return __riscv_vmflt_vv_f16m2_b8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool8_t test_vmflt_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmflt_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m2_b8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmflt_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, v
   return __riscv_vmflt_vv_f16m4_b4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool4_t test_vmflt_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmflt_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m4_b4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmflt_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, v
   return __riscv_vmflt_vv_f16m8_b2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool2_t test_vmflt_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmflt_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_vf_f16m8_b2_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-api-tests/vmfne.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vmfne.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfne_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t 
   return __riscv_vmfne_vv_f16mf4_b64_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfne_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfne_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16mf4_b64_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfne_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t 
   return __riscv_vmfne_vv_f16mf2_b32_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfne_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfne_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16mf2_b32_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfne_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs
   return __riscv_vmfne_vv_f16m1_b16_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfne_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfne_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m1_b16_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfne_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, v
   return __riscv_vmfne_vv_f16m2_b8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfne_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfne_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m2_b8_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfne_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, v
   return __riscv_vmfne_vv_f16m4_b4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfne_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfne_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m4_b4_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfne_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, v
   return __riscv_vmfne_vv_f16m8_b2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfne_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfne_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_vf_f16m8_b2_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfadd.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfadd.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vfloa
   return __riscv_vfadd_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vfloa
   return __riscv_vfadd_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat16m
   return __riscv_vfadd_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat16m
   return __riscv_vfadd_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat16m
   return __riscv_vfadd_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat16m
   return __riscv_vfadd_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfadd_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfadd_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfadd_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfadd_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfadd_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfadd_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfadd_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfadd_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfadd_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfadd_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfadd_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfadd_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfadd_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfadd_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfadd_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfadd_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfadd_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfadd_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vf
   return __riscv_vfadd_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vf
   return __riscv_vfadd_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat
   return __riscv_vfadd_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat
   return __riscv_vfadd_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat
   return __riscv_vfadd_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat
   return __riscv_vfadd_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfadd_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfadd_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfadd_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfadd_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfadd_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfadd_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfadd_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfadd_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfadd_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfadd_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfadd_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfadd_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfadd_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfadd_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfadd_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfadd_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfadd_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfadd_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfdiv.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfdiv.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vfloa
   return __riscv_vfdiv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vfloa
   return __riscv_vfdiv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat16m
   return __riscv_vfdiv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat16m
   return __riscv_vfdiv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat16m
   return __riscv_vfdiv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat16m
   return __riscv_vfdiv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfdiv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfdiv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfdiv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfdiv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfdiv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfdiv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfdiv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfdiv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfdiv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfdiv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfdiv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfdiv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfdiv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfdiv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfdiv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfdiv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfdiv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfdiv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vf
   return __riscv_vfdiv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vf
   return __riscv_vfdiv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat
   return __riscv_vfdiv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat
   return __riscv_vfdiv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat
   return __riscv_vfdiv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat
   return __riscv_vfdiv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfdiv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfdiv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfdiv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfdiv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfdiv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfdiv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfdiv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfdiv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfdiv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfdiv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfdiv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfdiv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfdiv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfdiv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfdiv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfdiv_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfdiv_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfdiv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfdiv_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfdiv_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfdiv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfdiv_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfdiv_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfdiv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfdiv_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfdiv_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfmacc.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfmacc.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, vflo
   return __riscv_vfmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, vflo
   return __riscv_vfmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16
   return __riscv_vfmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16
   return __riscv_vfmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16
   return __riscv_vfmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16
   return __riscv_vfmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, v
   return __riscv_vfmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, v
   return __riscv_vfmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloa
   return __riscv_vfmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloa
   return __riscv_vfmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloa
   return __riscv_vfmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloa
   return __riscv_vfmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vflo
   return __riscv_vfmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vflo
   return __riscv_vfmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat1
   return __riscv_vfmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16
   return __riscv_vfmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16
   return __riscv_vfmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16
   return __riscv_vfmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmacc_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfmadd.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfmadd.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, vflo
   return __riscv_vfmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, vflo
   return __riscv_vfmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16
   return __riscv_vfmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16
   return __riscv_vfmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16
   return __riscv_vfmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16
   return __riscv_vfmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfmadd_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfmadd_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfmadd_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfmadd_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfmadd_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfmadd_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfmadd_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfmadd_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfmadd_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfmadd_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfmadd_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfmadd_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfmadd_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfmadd_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfmadd_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfmadd_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfmadd_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfmadd_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, v
   return __riscv_vfmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, v
   return __riscv_vfmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloa
   return __riscv_vfmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloa
   return __riscv_vfmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloa
   return __riscv_vfmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloa
   return __riscv_vfmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfmadd_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfmadd_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfmadd_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfmadd_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfmadd_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfmadd_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vflo
   return __riscv_vfmadd_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vflo
   return __riscv_vfmadd_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat1
   return __riscv_vfmadd_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16
   return __riscv_vfmadd_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16
   return __riscv_vfmadd_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16
   return __riscv_vfmadd_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfmadd_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfmadd_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfmadd_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfmadd_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfmadd_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfmadd_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfmax.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfmax.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vfloa
   return __riscv_vfmax_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmax_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmax_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vfloa
   return __riscv_vfmax_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmax_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmax_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmax_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat16m
   return __riscv_vfmax_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmax_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmax_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat16m
   return __riscv_vfmax_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmax_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmax_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat16m
   return __riscv_vfmax_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmax_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmax_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat16m
   return __riscv_vfmax_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmax_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmax_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tu(vd, vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfmax_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmax_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmax_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfmax_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmax_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmax_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmax_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfmax_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmax_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmax_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfmax_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmax_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmax_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfmax_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmax_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmax_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfmax_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmax_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmax_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfmax_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmax_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmax_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfmax_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmax_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmax_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmax_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfmax_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmax_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmax_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfmax_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmax_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmax_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfmax_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmax_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmax_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfmax_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmax_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmax_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfmax_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmax_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmax_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfmax_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmax_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmax_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmax_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfmax_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmax_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmax_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfmax_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmax_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmax_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfmax_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmax_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmax_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfmax_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmax_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmax_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfmerge.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfmerge.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfmerge_vfm_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, vbool64_t v0, size_t vl) {
+vfloat16mf4_t test_vfmerge_vfm_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, vbool64_t v0, size_t vl) {
   return __riscv_vfmerge_tu(vd, vs2, rs1, v0, vl);
 }
 
-vfloat16mf2_t test_vfmerge_vfm_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, vbool32_t v0, size_t vl) {
+vfloat16mf2_t test_vfmerge_vfm_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, vbool32_t v0, size_t vl) {
   return __riscv_vfmerge_tu(vd, vs2, rs1, v0, vl);
 }
 
-vfloat16m1_t test_vfmerge_vfm_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, vbool16_t v0, size_t vl) {
+vfloat16m1_t test_vfmerge_vfm_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, vbool16_t v0, size_t vl) {
   return __riscv_vfmerge_tu(vd, vs2, rs1, v0, vl);
 }
 
-vfloat16m2_t test_vfmerge_vfm_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, vbool8_t v0, size_t vl) {
+vfloat16m2_t test_vfmerge_vfm_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, vbool8_t v0, size_t vl) {
   return __riscv_vfmerge_tu(vd, vs2, rs1, v0, vl);
 }
 
-vfloat16m4_t test_vfmerge_vfm_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, vbool4_t v0, size_t vl) {
+vfloat16m4_t test_vfmerge_vfm_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, vbool4_t v0, size_t vl) {
   return __riscv_vfmerge_tu(vd, vs2, rs1, v0, vl);
 }
 
-vfloat16m8_t test_vfmerge_vfm_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, vbool2_t v0, size_t vl) {
+vfloat16m8_t test_vfmerge_vfm_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, vbool2_t v0, size_t vl) {
   return __riscv_vfmerge_tu(vd, vs2, rs1, v0, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfmin.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfmin.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vfloa
   return __riscv_vfmin_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmin_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmin_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vfloa
   return __riscv_vfmin_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmin_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmin_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmin_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat16m
   return __riscv_vfmin_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmin_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmin_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat16m
   return __riscv_vfmin_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmin_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmin_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat16m
   return __riscv_vfmin_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmin_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmin_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat16m
   return __riscv_vfmin_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmin_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmin_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tu(vd, vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfmin_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmin_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmin_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfmin_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmin_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmin_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmin_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfmin_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmin_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmin_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfmin_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmin_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmin_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfmin_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmin_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmin_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfmin_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmin_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmin_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfmin_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmin_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmin_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfmin_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmin_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmin_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmin_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfmin_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmin_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmin_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfmin_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmin_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmin_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfmin_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmin_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmin_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfmin_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmin_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmin_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfmin_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmin_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmin_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfmin_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmin_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmin_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmin_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfmin_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmin_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmin_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfmin_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmin_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmin_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfmin_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmin_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmin_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfmin_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmin_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmin_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfmsac.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfmsac.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, vflo
   return __riscv_vfmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, vflo
   return __riscv_vfmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16
   return __riscv_vfmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16
   return __riscv_vfmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16
   return __riscv_vfmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16
   return __riscv_vfmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, v
   return __riscv_vfmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, v
   return __riscv_vfmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloa
   return __riscv_vfmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloa
   return __riscv_vfmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloa
   return __riscv_vfmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloa
   return __riscv_vfmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vflo
   return __riscv_vfmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vflo
   return __riscv_vfmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat1
   return __riscv_vfmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16
   return __riscv_vfmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16
   return __riscv_vfmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16
   return __riscv_vfmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsac_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfmsub.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfmsub.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, vflo
   return __riscv_vfmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, vflo
   return __riscv_vfmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat16
   return __riscv_vfmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat16
   return __riscv_vfmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat16
   return __riscv_vfmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat16
   return __riscv_vfmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfmsub_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfmsub_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfmsub_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfmsub_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfmsub_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfmsub_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfmsub_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfmsub_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfmsub_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfmsub_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfmsub_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfmsub_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfmsub_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfmsub_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfmsub_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfmsub_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfmsub_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfmsub_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, v
   return __riscv_vfmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, v
   return __riscv_vfmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloa
   return __riscv_vfmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloa
   return __riscv_vfmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloa
   return __riscv_vfmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloa
   return __riscv_vfmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfmsub_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfmsub_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfmsub_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfmsub_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfmsub_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfmsub_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vflo
   return __riscv_vfmsub_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vflo
   return __riscv_vfmsub_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat1
   return __riscv_vfmsub_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16
   return __riscv_vfmsub_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16
   return __riscv_vfmsub_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16
   return __riscv_vfmsub_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfmsub_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfmsub_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfmsub_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfmsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfmsub_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfmsub_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfmsub_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfmul.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfmul.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vfloa
   return __riscv_vfmul_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vfloa
   return __riscv_vfmul_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat16m
   return __riscv_vfmul_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat16m
   return __riscv_vfmul_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat16m
   return __riscv_vfmul_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat16m
   return __riscv_vfmul_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfmul_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfmul_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfmul_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfmul_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfmul_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfmul_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfmul_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfmul_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfmul_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfmul_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfmul_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfmul_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfmul_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfmul_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfmul_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfmul_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfmul_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfmul_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vf
   return __riscv_vfmul_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vf
   return __riscv_vfmul_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat
   return __riscv_vfmul_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat
   return __riscv_vfmul_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat
   return __riscv_vfmul_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat
   return __riscv_vfmul_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfmul_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfmul_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfmul_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfmul_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfmul_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfmul_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfmul_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfmul_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfmul_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfmul_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfmul_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfmul_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfmul_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmul_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmul_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfmul_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmul_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmul_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfmul_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmul_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmul_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfmul_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmul_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmul_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfmul_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmul_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmul_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfmul_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmul_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmul_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfmv.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfmv.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfmv_v_f_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmv_v_f_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_tu(vd, rs1, vl);
 }
 
-vfloat16mf2_t test_vfmv_v_f_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmv_v_f_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_tu(vd, rs1, vl);
 }
 
-vfloat16m1_t test_vfmv_v_f_f16m1_tu(vfloat16m1_t vd, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmv_v_f_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_tu(vd, rs1, vl);
 }
 
-vfloat16m2_t test_vfmv_v_f_f16m2_tu(vfloat16m2_t vd, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmv_v_f_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_tu(vd, rs1, vl);
 }
 
-vfloat16m4_t test_vfmv_v_f_f16m4_tu(vfloat16m4_t vd, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmv_v_f_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_tu(vd, rs1, vl);
 }
 
-vfloat16m8_t test_vfmv_v_f_f16m8_tu(vfloat16m8_t vd, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmv_v_f_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_tu(vd, rs1, vl);
 }
 
@@ -67,27 +67,27 @@ vfloat64m8_t test_vfmv_v_f_f64m8_tu(vfloat64m8_t vd, float64_t rs1, size_t vl) {
   return __riscv_vfmv_v_tu(vd, rs1, vl);
 }
 
-vfloat16mf4_t test_vfmv_s_f_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfmv_s_f_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_tu(vd, rs1, vl);
 }
 
-vfloat16mf2_t test_vfmv_s_f_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfmv_s_f_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_tu(vd, rs1, vl);
 }
 
-vfloat16m1_t test_vfmv_s_f_f16m1_tu(vfloat16m1_t vd, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmv_s_f_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_tu(vd, rs1, vl);
 }
 
-vfloat16m2_t test_vfmv_s_f_f16m2_tu(vfloat16m2_t vd, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmv_s_f_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_tu(vd, rs1, vl);
 }
 
-vfloat16m4_t test_vfmv_s_f_f16m4_tu(vfloat16m4_t vd, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmv_s_f_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_tu(vd, rs1, vl);
 }
 
-vfloat16m8_t test_vfmv_s_f_f16m8_tu(vfloat16m8_t vd, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmv_s_f_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_tu(vd, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfnmacc.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfnmacc.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat1
   return __riscv_vfnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfnmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfnmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfnmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfnmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfnmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfnmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfnmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfnmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfnmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfnmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfnmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfnmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, 
   return __riscv_vfnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, 
   return __riscv_vfnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vflo
   return __riscv_vfnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vflo
   return __riscv_vfnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vflo
   return __riscv_vfnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vflo
   return __riscv_vfnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vflo
   return __riscv_vfnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vflo
   return __riscv_vfnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat1
   return __riscv_vfnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16
   return __riscv_vfnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16
   return __riscv_vfnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16
   return __riscv_vfnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfl
   return __riscv_vfnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfl
   return __riscv_vfnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat
   return __riscv_vfnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat1
   return __riscv_vfnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat1
   return __riscv_vfnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat1
   return __riscv_vfnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmacc_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmacc_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmacc_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmacc_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfnmadd.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfnmadd.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfnmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfnmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfnmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfnmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfnmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat1
   return __riscv_vfnmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfnmadd_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfnmadd_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfnmadd_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfnmadd_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfnmadd_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfnmadd_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfnmadd_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfnmadd_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfnmadd_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfnmadd_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfnmadd_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfnmadd_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfnmadd_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfnmadd_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfnmadd_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfnmadd_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfnmadd_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfnmadd_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, 
   return __riscv_vfnmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, 
   return __riscv_vfnmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vflo
   return __riscv_vfnmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vflo
   return __riscv_vfnmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vflo
   return __riscv_vfnmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vflo
   return __riscv_vfnmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vflo
   return __riscv_vfnmadd_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vflo
   return __riscv_vfnmadd_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat1
   return __riscv_vfnmadd_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16
   return __riscv_vfnmadd_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16
   return __riscv_vfnmadd_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16
   return __riscv_vfnmadd_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfl
   return __riscv_vfnmadd_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfl
   return __riscv_vfnmadd_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat
   return __riscv_vfnmadd_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat1
   return __riscv_vfnmadd_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat1
   return __riscv_vfnmadd_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat1
   return __riscv_vfnmadd_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfnmadd_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfnmadd_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfnmadd_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfnmadd_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfnmadd_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfnmadd_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfnmsac.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfnmsac.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat1
   return __riscv_vfnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfnmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfnmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfnmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfnmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfnmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfnmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfnmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfnmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfnmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfnmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfnmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfnmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, 
   return __riscv_vfnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, 
   return __riscv_vfnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vflo
   return __riscv_vfnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vflo
   return __riscv_vfnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vflo
   return __riscv_vfnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vflo
   return __riscv_vfnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vflo
   return __riscv_vfnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vflo
   return __riscv_vfnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat1
   return __riscv_vfnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16
   return __riscv_vfnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16
   return __riscv_vfnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16
   return __riscv_vfnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfl
   return __riscv_vfnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfl
   return __riscv_vfnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat
   return __riscv_vfnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat1
   return __riscv_vfnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat1
   return __riscv_vfnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat1
   return __riscv_vfnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsac_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsac_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsac_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsac_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfnmsub.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfnmsub.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfnmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfnmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfnmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfnmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfnmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vfloat1
   return __riscv_vfnmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfnmsub_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfnmsub_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfnmsub_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfnmsub_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfnmsub_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfnmsub_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfnmsub_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfnmsub_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfnmsub_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfnmsub_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfnmsub_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfnmsub_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfnmsub_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfnmsub_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfnmsub_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfnmsub_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfnmsub_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfnmsub_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, 
   return __riscv_vfnmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, 
   return __riscv_vfnmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1, vflo
   return __riscv_vfnmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1, vflo
   return __riscv_vfnmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1, vflo
   return __riscv_vfnmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1, vflo
   return __riscv_vfnmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vflo
   return __riscv_vfnmsub_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vflo
   return __riscv_vfnmsub_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat1
   return __riscv_vfnmsub_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16
   return __riscv_vfnmsub_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16
   return __riscv_vfnmsub_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16
   return __riscv_vfnmsub_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfl
   return __riscv_vfnmsub_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfl
   return __riscv_vfnmsub_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat
   return __riscv_vfnmsub_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat1
   return __riscv_vfnmsub_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat1
   return __riscv_vfnmsub_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat1
   return __riscv_vfnmsub_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfnmsub_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfnmsub_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfnmsub_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2, size_t vl) {
+vfloat16m1_t test_vfnmsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfnmsub_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2, size_t vl) {
+vfloat16m2_t test_vfnmsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfnmsub_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2, size_t vl) {
+vfloat16m4_t test_vfnmsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfnmsub_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2, size_t vl) {
+vfloat16m8_t test_vfnmsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfrdiv.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfrdiv.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, vl);
 }
 
@@ -67,27 +67,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2, float64_
   return __riscv_vfrdiv_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -127,27 +127,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_tum(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -187,27 +187,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -247,27 +247,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t 
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -307,27 +307,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_rm_tu(vfloat64m8_t vd, vfloat64m8_t vs2, float
   return __riscv_vfrdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -367,27 +367,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_rm_tum(vbool8_t vm, vfloat64m8_t vd, vfloat64m
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -427,27 +427,27 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_rm_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat64
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrdiv_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrdiv_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrdiv_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrdiv_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrdiv_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrdiv_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrdiv_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrdiv_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfrsub.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfrsub.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, vl);
 }
 
@@ -67,27 +67,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2, float64_
   return __riscv_vfrsub_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -127,27 +127,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8_tum(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -187,27 +187,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -247,27 +247,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t 
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -307,27 +307,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8_rm_tu(vfloat64m8_t vd, vfloat64m8_t vs2, float
   return __riscv_vfrsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -367,27 +367,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8_rm_tum(vbool8_t vm, vfloat64m8_t vd, vfloat64m
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -427,27 +427,27 @@ vfloat64m8_t test_vfrsub_vf_f64m8_rm_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat64
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfrsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfrsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfrsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfrsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfrsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfrsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfrsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfrsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfsgnj.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfsgnj.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vflo
   return __riscv_vfsgnj_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnj_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnj_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vflo
   return __riscv_vfsgnj_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnj_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnj_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat16
   return __riscv_vfsgnj_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnj_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnj_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat16
   return __riscv_vfsgnj_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnj_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnj_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat16
   return __riscv_vfsgnj_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnj_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnj_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat16
   return __riscv_vfsgnj_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnj_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnj_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tu(vd, vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfsgnj_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnj_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnj_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfsgnj_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnj_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnj_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfsgnj_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnj_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnj_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfsgnj_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnj_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnj_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfsgnj_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnj_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnj_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfsgnj_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnj_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnj_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfsgnj_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnj_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnj_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfsgnj_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnj_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnj_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfsgnj_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnj_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnj_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfsgnj_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnj_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnj_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfsgnj_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnj_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnj_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfsgnj_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnj_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnj_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfsgnj_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnj_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnj_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfsgnj_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnj_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnj_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfsgnj_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnj_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnj_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfsgnj_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnj_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnj_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfsgnj_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnj_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnj_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfsgnj_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnj_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnj_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfsgnjn.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfsgnjn.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vfl
   return __riscv_vfsgnjn_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjn_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjn_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vfl
   return __riscv_vfsgnjn_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjn_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjn_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat1
   return __riscv_vfsgnjn_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjn_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjn_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat1
   return __riscv_vfsgnjn_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjn_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjn_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat1
   return __riscv_vfsgnjn_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjn_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjn_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat1
   return __riscv_vfsgnjn_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjn_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjn_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tu(vd, vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfsgnjn_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjn_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjn_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfsgnjn_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjn_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjn_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfsgnjn_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjn_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjn_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfsgnjn_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjn_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjn_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfsgnjn_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjn_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjn_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfsgnjn_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjn_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjn_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfsgnjn_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjn_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjn_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfsgnjn_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjn_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjn_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfsgnjn_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjn_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjn_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfsgnjn_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjn_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjn_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfsgnjn_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjn_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjn_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfsgnjn_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjn_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjn_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfsgnjn_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjn_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjn_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfsgnjn_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjn_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjn_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfsgnjn_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjn_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjn_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfsgnjn_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjn_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjn_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfsgnjn_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjn_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjn_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfsgnjn_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjn_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjn_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfsgnjx.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfsgnjx.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vfl
   return __riscv_vfsgnjx_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjx_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjx_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vfl
   return __riscv_vfsgnjx_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjx_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjx_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat1
   return __riscv_vfsgnjx_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjx_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjx_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat1
   return __riscv_vfsgnjx_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjx_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjx_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat1
   return __riscv_vfsgnjx_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjx_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjx_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat1
   return __riscv_vfsgnjx_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjx_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjx_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tu(vd, vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfsgnjx_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjx_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjx_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfsgnjx_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjx_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjx_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfsgnjx_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjx_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjx_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfsgnjx_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjx_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjx_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfsgnjx_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjx_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjx_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfsgnjx_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjx_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjx_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfsgnjx_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjx_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjx_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfsgnjx_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjx_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjx_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfsgnjx_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjx_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjx_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfsgnjx_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjx_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjx_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfsgnjx_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjx_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjx_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfsgnjx_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjx_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjx_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfsgnjx_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsgnjx_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsgnjx_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfsgnjx_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsgnjx_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsgnjx_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfsgnjx_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsgnjx_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsgnjx_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfsgnjx_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsgnjx_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsgnjx_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfsgnjx_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsgnjx_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsgnjx_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfsgnjx_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsgnjx_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsgnjx_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfslide1down.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfslide1down.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfslide1down_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1down_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1down_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1down_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1down_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1down_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1down_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1down_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1down_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1down_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1down_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1down_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tu(vd, vs2, rs1, vl);
 }
 
@@ -67,27 +67,27 @@ vfloat64m8_t test_vfslide1down_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2, fl
   return __riscv_vfslide1down_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfslide1down_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1down_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1down_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1down_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1down_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1down_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1down_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1down_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1down_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1down_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1down_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1down_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -127,27 +127,27 @@ vfloat64m8_t test_vfslide1down_vf_f64m8_tum(vbool8_t vm, vfloat64m8_t vd, vfloat
   return __riscv_vfslide1down_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfslide1down_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1down_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1down_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1down_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1down_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1down_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1down_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1down_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1down_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1down_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1down_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1down_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -187,27 +187,27 @@ vfloat64m8_t test_vfslide1down_vf_f64m8_tumu(vbool8_t vm, vfloat64m8_t vd, vfloa
   return __riscv_vfslide1down_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfslide1down_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1down_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1down_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1down_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1down_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1down_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1down_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1down_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1down_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1down_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1down_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1down_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfslide1up.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfslide1up.c
@@ -7,27 +7,27 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfslide1up_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1up_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1up_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1up_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1up_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1up_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1up_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1up_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1up_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1up_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1up_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1up_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tu(vd, vs2, rs1, vl);
 }
 
@@ -67,27 +67,27 @@ vfloat64m8_t test_vfslide1up_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2, floa
   return __riscv_vfslide1up_tu(vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfslide1up_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1up_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1up_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1up_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1up_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1up_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1up_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1up_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1up_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1up_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1up_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1up_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -127,27 +127,27 @@ vfloat64m8_t test_vfslide1up_vf_f64m8_tum(vbool8_t vm, vfloat64m8_t vd, vfloat64
   return __riscv_vfslide1up_tum(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfslide1up_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1up_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1up_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1up_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1up_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1up_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1up_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1up_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1up_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1up_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1up_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1up_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -187,27 +187,27 @@ vfloat64m8_t test_vfslide1up_vf_f64m8_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat6
   return __riscv_vfslide1up_tumu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf4_t test_vfslide1up_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfslide1up_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16mf2_t test_vfslide1up_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfslide1up_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m1_t test_vfslide1up_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfslide1up_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m2_t test_vfslide1up_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfslide1up_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m4_t test_vfslide1up_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfslide1up_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_mu(vm, vd, vs2, rs1, vl);
 }
 
-vfloat16m8_t test_vfslide1up_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfslide1up_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfsub.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfsub.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vfloa
   return __riscv_vfsub_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vfloa
   return __riscv_vfsub_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat16m
   return __riscv_vfsub_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat16m
   return __riscv_vfsub_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat16m
   return __riscv_vfsub_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat16m
   return __riscv_vfsub_tu(vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, vl);
 }
 
@@ -131,7 +131,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16m
   return __riscv_vfsub_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -139,7 +139,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16m
   return __riscv_vfsub_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -147,7 +147,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t
   return __riscv_vfsub_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t 
   return __riscv_vfsub_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t 
   return __riscv_vfsub_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t 
   return __riscv_vfsub_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16
   return __riscv_vfsub_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16
   return __riscv_vfsub_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -267,7 +267,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_
   return __riscv_vfsub_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -275,7 +275,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t
   return __riscv_vfsub_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -283,7 +283,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t
   return __riscv_vfsub_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -291,7 +291,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t
   return __riscv_vfsub_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf
   return __riscv_vfsub_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf
   return __riscv_vfsub_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t 
   return __riscv_vfsub_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t v
   return __riscv_vfsub_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t v
   return __riscv_vfsub_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -411,7 +411,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t v
   return __riscv_vfsub_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, vf
   return __riscv_vfsub_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, vf
   return __riscv_vfsub_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, vfloat
   return __riscv_vfsub_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, vfloat
   return __riscv_vfsub_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, vfloat
   return __riscv_vfsub_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, vfloat
   return __riscv_vfsub_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat
   return __riscv_vfsub_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat
   return __riscv_vfsub_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m
   return __riscv_vfsub_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2
   return __riscv_vfsub_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4
   return __riscv_vfsub_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8
   return __riscv_vfsub_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloa
   return __riscv_vfsub_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloa
   return __riscv_vfsub_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16
   return __riscv_vfsub_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m
   return __riscv_vfsub_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m
   return __riscv_vfsub_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m
   return __riscv_vfsub_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -851,7 +851,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat1
   return __riscv_vfsub_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf4_t test_vfsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat1
   return __riscv_vfsub_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat16mf2_t test_vfsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -867,7 +867,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1
   return __riscv_vfsub_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_
   return __riscv_vfsub_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_
   return __riscv_vfsub_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_
   return __riscv_vfsub_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfwadd.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfwadd.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, vflo
   return __riscv_vfwadd_vv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, vflo
   return __riscv_vfwadd_wv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, vfloat1
   return __riscv_vfwadd_vv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2, vfloat16
   return __riscv_vfwadd_wv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2, vfloat16
   return __riscv_vfwadd_vv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2, vfloat16
   return __riscv_vfwadd_wv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -59,7 +59,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2, vfloat16
   return __riscv_vfwadd_vv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2, vfloat16
   return __riscv_vfwadd_wv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -75,7 +75,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2, vfloat16
   return __riscv_vfwadd_vv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2, vfloat16
   return __riscv_vfwadd_wv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16
   return __riscv_vfwadd_vv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32
   return __riscv_vfwadd_wv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2
   return __riscv_vfwadd_vv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_
   return __riscv_vfwadd_wv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_
   return __riscv_vfwadd_vv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -195,7 +195,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_
   return __riscv_vfwadd_wv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -203,7 +203,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t
   return __riscv_vfwadd_vv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -211,7 +211,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t
   return __riscv_vfwadd_wv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -219,7 +219,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t
   return __riscv_vfwadd_vv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t
   return __riscv_vfwadd_wv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -299,7 +299,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat1
   return __riscv_vfwadd_vv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -307,7 +307,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat3
   return __riscv_vfwadd_wv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -315,7 +315,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf
   return __riscv_vfwadd_vv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -323,7 +323,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1
   return __riscv_vfwadd_wv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -331,7 +331,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1
   return __riscv_vfwadd_vv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -339,7 +339,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2
   return __riscv_vfwadd_wv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -347,7 +347,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_
   return __riscv_vfwadd_vv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -355,7 +355,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_
   return __riscv_vfwadd_wv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -363,7 +363,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_
   return __riscv_vfwadd_vv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_
   return __riscv_vfwadd_wv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -443,7 +443,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16m
   return __riscv_vfwadd_vv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -451,7 +451,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32m
   return __riscv_vfwadd_wv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -459,7 +459,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_
   return __riscv_vfwadd_vv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -467,7 +467,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t
   return __riscv_vfwadd_wv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -475,7 +475,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t
   return __riscv_vfwadd_vv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -483,7 +483,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t
   return __riscv_vfwadd_wv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t 
   return __riscv_vfwadd_vv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t 
   return __riscv_vfwadd_wv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t 
   return __riscv_vfwadd_vv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t 
   return __riscv_vfwadd_wv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -587,7 +587,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, v
   return __riscv_vfwadd_vv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -595,7 +595,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, v
   return __riscv_vfwadd_wv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -603,7 +603,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, vflo
   return __riscv_vfwadd_vv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2, vfloa
   return __riscv_vfwadd_wv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2, vfloa
   return __riscv_vfwadd_vv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2, vfloa
   return __riscv_vfwadd_wv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2, vfloa
   return __riscv_vfwadd_vv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2, vfloa
   return __riscv_vfwadd_wv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2, vfloa
   return __riscv_vfwadd_vv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -659,7 +659,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2, vfloa
   return __riscv_vfwadd_wv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwadd_vv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwadd_wv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16
   return __riscv_vfwadd_vv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32
   return __riscv_vfwadd_wv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16
   return __riscv_vfwadd_vv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32
   return __riscv_vfwadd_wv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -779,7 +779,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m
   return __riscv_vfwadd_vv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -787,7 +787,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m
   return __riscv_vfwadd_wv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -795,7 +795,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m
   return __riscv_vfwadd_vv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -803,7 +803,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m
   return __riscv_vfwadd_wv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vflo
   return __riscv_vfwadd_vv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vflo
   return __riscv_vfwadd_wv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat1
   return __riscv_vfwadd_vv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -899,7 +899,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat3
   return __riscv_vfwadd_wv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -907,7 +907,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat1
   return __riscv_vfwadd_vv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -915,7 +915,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat3
   return __riscv_vfwadd_wv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -923,7 +923,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16
   return __riscv_vfwadd_vv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -931,7 +931,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32
   return __riscv_vfwadd_wv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -939,7 +939,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16
   return __riscv_vfwadd_vv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -947,7 +947,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32
   return __riscv_vfwadd_wv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1019,7 +1019,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwadd_vv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1027,7 +1027,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwadd_wv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1035,7 +1035,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16m
   return __riscv_vfwadd_vv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1043,7 +1043,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m
   return __riscv_vfwadd_wv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwadd_wf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwadd_wf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1051,7 +1051,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m
   return __riscv_vfwadd_vv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1059,7 +1059,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m
   return __riscv_vfwadd_wv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwadd_wf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwadd_wf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1067,7 +1067,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2
   return __riscv_vfwadd_vv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1075,7 +1075,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4
   return __riscv_vfwadd_wv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwadd_wf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwadd_wf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1083,7 +1083,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4
   return __riscv_vfwadd_vv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1091,7 +1091,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8
   return __riscv_vfwadd_wv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwadd_wf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwadd_wf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfwmacc.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfwmacc.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloat
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat1
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16m
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -299,7 +299,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1, 
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -307,7 +307,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -315,7 +315,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1, vflo
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -323,7 +323,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1, vflo
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -331,7 +331,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1, vflo
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vflo
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat1
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat1
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -443,7 +443,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfl
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -451,7 +451,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +459,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -467,7 +467,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat1
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -475,7 +475,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat1
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmacc_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmacc_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -539,7 +539,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmacc_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -547,7 +547,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmacc_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfwmsac.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfwmsac.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1, vfl
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloat
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat1
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat1
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat1
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat1
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16m
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -299,7 +299,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1, 
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -307,7 +307,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1, vfl
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -315,7 +315,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1, vflo
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -323,7 +323,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1, vflo
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -331,7 +331,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1, vflo
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vflo
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat1
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat1
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -443,7 +443,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfl
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -451,7 +451,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +459,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -467,7 +467,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat1
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -475,7 +475,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat1
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwmsac_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwmsac_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -539,7 +539,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwmsac_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -547,7 +547,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwmsac_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfwmul.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfwmul.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, vflo
   return __riscv_vfwmul_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, vfloat1
   return __riscv_vfwmul_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2, vfloat16
   return __riscv_vfwmul_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2, vfloat16
   return __riscv_vfwmul_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2, vfloat16
   return __riscv_vfwmul_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16
   return __riscv_vfwmul_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2
   return __riscv_vfwmul_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_
   return __riscv_vfwmul_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t
   return __riscv_vfwmul_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t
   return __riscv_vfwmul_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat1
   return __riscv_vfwmul_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf
   return __riscv_vfwmul_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1
   return __riscv_vfwmul_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_
   return __riscv_vfwmul_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_
   return __riscv_vfwmul_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16m
   return __riscv_vfwmul_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_
   return __riscv_vfwmul_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t
   return __riscv_vfwmul_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t 
   return __riscv_vfwmul_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t 
   return __riscv_vfwmul_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -299,7 +299,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, v
   return __riscv_vfwmul_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -307,7 +307,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, vflo
   return __riscv_vfwmul_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -315,7 +315,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2, vfloa
   return __riscv_vfwmul_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -323,7 +323,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2, vfloa
   return __riscv_vfwmul_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -331,7 +331,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2, vfloa
   return __riscv_vfwmul_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwmul_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16
   return __riscv_vfwmul_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16
   return __riscv_vfwmul_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m
   return __riscv_vfwmul_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m
   return __riscv_vfwmul_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -443,7 +443,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vflo
   return __riscv_vfwmul_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -451,7 +451,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat1
   return __riscv_vfwmul_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +459,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat1
   return __riscv_vfwmul_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -467,7 +467,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16
   return __riscv_vfwmul_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -475,7 +475,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16
   return __riscv_vfwmul_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwmul_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16m
   return __riscv_vfwmul_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmul_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwmul_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m
   return __riscv_vfwmul_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmul_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwmul_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -539,7 +539,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2
   return __riscv_vfwmul_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmul_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwmul_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -547,7 +547,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4
   return __riscv_vfwmul_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmul_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwmul_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfwnmacc.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfwnmacc.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1, vf
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloa
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16m
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat1
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -299,7 +299,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -307,7 +307,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1, vf
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -315,7 +315,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1, vfl
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -323,7 +323,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1, vfl
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -331,7 +331,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1, vfl
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfl
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat1
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat1
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -443,7 +443,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vf
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -451,7 +451,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloa
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +459,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloa
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -467,7 +467,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -475,7 +475,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vflo
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat1
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat1
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -539,7 +539,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -547,7 +547,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfwnmsac.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfwnmsac.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1, vf
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1, vfloa
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1, vfloat
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1, vfloat
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16m
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -99,7 +99,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -107,7 +107,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -115,7 +115,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat1
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -235,7 +235,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -243,7 +243,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -251,7 +251,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -259,7 +259,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
@@ -299,7 +299,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -307,7 +307,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1, vf
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -315,7 +315,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1, vfl
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -323,7 +323,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1, vfl
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -331,7 +331,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1, vfl
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfl
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -379,7 +379,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -387,7 +387,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -395,7 +395,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat1
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -403,7 +403,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat1
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -443,7 +443,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vf
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -451,7 +451,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloa
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -459,7 +459,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloa
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -467,7 +467,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -475,7 +475,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vflo
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1, vfloat16mf4_t vs2, size_t vl) {
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1, vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -523,7 +523,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat1
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1, vfloat16mf2_t vs2, size_t vl) {
+vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1, vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -531,7 +531,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat1
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1, vfloat16m1_t vs2, size_t vl) {
+vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -539,7 +539,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1, vfloat16m2_t vs2, size_t vl) {
+vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
@@ -547,7 +547,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1, vfloat16m4_t vs2, size_t vl) {
+vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfwsub.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfwsub.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, vflo
   return __riscv_vfwsub_vv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, vflo
   return __riscv_vfwsub_wv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, vfloat1
   return __riscv_vfwsub_vv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2, vfloat16
   return __riscv_vfwsub_wv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2, vfloat16
   return __riscv_vfwsub_vv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2, vfloat16
   return __riscv_vfwsub_wv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -59,7 +59,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2, vfloat16
   return __riscv_vfwsub_vv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2, vfloat16
   return __riscv_vfwsub_wv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -75,7 +75,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2, vfloat16
   return __riscv_vfwsub_vv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -83,7 +83,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2, vfloat16
   return __riscv_vfwsub_wv_tu(vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -155,7 +155,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16
   return __riscv_vfwsub_vv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -163,7 +163,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32
   return __riscv_vfwsub_wv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -171,7 +171,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2
   return __riscv_vfwsub_vv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -179,7 +179,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_
   return __riscv_vfwsub_wv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -187,7 +187,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_
   return __riscv_vfwsub_vv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -195,7 +195,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_
   return __riscv_vfwsub_wv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -203,7 +203,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t
   return __riscv_vfwsub_vv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -211,7 +211,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t
   return __riscv_vfwsub_wv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -219,7 +219,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t
   return __riscv_vfwsub_vv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -227,7 +227,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t
   return __riscv_vfwsub_wv_tum(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, vl);
 }
 
@@ -299,7 +299,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat1
   return __riscv_vfwsub_vv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -307,7 +307,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat3
   return __riscv_vfwsub_wv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -315,7 +315,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf
   return __riscv_vfwsub_vv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -323,7 +323,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1
   return __riscv_vfwsub_wv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -331,7 +331,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1
   return __riscv_vfwsub_vv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -339,7 +339,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2
   return __riscv_vfwsub_wv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -347,7 +347,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_
   return __riscv_vfwsub_vv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -355,7 +355,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_
   return __riscv_vfwsub_wv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -363,7 +363,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_
   return __riscv_vfwsub_vv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -371,7 +371,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_
   return __riscv_vfwsub_wv_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, vl);
 }
 
@@ -443,7 +443,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16m
   return __riscv_vfwsub_vv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -451,7 +451,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32m
   return __riscv_vfwsub_wv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -459,7 +459,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_
   return __riscv_vfwsub_vv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -467,7 +467,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t
   return __riscv_vfwsub_wv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -475,7 +475,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t
   return __riscv_vfwsub_vv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -483,7 +483,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t
   return __riscv_vfwsub_wv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -491,7 +491,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t 
   return __riscv_vfwsub_vv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -499,7 +499,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t 
   return __riscv_vfwsub_wv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -507,7 +507,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t 
   return __riscv_vfwsub_vv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -515,7 +515,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t 
   return __riscv_vfwsub_wv_mu(vm, vd, vs2, vs1, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -587,7 +587,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, v
   return __riscv_vfwsub_vv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -595,7 +595,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, v
   return __riscv_vfwsub_wv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -603,7 +603,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, vflo
   return __riscv_vfwsub_vv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -611,7 +611,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2, vfloa
   return __riscv_vfwsub_wv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -619,7 +619,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2, vfloa
   return __riscv_vfwsub_vv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -627,7 +627,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2, vfloa
   return __riscv_vfwsub_wv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -635,7 +635,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2, vfloa
   return __riscv_vfwsub_vv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -643,7 +643,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2, vfloa
   return __riscv_vfwsub_wv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -651,7 +651,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2, vfloa
   return __riscv_vfwsub_vv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -659,7 +659,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2, vfloa
   return __riscv_vfwsub_wv_tu(vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +731,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwsub_vv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -739,7 +739,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloa
   return __riscv_vfwsub_wv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -747,7 +747,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16
   return __riscv_vfwsub_vv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -755,7 +755,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32
   return __riscv_vfwsub_wv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -763,7 +763,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16
   return __riscv_vfwsub_vv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -771,7 +771,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32
   return __riscv_vfwsub_wv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -779,7 +779,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m
   return __riscv_vfwsub_vv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -787,7 +787,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m
   return __riscv_vfwsub_wv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -795,7 +795,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m
   return __riscv_vfwsub_vv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -803,7 +803,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m
   return __riscv_vfwsub_wv_tum(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -875,7 +875,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vflo
   return __riscv_vfwsub_vv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -883,7 +883,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vflo
   return __riscv_vfwsub_wv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -891,7 +891,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat1
   return __riscv_vfwsub_vv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -899,7 +899,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat3
   return __riscv_vfwsub_wv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -907,7 +907,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat1
   return __riscv_vfwsub_vv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -915,7 +915,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat3
   return __riscv_vfwsub_wv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -923,7 +923,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16
   return __riscv_vfwsub_vv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -931,7 +931,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32
   return __riscv_vfwsub_wv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -939,7 +939,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16
   return __riscv_vfwsub_vv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -947,7 +947,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32
   return __riscv_vfwsub_wv_tumu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1019,7 +1019,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwsub_vv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1027,7 +1027,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat
   return __riscv_vfwsub_wv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd, vfloat32mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1035,7 +1035,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16m
   return __riscv_vfwsub_vv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1043,7 +1043,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m
   return __riscv_vfwsub_wv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwsub_wf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m1_t test_vfwsub_wf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1051,7 +1051,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m
   return __riscv_vfwsub_vv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1059,7 +1059,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m
   return __riscv_vfwsub_wv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwsub_wf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m2_t test_vfwsub_wf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1067,7 +1067,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2
   return __riscv_vfwsub_vv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1075,7 +1075,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4
   return __riscv_vfwsub_wv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwsub_wf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m4_t test_vfwsub_wf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1083,7 +1083,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4
   return __riscv_vfwsub_vv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1091,7 +1091,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8
   return __riscv_vfwsub_wv_mu(vm, vd, vs2, vs1, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwsub_wf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, float16_t rs1, size_t vl) {
+vfloat32m8_t test_vfwsub_wf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vmfeq.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vmfeq.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfeq_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t 
   return __riscv_vmfeq_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfeq_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfeq_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfeq_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t 
   return __riscv_vmfeq_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfeq_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfeq_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfeq_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs
   return __riscv_vmfeq_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfeq_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfeq_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfeq_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, v
   return __riscv_vmfeq_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfeq_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfeq_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfeq_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, v
   return __riscv_vmfeq_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfeq_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfeq_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfeq_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, v
   return __riscv_vmfeq_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfeq_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfeq_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vmfge.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vmfge.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfge_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t 
   return __riscv_vmfge_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfge_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfge_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfge_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t 
   return __riscv_vmfge_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfge_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfge_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfge_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs
   return __riscv_vmfge_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfge_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfge_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfge_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, v
   return __riscv_vmfge_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfge_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfge_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfge_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, v
   return __riscv_vmfge_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfge_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfge_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfge_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, v
   return __riscv_vmfge_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfge_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfge_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfge_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vmfgt.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vmfgt.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfgt_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t 
   return __riscv_vmfgt_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfgt_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfgt_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfgt_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t 
   return __riscv_vmfgt_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfgt_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfgt_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfgt_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs
   return __riscv_vmfgt_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfgt_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfgt_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfgt_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, v
   return __riscv_vmfgt_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfgt_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfgt_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfgt_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, v
   return __riscv_vmfgt_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfgt_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfgt_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfgt_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, v
   return __riscv_vmfgt_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfgt_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfgt_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vmfle.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vmfle.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfle_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t 
   return __riscv_vmfle_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfle_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfle_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfle_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t 
   return __riscv_vmfle_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfle_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfle_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfle_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs
   return __riscv_vmfle_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfle_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfle_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfle_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, v
   return __riscv_vmfle_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfle_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfle_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfle_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, v
   return __riscv_vmfle_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfle_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfle_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfle_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, v
   return __riscv_vmfle_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfle_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfle_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfle_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vmflt.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vmflt.c
@@ -11,7 +11,7 @@ vbool64_t test_vmflt_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t 
   return __riscv_vmflt_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool64_t test_vmflt_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmflt_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmflt_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t 
   return __riscv_vmflt_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool32_t test_vmflt_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmflt_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmflt_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs
   return __riscv_vmflt_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool16_t test_vmflt_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmflt_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmflt_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, v
   return __riscv_vmflt_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool8_t test_vmflt_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmflt_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmflt_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, v
   return __riscv_vmflt_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool4_t test_vmflt_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmflt_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmflt_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, v
   return __riscv_vmflt_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool2_t test_vmflt_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmflt_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmflt_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vmfne.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vmfne.c
@@ -11,7 +11,7 @@ vbool64_t test_vmfne_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t 
   return __riscv_vmfne_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool64_t test_vmfne_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, float16_t rs1, size_t vl) {
+vbool64_t test_vmfne_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -19,7 +19,7 @@ vbool32_t test_vmfne_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t 
   return __riscv_vmfne_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool32_t test_vmfne_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, float16_t rs1, size_t vl) {
+vbool32_t test_vmfne_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -27,7 +27,7 @@ vbool16_t test_vmfne_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs
   return __riscv_vmfne_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool16_t test_vmfne_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, float16_t rs1, size_t vl) {
+vbool16_t test_vmfne_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -35,7 +35,7 @@ vbool8_t test_vmfne_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, v
   return __riscv_vmfne_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool8_t test_vmfne_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, float16_t rs1, size_t vl) {
+vbool8_t test_vmfne_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -43,7 +43,7 @@ vbool4_t test_vmfne_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, v
   return __riscv_vmfne_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool4_t test_vmfne_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, float16_t rs1, size_t vl) {
+vbool4_t test_vmfne_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vbool2_t test_vmfne_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, v
   return __riscv_vmfne_mu(vm, vd, vs2, vs1, vl);
 }
 
-vbool2_t test_vmfne_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, float16_t rs1, size_t vl) {
+vbool2_t test_vmfne_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vmfne_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/intrinsic_funcs/04_vector_floating-point_instructions.adoc
+++ b/auto-generated/policy_funcs/intrinsic_funcs/04_vector_floating-point_instructions.adoc
@@ -9,27 +9,27 @@
 vfloat16mf4_t __riscv_vfadd_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                          vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfadd_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfadd_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                          vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfadd_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfadd_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfadd_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfadd_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                                        vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfadd_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfadd_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                                        vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfadd_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfadd_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                                        vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfadd_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfadd_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                          vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfadd_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
@@ -69,27 +69,27 @@ vfloat64m8_t __riscv_vfadd_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfsub_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                          vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsub_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsub_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                          vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsub_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsub_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsub_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsub_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                                        vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsub_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsub_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                                        vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsub_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsub_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                                        vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsub_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsub_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                          vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsub_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
@@ -127,17 +127,17 @@ vfloat64m8_t __riscv_vfsub_vv_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfsub_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
                                        float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfrsub_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl);
+                                          _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfrsub_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                          float16_t rs1, size_t vl);
+                                          _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfrsub_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfrsub_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfrsub_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfrsub_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrsub_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                           float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfrsub_vf_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
@@ -191,37 +191,37 @@ vfloat16mf4_t __riscv_vfadd_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
                                           vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfadd_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
                                           vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m1_t __riscv_vfadd_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
                                         vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         size_t vl);
 vfloat16m1_t __riscv_vfadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m2_t __riscv_vfadd_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
                                         vfloat16m2_t vs2, vfloat16m2_t vs1,
                                         size_t vl);
 vfloat16m2_t __riscv_vfadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m4_t __riscv_vfadd_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
                                         vfloat16m4_t vs2, vfloat16m4_t vs1,
                                         size_t vl);
 vfloat16m4_t __riscv_vfadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m8_t __riscv_vfadd_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
                                         vfloat16m8_t vs2, vfloat16m8_t vs1,
                                         size_t vl);
 vfloat16m8_t __riscv_vfadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfadd_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -281,37 +281,37 @@ vfloat16mf4_t __riscv_vfsub_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
                                           vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfsub_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
                                           vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m1_t __riscv_vfsub_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
                                         vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         size_t vl);
 vfloat16m1_t __riscv_vfsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m2_t __riscv_vfsub_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
                                         vfloat16m2_t vs2, vfloat16m2_t vs1,
                                         size_t vl);
 vfloat16m2_t __riscv_vfsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m4_t __riscv_vfsub_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
                                         vfloat16m4_t vs2, vfloat16m4_t vs1,
                                         size_t vl);
 vfloat16m4_t __riscv_vfsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m8_t __riscv_vfsub_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
                                         vfloat16m8_t vs2, vfloat16m8_t vs1,
                                         size_t vl);
 vfloat16m8_t __riscv_vfsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfsub_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -368,22 +368,22 @@ vfloat64m8_t __riscv_vfsub_vf_f64m8_tum(vbool8_t vm, vfloat64m8_t vd,
                                         vfloat64m8_t vs2, float64_t rs1,
                                         size_t vl);
 vfloat16mf4_t __riscv_vfrsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfrsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16m1_t __riscv_vfrsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfrsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfrsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfrsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfrsub_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs2, float32_t rs1,
@@ -447,37 +447,37 @@ vfloat16mf4_t __riscv_vfadd_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                            vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfadd_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                            vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16m1_t __riscv_vfadd_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
                                          vfloat16m1_t vs2, vfloat16m1_t vs1,
                                          size_t vl);
 vfloat16m1_t __riscv_vfadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfadd_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
                                          vfloat16m2_t vs2, vfloat16m2_t vs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfadd_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
                                          vfloat16m4_t vs2, vfloat16m4_t vs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfadd_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
                                          vfloat16m8_t vs2, vfloat16m8_t vs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfadd_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -537,37 +537,37 @@ vfloat16mf4_t __riscv_vfsub_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                            vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfsub_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                            vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16m1_t __riscv_vfsub_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
                                          vfloat16m1_t vs2, vfloat16m1_t vs1,
                                          size_t vl);
 vfloat16m1_t __riscv_vfsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfsub_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
                                          vfloat16m2_t vs2, vfloat16m2_t vs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfsub_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
                                          vfloat16m4_t vs2, vfloat16m4_t vs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfsub_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
                                          vfloat16m8_t vs2, vfloat16m8_t vs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfsub_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -624,22 +624,22 @@ vfloat64m8_t __riscv_vfsub_vf_f64m8_tumu(vbool8_t vm, vfloat64m8_t vd,
                                          vfloat64m8_t vs2, float64_t rs1,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfrsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfrsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                            vfloat16mf2_t vs2, float16_t rs1,
+                                            vfloat16mf2_t vs2, _Float16 rs1,
                                             size_t vl);
 vfloat16m1_t __riscv_vfrsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m2_t __riscv_vfrsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m4_t __riscv_vfrsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m8_t __riscv_vfrsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                          vfloat16m8_t vs2, float16_t rs1,
+                                          vfloat16m8_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfrsub_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs2, float32_t rs1,
@@ -703,37 +703,37 @@ vfloat16mf4_t __riscv_vfadd_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
                                          vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfadd_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
                                          vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m1_t __riscv_vfadd_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
                                        vfloat16m1_t vs2, vfloat16m1_t vs1,
                                        size_t vl);
 vfloat16m1_t __riscv_vfadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m2_t __riscv_vfadd_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
                                        vfloat16m2_t vs2, vfloat16m2_t vs1,
                                        size_t vl);
 vfloat16m2_t __riscv_vfadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m4_t __riscv_vfadd_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
                                        vfloat16m4_t vs2, vfloat16m4_t vs1,
                                        size_t vl);
 vfloat16m4_t __riscv_vfadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m8_t __riscv_vfadd_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
                                        vfloat16m8_t vs2, vfloat16m8_t vs1,
                                        size_t vl);
 vfloat16m8_t __riscv_vfadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfadd_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                          vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -793,37 +793,37 @@ vfloat16mf4_t __riscv_vfsub_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
                                          vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfsub_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
                                          vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m1_t __riscv_vfsub_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
                                        vfloat16m1_t vs2, vfloat16m1_t vs1,
                                        size_t vl);
 vfloat16m1_t __riscv_vfsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m2_t __riscv_vfsub_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
                                        vfloat16m2_t vs2, vfloat16m2_t vs1,
                                        size_t vl);
 vfloat16m2_t __riscv_vfsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m4_t __riscv_vfsub_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
                                        vfloat16m4_t vs2, vfloat16m4_t vs1,
                                        size_t vl);
 vfloat16m4_t __riscv_vfsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m8_t __riscv_vfsub_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
                                        vfloat16m8_t vs2, vfloat16m8_t vs1,
                                        size_t vl);
 vfloat16m8_t __riscv_vfsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfsub_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                          vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -880,22 +880,22 @@ vfloat64m8_t __riscv_vfsub_vf_f64m8_mu(vbool8_t vm, vfloat64m8_t vd,
                                        vfloat64m8_t vs2, float64_t rs1,
                                        size_t vl);
 vfloat16mf4_t __riscv_vfrsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfrsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m1_t __riscv_vfrsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m2_t __riscv_vfrsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m4_t __riscv_vfrsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m8_t __riscv_vfrsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfrsub_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs2, float32_t rs1,
@@ -958,37 +958,37 @@ vfloat16mf4_t __riscv_vfadd_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                             vfloat16mf4_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf4_t __riscv_vfadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfadd_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                             vfloat16mf2_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat16m1_t __riscv_vfadd_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                                           vfloat16m1_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat16m1_t __riscv_vfadd_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m2_t __riscv_vfadd_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                                           vfloat16m2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat16m2_t __riscv_vfadd_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m4_t __riscv_vfadd_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                                           vfloat16m4_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat16m4_t __riscv_vfadd_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m8_t __riscv_vfadd_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                                           vfloat16m8_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat16m8_t __riscv_vfadd_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfadd_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                             vfloat32mf2_t vs1, unsigned int frm,
@@ -1048,37 +1048,37 @@ vfloat16mf4_t __riscv_vfsub_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                             vfloat16mf4_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf4_t __riscv_vfsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfsub_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                             vfloat16mf2_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat16m1_t __riscv_vfsub_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                                           vfloat16m1_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat16m1_t __riscv_vfsub_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m2_t __riscv_vfsub_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                                           vfloat16m2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat16m2_t __riscv_vfsub_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m4_t __riscv_vfsub_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                                           vfloat16m4_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat16m4_t __riscv_vfsub_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m8_t __riscv_vfsub_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                                           vfloat16m8_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat16m8_t __riscv_vfsub_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfsub_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                             vfloat32mf2_t vs1, unsigned int frm,
@@ -1135,22 +1135,22 @@ vfloat64m8_t __riscv_vfsub_vf_f64m8_rm_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
                                           float64_t rs1, unsigned int frm,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfrsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfrsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd,
-                                             vfloat16mf2_t vs2, float16_t rs1,
+                                             vfloat16mf2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfrsub_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16m2_t __riscv_vfrsub_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16m4_t __riscv_vfrsub_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16m8_t __riscv_vfrsub_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfrsub_vf_f32mf2_rm_tu(vfloat32mf2_t vd,
                                              vfloat32mf2_t vs2, float32_t rs1,
@@ -1185,38 +1185,38 @@ vfloat16mf4_t __riscv_vfadd_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfadd_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs2,
                                              vfloat16mf2_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                             vfloat16mf2_t vs2, float16_t rs1,
+                                             vfloat16mf2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfadd_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs2, vfloat16m1_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                           vfloat16m1_t vs2, float16_t rs1,
+                                           vfloat16m1_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfadd_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs2, vfloat16m2_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                           vfloat16m2_t vs2, float16_t rs1,
+                                           vfloat16m2_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfadd_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs2, vfloat16m4_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                           vfloat16m4_t vs2, float16_t rs1,
+                                           vfloat16m4_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfadd_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs2, vfloat16m8_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                           vfloat16m8_t vs2, float16_t rs1,
+                                           vfloat16m8_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfadd_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs2,
@@ -1278,38 +1278,38 @@ vfloat16mf4_t __riscv_vfsub_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfsub_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs2,
                                              vfloat16mf2_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                             vfloat16mf2_t vs2, float16_t rs1,
+                                             vfloat16mf2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfsub_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs2, vfloat16m1_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                           vfloat16m1_t vs2, float16_t rs1,
+                                           vfloat16m1_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfsub_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs2, vfloat16m2_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                           vfloat16m2_t vs2, float16_t rs1,
+                                           vfloat16m2_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfsub_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs2, vfloat16m4_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                           vfloat16m4_t vs2, float16_t rs1,
+                                           vfloat16m4_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfsub_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs2, vfloat16m8_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                           vfloat16m8_t vs2, float16_t rs1,
+                                           vfloat16m8_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfsub_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs2,
@@ -1367,22 +1367,22 @@ vfloat64m8_t __riscv_vfsub_vf_f64m8_rm_tum(vbool8_t vm, vfloat64m8_t vd,
                                            vfloat64m8_t vs2, float64_t rs1,
                                            unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfrsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                              vfloat16mf4_t vs2, float16_t rs1,
+                                              vfloat16mf4_t vs2, _Float16 rs1,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfrsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                              vfloat16mf2_t vs2, float16_t rs1,
+                                              vfloat16mf2_t vs2, _Float16 rs1,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfrsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                            vfloat16m1_t vs2, float16_t rs1,
+                                            vfloat16m1_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfrsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                            vfloat16m2_t vs2, float16_t rs1,
+                                            vfloat16m2_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfrsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                            vfloat16m4_t vs2, float16_t rs1,
+                                            vfloat16m4_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfrsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                            vfloat16m8_t vs2, float16_t rs1,
+                                            vfloat16m8_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrsub_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat32mf2_t vs2, float32_t rs1,
@@ -1417,38 +1417,38 @@ vfloat16mf4_t __riscv_vfadd_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                               vfloat16mf4_t vs1,
                                               unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                              vfloat16mf4_t vs2, float16_t rs1,
+                                              vfloat16mf4_t vs2, _Float16 rs1,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfadd_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                               vfloat16mf2_t vs2,
                                               vfloat16mf2_t vs1,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                              vfloat16mf2_t vs2, float16_t rs1,
+                                              vfloat16mf2_t vs2, _Float16 rs1,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfadd_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
                                             vfloat16m1_t vs2, vfloat16m1_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                            vfloat16m1_t vs2, float16_t rs1,
+                                            vfloat16m1_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfadd_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
                                             vfloat16m2_t vs2, vfloat16m2_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                            vfloat16m2_t vs2, float16_t rs1,
+                                            vfloat16m2_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfadd_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
                                             vfloat16m4_t vs2, vfloat16m4_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                            vfloat16m4_t vs2, float16_t rs1,
+                                            vfloat16m4_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfadd_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
                                             vfloat16m8_t vs2, vfloat16m8_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                            vfloat16m8_t vs2, float16_t rs1,
+                                            vfloat16m8_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfadd_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat32mf2_t vs2,
@@ -1510,38 +1510,38 @@ vfloat16mf4_t __riscv_vfsub_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                               vfloat16mf4_t vs1,
                                               unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                              vfloat16mf4_t vs2, float16_t rs1,
+                                              vfloat16mf4_t vs2, _Float16 rs1,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfsub_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                               vfloat16mf2_t vs2,
                                               vfloat16mf2_t vs1,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                              vfloat16mf2_t vs2, float16_t rs1,
+                                              vfloat16mf2_t vs2, _Float16 rs1,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfsub_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
                                             vfloat16m1_t vs2, vfloat16m1_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                            vfloat16m1_t vs2, float16_t rs1,
+                                            vfloat16m1_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfsub_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
                                             vfloat16m2_t vs2, vfloat16m2_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                            vfloat16m2_t vs2, float16_t rs1,
+                                            vfloat16m2_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfsub_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
                                             vfloat16m4_t vs2, vfloat16m4_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                            vfloat16m4_t vs2, float16_t rs1,
+                                            vfloat16m4_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfsub_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
                                             vfloat16m8_t vs2, vfloat16m8_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                            vfloat16m8_t vs2, float16_t rs1,
+                                            vfloat16m8_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfsub_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat32mf2_t vs2,
@@ -1599,22 +1599,22 @@ vfloat64m8_t __riscv_vfsub_vf_f64m8_rm_tumu(vbool8_t vm, vfloat64m8_t vd,
                                             vfloat64m8_t vs2, float64_t rs1,
                                             unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfrsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                               vfloat16mf4_t vs2, float16_t rs1,
+                                               vfloat16mf4_t vs2, _Float16 rs1,
                                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfrsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                               vfloat16mf2_t vs2, float16_t rs1,
+                                               vfloat16mf2_t vs2, _Float16 rs1,
                                                unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfrsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                             vfloat16m1_t vs2, float16_t rs1,
+                                             vfloat16m1_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfrsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                             vfloat16m2_t vs2, float16_t rs1,
+                                             vfloat16m2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfrsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                             vfloat16m4_t vs2, float16_t rs1,
+                                             vfloat16m4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfrsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                             vfloat16m8_t vs2, float16_t rs1,
+                                             vfloat16m8_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrsub_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat32mf2_t vs2, float32_t rs1,
@@ -1649,38 +1649,38 @@ vfloat16mf4_t __riscv_vfadd_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf4_t __riscv_vfadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfadd_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs2,
                                             vfloat16mf2_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                            vfloat16mf2_t vs2, float16_t rs1,
+                                            vfloat16mf2_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfadd_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs2, vfloat16m1_t vs1,
                                           unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfadd_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs2, vfloat16m2_t vs1,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfadd_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs2, vfloat16m4_t vs1,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfadd_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs2, vfloat16m8_t vs1,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                          vfloat16m8_t vs2, float16_t rs1,
+                                          vfloat16m8_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfadd_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs2,
@@ -1742,38 +1742,38 @@ vfloat16mf4_t __riscv_vfsub_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf4_t __riscv_vfsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfsub_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs2,
                                             vfloat16mf2_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                            vfloat16mf2_t vs2, float16_t rs1,
+                                            vfloat16mf2_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfsub_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs2, vfloat16m1_t vs1,
                                           unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfsub_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs2, vfloat16m2_t vs1,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfsub_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs2, vfloat16m4_t vs1,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfsub_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs2, vfloat16m8_t vs1,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                          vfloat16m8_t vs2, float16_t rs1,
+                                          vfloat16m8_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfsub_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs2,
@@ -1831,22 +1831,22 @@ vfloat64m8_t __riscv_vfsub_vf_f64m8_rm_mu(vbool8_t vm, vfloat64m8_t vd,
                                           vfloat64m8_t vs2, float64_t rs1,
                                           unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfrsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfrsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                             vfloat16mf2_t vs2, float16_t rs1,
+                                             vfloat16mf2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfrsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                           vfloat16m1_t vs2, float16_t rs1,
+                                           vfloat16m1_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfrsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                           vfloat16m2_t vs2, float16_t rs1,
+                                           vfloat16m2_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfrsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                           vfloat16m4_t vs2, float16_t rs1,
+                                           vfloat16m4_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfrsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                           vfloat16m8_t vs2, float16_t rs1,
+                                           vfloat16m8_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrsub_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs2, float32_t rs1,
@@ -1885,43 +1885,43 @@ vfloat64m8_t __riscv_vfrsub_vf_f64m8_rm_mu(vbool8_t vm, vfloat64m8_t vd,
 vfloat32mf2_t __riscv_vfwadd_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
                                           vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl);
+                                          _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                           vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
-                                          float16_t rs1, size_t vl);
+                                          _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
                                         vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
                                         vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
                                         vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
                                         vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
                                         vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
                                         vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_f64m1_tu(vfloat64m1_t vd, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vf_f64m1_tu(vfloat64m1_t vd, vfloat32mf2_t vs2,
@@ -1957,43 +1957,43 @@ vfloat64m8_t __riscv_vfwadd_wf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat32mf2_t __riscv_vfwsub_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
                                           vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl);
+                                          _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                           vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
-                                          float16_t rs1, size_t vl);
+                                          _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
                                         vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
                                         vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
                                         vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
                                         vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
                                         vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
                                         vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_f64m1_tu(vfloat64m1_t vd, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vf_f64m1_tu(vfloat64m1_t vd, vfloat32mf2_t vs2,
@@ -2031,61 +2031,61 @@ vfloat32mf2_t __riscv_vfwadd_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                           vfloat32mf2_t vs2, float16_t rs1,
+                                           vfloat32mf2_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
                                          vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
                                          vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                          size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                         vfloat32m1_t vs2, float16_t rs1,
+                                         vfloat32m1_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
                                          vfloat16m1_t vs2, vfloat16m1_t vs1,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
                                          vfloat32m2_t vs2, vfloat16m1_t vs1,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                         vfloat32m2_t vs2, float16_t rs1,
+                                         vfloat32m2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
                                          vfloat16m2_t vs2, vfloat16m2_t vs1,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
                                          vfloat32m4_t vs2, vfloat16m2_t vs1,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                         vfloat32m4_t vs2, float16_t rs1,
+                                         vfloat32m4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
                                          vfloat16m4_t vs2, vfloat16m4_t vs1,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
                                          vfloat32m8_t vs2, vfloat16m4_t vs1,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                         vfloat32m8_t vs2, float16_t rs1,
+                                         vfloat32m8_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_f64m1_tum(vbool64_t vm, vfloat64m1_t vd,
                                          vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -2139,61 +2139,61 @@ vfloat32mf2_t __riscv_vfwsub_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                           vfloat32mf2_t vs2, float16_t rs1,
+                                           vfloat32mf2_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
                                          vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
                                          vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                          size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                         vfloat32m1_t vs2, float16_t rs1,
+                                         vfloat32m1_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
                                          vfloat16m1_t vs2, vfloat16m1_t vs1,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
                                          vfloat32m2_t vs2, vfloat16m1_t vs1,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                         vfloat32m2_t vs2, float16_t rs1,
+                                         vfloat32m2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
                                          vfloat16m2_t vs2, vfloat16m2_t vs1,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
                                          vfloat32m4_t vs2, vfloat16m2_t vs1,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                         vfloat32m4_t vs2, float16_t rs1,
+                                         vfloat32m4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
                                          vfloat16m4_t vs2, vfloat16m4_t vs1,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
                                          vfloat32m8_t vs2, vfloat16m4_t vs1,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                         vfloat32m8_t vs2, float16_t rs1,
+                                         vfloat32m8_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_f64m1_tum(vbool64_t vm, vfloat64m1_t vd,
                                          vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -2248,61 +2248,61 @@ vfloat32mf2_t __riscv_vfwadd_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat16mf4_t vs2,
                                             vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs2,
                                             vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                            vfloat32mf2_t vs2, float16_t rs1,
+                                            vfloat32mf2_t vs2, _Float16 rs1,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
                                           vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
                                           vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                          vfloat32m1_t vs2, float16_t rs1,
+                                          vfloat32m1_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
                                           vfloat16m1_t vs2, vfloat16m1_t vs1,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
                                           vfloat32m2_t vs2, vfloat16m1_t vs1,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                          vfloat32m2_t vs2, float16_t rs1,
+                                          vfloat32m2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
                                           vfloat16m2_t vs2, vfloat16m2_t vs1,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
                                           vfloat32m4_t vs2, vfloat16m2_t vs1,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                          vfloat32m4_t vs2, float16_t rs1,
+                                          vfloat32m4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
                                           vfloat16m4_t vs2, vfloat16m4_t vs1,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
                                           vfloat32m8_t vs2, vfloat16m4_t vs1,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                          vfloat32m8_t vs2, float16_t rs1,
+                                          vfloat32m8_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_f64m1_tumu(vbool64_t vm, vfloat64m1_t vd,
                                           vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -2356,61 +2356,61 @@ vfloat32mf2_t __riscv_vfwsub_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat16mf4_t vs2,
                                             vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs2,
                                             vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                            vfloat32mf2_t vs2, float16_t rs1,
+                                            vfloat32mf2_t vs2, _Float16 rs1,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
                                           vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
                                           vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                          vfloat32m1_t vs2, float16_t rs1,
+                                          vfloat32m1_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
                                           vfloat16m1_t vs2, vfloat16m1_t vs1,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
                                           vfloat32m2_t vs2, vfloat16m1_t vs1,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                          vfloat32m2_t vs2, float16_t rs1,
+                                          vfloat32m2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
                                           vfloat16m2_t vs2, vfloat16m2_t vs1,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
                                           vfloat32m4_t vs2, vfloat16m2_t vs1,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                          vfloat32m4_t vs2, float16_t rs1,
+                                          vfloat32m4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
                                           vfloat16m4_t vs2, vfloat16m4_t vs1,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
                                           vfloat32m8_t vs2, vfloat16m4_t vs1,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                          vfloat32m8_t vs2, float16_t rs1,
+                                          vfloat32m8_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_f64m1_tumu(vbool64_t vm, vfloat64m1_t vd,
                                           vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -2465,61 +2465,61 @@ vfloat32mf2_t __riscv_vfwadd_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                          vfloat32mf2_t vs2, float16_t rs1,
+                                          vfloat32mf2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
                                         vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                         size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
                                         vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                         size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                        vfloat32m1_t vs2, float16_t rs1,
+                                        vfloat32m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
                                         vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
                                         vfloat32m2_t vs2, vfloat16m1_t vs1,
                                         size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                        vfloat32m2_t vs2, float16_t rs1,
+                                        vfloat32m2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
                                         vfloat16m2_t vs2, vfloat16m2_t vs1,
                                         size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
                                         vfloat32m4_t vs2, vfloat16m2_t vs1,
                                         size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                        vfloat32m4_t vs2, float16_t rs1,
+                                        vfloat32m4_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
                                         vfloat16m4_t vs2, vfloat16m4_t vs1,
                                         size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
                                         vfloat32m8_t vs2, vfloat16m4_t vs1,
                                         size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                        vfloat32m8_t vs2, float16_t rs1,
+                                        vfloat32m8_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_f64m1_mu(vbool64_t vm, vfloat64m1_t vd,
                                         vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -2573,61 +2573,61 @@ vfloat32mf2_t __riscv_vfwsub_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                          vfloat32mf2_t vs2, float16_t rs1,
+                                          vfloat32mf2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
                                         vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                         size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
                                         vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                         size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                        vfloat32m1_t vs2, float16_t rs1,
+                                        vfloat32m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
                                         vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
                                         vfloat32m2_t vs2, vfloat16m1_t vs1,
                                         size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                        vfloat32m2_t vs2, float16_t rs1,
+                                        vfloat32m2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
                                         vfloat16m2_t vs2, vfloat16m2_t vs1,
                                         size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
                                         vfloat32m4_t vs2, vfloat16m2_t vs1,
                                         size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                        vfloat32m4_t vs2, float16_t rs1,
+                                        vfloat32m4_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
                                         vfloat16m4_t vs2, vfloat16m4_t vs1,
                                         size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
                                         vfloat32m8_t vs2, vfloat16m4_t vs1,
                                         size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                        vfloat32m8_t vs2, float16_t rs1,
+                                        vfloat32m8_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_f64m1_mu(vbool64_t vm, vfloat64m1_t vd,
                                         vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -2682,62 +2682,62 @@ vfloat32mf2_t __riscv_vfwadd_vv_f32mf2_rm_tu(vfloat32mf2_t vd,
                                              vfloat16mf4_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_f32mf2_rm_tu(vfloat32mf2_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_f32mf2_rm_tu(vfloat32mf2_t vd,
                                              vfloat32mf2_t vs2,
                                              vfloat16mf4_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_f32mf2_rm_tu(vfloat32mf2_t vd,
-                                             vfloat32mf2_t vs2, float16_t rs1,
+                                             vfloat32mf2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
                                            vfloat16mf2_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
                                            vfloat16mf2_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
                                            vfloat16m1_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
                                            vfloat16m1_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
                                            vfloat16m2_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
                                            vfloat16m2_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
                                            vfloat16m4_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
                                            vfloat16m4_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_f64m1_rm_tu(vfloat64m1_t vd, vfloat32mf2_t vs2,
                                            vfloat32mf2_t vs1, unsigned int frm,
@@ -2792,62 +2792,62 @@ vfloat32mf2_t __riscv_vfwsub_vv_f32mf2_rm_tu(vfloat32mf2_t vd,
                                              vfloat16mf4_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_f32mf2_rm_tu(vfloat32mf2_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_f32mf2_rm_tu(vfloat32mf2_t vd,
                                              vfloat32mf2_t vs2,
                                              vfloat16mf4_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_f32mf2_rm_tu(vfloat32mf2_t vd,
-                                             vfloat32mf2_t vs2, float16_t rs1,
+                                             vfloat32mf2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
                                            vfloat16mf2_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
                                            vfloat16mf2_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
                                            vfloat16m1_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
                                            vfloat16m1_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
                                            vfloat16m2_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
                                            vfloat16m2_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
                                            vfloat16m4_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
                                            vfloat16m4_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_f64m1_rm_tu(vfloat64m1_t vd, vfloat32mf2_t vs2,
                                            vfloat32mf2_t vs1, unsigned int frm,
@@ -2903,63 +2903,63 @@ vfloat32mf2_t __riscv_vfwadd_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat16mf4_t vs1,
                                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                              vfloat16mf4_t vs2, float16_t rs1,
+                                              vfloat16mf4_t vs2, _Float16 rs1,
                                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat32mf2_t vs2,
                                               vfloat16mf4_t vs1,
                                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                              vfloat32mf2_t vs2, float16_t rs1,
+                                              vfloat32mf2_t vs2, _Float16 rs1,
                                               unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
                                             vfloat16mf2_t vs2,
                                             vfloat16mf2_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                            vfloat16mf2_t vs2, float16_t rs1,
+                                            vfloat16mf2_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
                                             vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                            vfloat32m1_t vs2, float16_t rs1,
+                                            vfloat32m1_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
                                             vfloat16m1_t vs2, vfloat16m1_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                            vfloat16m1_t vs2, float16_t rs1,
+                                            vfloat16m1_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
                                             vfloat32m2_t vs2, vfloat16m1_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                            vfloat32m2_t vs2, float16_t rs1,
+                                            vfloat32m2_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
                                             vfloat16m2_t vs2, vfloat16m2_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                            vfloat16m2_t vs2, float16_t rs1,
+                                            vfloat16m2_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
                                             vfloat32m4_t vs2, vfloat16m2_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                            vfloat32m4_t vs2, float16_t rs1,
+                                            vfloat32m4_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
                                             vfloat16m4_t vs2, vfloat16m4_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                            vfloat16m4_t vs2, float16_t rs1,
+                                            vfloat16m4_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
                                             vfloat32m8_t vs2, vfloat16m4_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                            vfloat32m8_t vs2, float16_t rs1,
+                                            vfloat32m8_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_f64m1_rm_tum(vbool64_t vm, vfloat64m1_t vd,
                                             vfloat32mf2_t vs2,
@@ -3015,63 +3015,63 @@ vfloat32mf2_t __riscv_vfwsub_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat16mf4_t vs1,
                                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                              vfloat16mf4_t vs2, float16_t rs1,
+                                              vfloat16mf4_t vs2, _Float16 rs1,
                                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat32mf2_t vs2,
                                               vfloat16mf4_t vs1,
                                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                              vfloat32mf2_t vs2, float16_t rs1,
+                                              vfloat32mf2_t vs2, _Float16 rs1,
                                               unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
                                             vfloat16mf2_t vs2,
                                             vfloat16mf2_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                            vfloat16mf2_t vs2, float16_t rs1,
+                                            vfloat16mf2_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
                                             vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                            vfloat32m1_t vs2, float16_t rs1,
+                                            vfloat32m1_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
                                             vfloat16m1_t vs2, vfloat16m1_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                            vfloat16m1_t vs2, float16_t rs1,
+                                            vfloat16m1_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
                                             vfloat32m2_t vs2, vfloat16m1_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                            vfloat32m2_t vs2, float16_t rs1,
+                                            vfloat32m2_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
                                             vfloat16m2_t vs2, vfloat16m2_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                            vfloat16m2_t vs2, float16_t rs1,
+                                            vfloat16m2_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
                                             vfloat32m4_t vs2, vfloat16m2_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                            vfloat32m4_t vs2, float16_t rs1,
+                                            vfloat32m4_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
                                             vfloat16m4_t vs2, vfloat16m4_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                            vfloat16m4_t vs2, float16_t rs1,
+                                            vfloat16m4_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
                                             vfloat32m8_t vs2, vfloat16m4_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                            vfloat32m8_t vs2, float16_t rs1,
+                                            vfloat32m8_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_f64m1_rm_tum(vbool64_t vm, vfloat64m1_t vd,
                                             vfloat32mf2_t vs2,
@@ -3128,64 +3128,64 @@ vfloat32mf2_t __riscv_vfwadd_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat16mf4_t vs1,
                                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                               vfloat16mf4_t vs2, float16_t rs1,
+                                               vfloat16mf4_t vs2, _Float16 rs1,
                                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat32mf2_t vs2,
                                                vfloat16mf4_t vs1,
                                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                               vfloat32mf2_t vs2, float16_t rs1,
+                                               vfloat32mf2_t vs2, _Float16 rs1,
                                                unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
                                              vfloat16mf2_t vs2,
                                              vfloat16mf2_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                             vfloat16mf2_t vs2, float16_t rs1,
+                                             vfloat16mf2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
                                              vfloat32m1_t vs2,
                                              vfloat16mf2_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                             vfloat32m1_t vs2, float16_t rs1,
+                                             vfloat32m1_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
                                              vfloat16m1_t vs2, vfloat16m1_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                             vfloat16m1_t vs2, float16_t rs1,
+                                             vfloat16m1_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
                                              vfloat32m2_t vs2, vfloat16m1_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                             vfloat32m2_t vs2, float16_t rs1,
+                                             vfloat32m2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
                                              vfloat16m2_t vs2, vfloat16m2_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                             vfloat16m2_t vs2, float16_t rs1,
+                                             vfloat16m2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
                                              vfloat32m4_t vs2, vfloat16m2_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                             vfloat32m4_t vs2, float16_t rs1,
+                                             vfloat32m4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
                                              vfloat16m4_t vs2, vfloat16m4_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                             vfloat16m4_t vs2, float16_t rs1,
+                                             vfloat16m4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
                                              vfloat32m8_t vs2, vfloat16m4_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                             vfloat32m8_t vs2, float16_t rs1,
+                                             vfloat32m8_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_f64m1_rm_tumu(vbool64_t vm, vfloat64m1_t vd,
                                              vfloat32mf2_t vs2,
@@ -3242,64 +3242,64 @@ vfloat32mf2_t __riscv_vfwsub_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat16mf4_t vs1,
                                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                               vfloat16mf4_t vs2, float16_t rs1,
+                                               vfloat16mf4_t vs2, _Float16 rs1,
                                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat32mf2_t vs2,
                                                vfloat16mf4_t vs1,
                                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                               vfloat32mf2_t vs2, float16_t rs1,
+                                               vfloat32mf2_t vs2, _Float16 rs1,
                                                unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
                                              vfloat16mf2_t vs2,
                                              vfloat16mf2_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                             vfloat16mf2_t vs2, float16_t rs1,
+                                             vfloat16mf2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
                                              vfloat32m1_t vs2,
                                              vfloat16mf2_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                             vfloat32m1_t vs2, float16_t rs1,
+                                             vfloat32m1_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
                                              vfloat16m1_t vs2, vfloat16m1_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                             vfloat16m1_t vs2, float16_t rs1,
+                                             vfloat16m1_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
                                              vfloat32m2_t vs2, vfloat16m1_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                             vfloat32m2_t vs2, float16_t rs1,
+                                             vfloat32m2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
                                              vfloat16m2_t vs2, vfloat16m2_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                             vfloat16m2_t vs2, float16_t rs1,
+                                             vfloat16m2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
                                              vfloat32m4_t vs2, vfloat16m2_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                             vfloat32m4_t vs2, float16_t rs1,
+                                             vfloat32m4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
                                              vfloat16m4_t vs2, vfloat16m4_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                             vfloat16m4_t vs2, float16_t rs1,
+                                             vfloat16m4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
                                              vfloat32m8_t vs2, vfloat16m4_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                             vfloat32m8_t vs2, float16_t rs1,
+                                             vfloat32m8_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_f64m1_rm_tumu(vbool64_t vm, vfloat64m1_t vd,
                                              vfloat32mf2_t vs2,
@@ -3357,62 +3357,62 @@ vfloat32mf2_t __riscv_vfwadd_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat16mf4_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs2,
                                              vfloat16mf4_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                             vfloat32mf2_t vs2, float16_t rs1,
+                                             vfloat32mf2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
                                            vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
                                            vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                           vfloat32m1_t vs2, float16_t rs1,
+                                           vfloat32m1_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
                                            vfloat16m1_t vs2, vfloat16m1_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                           vfloat16m1_t vs2, float16_t rs1,
+                                           vfloat16m1_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
                                            vfloat32m2_t vs2, vfloat16m1_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                           vfloat32m2_t vs2, float16_t rs1,
+                                           vfloat32m2_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
                                            vfloat16m2_t vs2, vfloat16m2_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                           vfloat16m2_t vs2, float16_t rs1,
+                                           vfloat16m2_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
                                            vfloat32m4_t vs2, vfloat16m2_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                           vfloat32m4_t vs2, float16_t rs1,
+                                           vfloat32m4_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
                                            vfloat16m4_t vs2, vfloat16m4_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                           vfloat16m4_t vs2, float16_t rs1,
+                                           vfloat16m4_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
                                            vfloat32m8_t vs2, vfloat16m4_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                           vfloat32m8_t vs2, float16_t rs1,
+                                           vfloat32m8_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_f64m1_rm_mu(vbool64_t vm, vfloat64m1_t vd,
                                            vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -3467,62 +3467,62 @@ vfloat32mf2_t __riscv_vfwsub_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat16mf4_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs2,
                                              vfloat16mf4_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                             vfloat32mf2_t vs2, float16_t rs1,
+                                             vfloat32mf2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
                                            vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
                                            vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                           vfloat32m1_t vs2, float16_t rs1,
+                                           vfloat32m1_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
                                            vfloat16m1_t vs2, vfloat16m1_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                           vfloat16m1_t vs2, float16_t rs1,
+                                           vfloat16m1_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
                                            vfloat32m2_t vs2, vfloat16m1_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                           vfloat32m2_t vs2, float16_t rs1,
+                                           vfloat32m2_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
                                            vfloat16m2_t vs2, vfloat16m2_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                           vfloat16m2_t vs2, float16_t rs1,
+                                           vfloat16m2_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
                                            vfloat32m4_t vs2, vfloat16m2_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                           vfloat32m4_t vs2, float16_t rs1,
+                                           vfloat32m4_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
                                            vfloat16m4_t vs2, vfloat16m4_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                           vfloat16m4_t vs2, float16_t rs1,
+                                           vfloat16m4_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
                                            vfloat32m8_t vs2, vfloat16m4_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                           vfloat32m8_t vs2, float16_t rs1,
+                                           vfloat32m8_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_f64m1_rm_mu(vbool64_t vm, vfloat64m1_t vd,
                                            vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -3582,27 +3582,27 @@ vfloat64m8_t __riscv_vfwsub_wf_f64m8_rm_mu(vbool8_t vm, vfloat64m8_t vd,
 vfloat16mf4_t __riscv_vfmul_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                          vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfmul_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmul_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                          vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfmul_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmul_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfmul_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmul_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                                        vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfmul_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmul_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                                        vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfmul_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmul_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                                        vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfmul_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmul_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                          vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmul_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
@@ -3642,27 +3642,27 @@ vfloat64m8_t __riscv_vfmul_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfdiv_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                          vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfdiv_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                          vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfdiv_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfdiv_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfdiv_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                                        vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfdiv_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfdiv_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                                        vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfdiv_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfdiv_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                                        vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfdiv_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                          vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
@@ -3700,17 +3700,17 @@ vfloat64m8_t __riscv_vfdiv_vv_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfdiv_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
                                        float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl);
+                                          _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                          float16_t rs1, size_t vl);
+                                          _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfrdiv_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfrdiv_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfrdiv_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfrdiv_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                           float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfrdiv_vf_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
@@ -3734,37 +3734,37 @@ vfloat16mf4_t __riscv_vfmul_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
                                           vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfmul_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmul_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
                                           vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmul_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmul_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
                                         vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         size_t vl);
 vfloat16m1_t __riscv_vfmul_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmul_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
                                         vfloat16m2_t vs2, vfloat16m2_t vs1,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmul_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmul_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
                                         vfloat16m4_t vs2, vfloat16m4_t vs1,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmul_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmul_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
                                         vfloat16m8_t vs2, vfloat16m8_t vs1,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmul_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfmul_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -3824,37 +3824,37 @@ vfloat16mf4_t __riscv_vfdiv_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
                                           vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfdiv_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
                                           vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m1_t __riscv_vfdiv_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
                                         vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         size_t vl);
 vfloat16m1_t __riscv_vfdiv_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m2_t __riscv_vfdiv_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
                                         vfloat16m2_t vs2, vfloat16m2_t vs1,
                                         size_t vl);
 vfloat16m2_t __riscv_vfdiv_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m4_t __riscv_vfdiv_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
                                         vfloat16m4_t vs2, vfloat16m4_t vs1,
                                         size_t vl);
 vfloat16m4_t __riscv_vfdiv_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m8_t __riscv_vfdiv_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
                                         vfloat16m8_t vs2, vfloat16m8_t vs1,
                                         size_t vl);
 vfloat16m8_t __riscv_vfdiv_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -3911,22 +3911,22 @@ vfloat64m8_t __riscv_vfdiv_vf_f64m8_tum(vbool8_t vm, vfloat64m8_t vd,
                                         vfloat64m8_t vs2, float64_t rs1,
                                         size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16m1_t __riscv_vfrdiv_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfrdiv_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfrdiv_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfrdiv_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs2, float32_t rs1,
@@ -3960,37 +3960,37 @@ vfloat16mf4_t __riscv_vfmul_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                            vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfmul_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfmul_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                            vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfmul_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16m1_t __riscv_vfmul_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
                                          vfloat16m1_t vs2, vfloat16m1_t vs1,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmul_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfmul_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
                                          vfloat16m2_t vs2, vfloat16m2_t vs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfmul_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfmul_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
                                          vfloat16m4_t vs2, vfloat16m4_t vs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfmul_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfmul_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
                                          vfloat16m8_t vs2, vfloat16m8_t vs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfmul_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfmul_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -4050,37 +4050,37 @@ vfloat16mf4_t __riscv_vfdiv_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                            vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfdiv_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                            vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16m1_t __riscv_vfdiv_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
                                          vfloat16m1_t vs2, vfloat16m1_t vs1,
                                          size_t vl);
 vfloat16m1_t __riscv_vfdiv_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfdiv_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
                                          vfloat16m2_t vs2, vfloat16m2_t vs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfdiv_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfdiv_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
                                          vfloat16m4_t vs2, vfloat16m4_t vs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfdiv_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfdiv_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
                                          vfloat16m8_t vs2, vfloat16m8_t vs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfdiv_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -4137,22 +4137,22 @@ vfloat64m8_t __riscv_vfdiv_vf_f64m8_tumu(vbool8_t vm, vfloat64m8_t vd,
                                          vfloat64m8_t vs2, float64_t rs1,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                            vfloat16mf2_t vs2, float16_t rs1,
+                                            vfloat16mf2_t vs2, _Float16 rs1,
                                             size_t vl);
 vfloat16m1_t __riscv_vfrdiv_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m2_t __riscv_vfrdiv_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m4_t __riscv_vfrdiv_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m8_t __riscv_vfrdiv_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                          vfloat16m8_t vs2, float16_t rs1,
+                                          vfloat16m8_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs2, float32_t rs1,
@@ -4186,37 +4186,37 @@ vfloat16mf4_t __riscv_vfmul_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
                                          vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfmul_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmul_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
                                          vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmul_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmul_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
                                        vfloat16m1_t vs2, vfloat16m1_t vs1,
                                        size_t vl);
 vfloat16m1_t __riscv_vfmul_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmul_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
                                        vfloat16m2_t vs2, vfloat16m2_t vs1,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmul_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmul_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
                                        vfloat16m4_t vs2, vfloat16m4_t vs1,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmul_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmul_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
                                        vfloat16m8_t vs2, vfloat16m8_t vs1,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmul_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfmul_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                          vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -4276,37 +4276,37 @@ vfloat16mf4_t __riscv_vfdiv_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
                                          vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfdiv_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
                                          vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m1_t __riscv_vfdiv_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
                                        vfloat16m1_t vs2, vfloat16m1_t vs1,
                                        size_t vl);
 vfloat16m1_t __riscv_vfdiv_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m2_t __riscv_vfdiv_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
                                        vfloat16m2_t vs2, vfloat16m2_t vs1,
                                        size_t vl);
 vfloat16m2_t __riscv_vfdiv_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m4_t __riscv_vfdiv_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
                                        vfloat16m4_t vs2, vfloat16m4_t vs1,
                                        size_t vl);
 vfloat16m4_t __riscv_vfdiv_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m8_t __riscv_vfdiv_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
                                        vfloat16m8_t vs2, vfloat16m8_t vs1,
                                        size_t vl);
 vfloat16m8_t __riscv_vfdiv_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                          vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -4363,22 +4363,22 @@ vfloat64m8_t __riscv_vfdiv_vf_f64m8_mu(vbool8_t vm, vfloat64m8_t vd,
                                        vfloat64m8_t vs2, float64_t rs1,
                                        size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m1_t __riscv_vfrdiv_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m2_t __riscv_vfrdiv_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m4_t __riscv_vfrdiv_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m8_t __riscv_vfrdiv_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs2, float32_t rs1,
@@ -4411,37 +4411,37 @@ vfloat16mf4_t __riscv_vfmul_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                             vfloat16mf4_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf4_t __riscv_vfmul_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfmul_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                             vfloat16mf2_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfmul_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat16m1_t __riscv_vfmul_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                                           vfloat16m1_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmul_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m2_t __riscv_vfmul_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                                           vfloat16m2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat16m2_t __riscv_vfmul_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m4_t __riscv_vfmul_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                                           vfloat16m4_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat16m4_t __riscv_vfmul_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m8_t __riscv_vfmul_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                                           vfloat16m8_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat16m8_t __riscv_vfmul_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfmul_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                             vfloat32mf2_t vs1, unsigned int frm,
@@ -4501,37 +4501,37 @@ vfloat16mf4_t __riscv_vfdiv_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                             vfloat16mf4_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf4_t __riscv_vfdiv_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                             vfloat16mf2_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                            float16_t rs1, unsigned int frm,
+                                            _Float16 rs1, unsigned int frm,
                                             size_t vl);
 vfloat16m1_t __riscv_vfdiv_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                                           vfloat16m1_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat16m1_t __riscv_vfdiv_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m2_t __riscv_vfdiv_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                                           vfloat16m2_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat16m2_t __riscv_vfdiv_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m4_t __riscv_vfdiv_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                                           vfloat16m4_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat16m4_t __riscv_vfdiv_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat16m8_t __riscv_vfdiv_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                                           vfloat16m8_t vs1, unsigned int frm,
                                           size_t vl);
 vfloat16m8_t __riscv_vfdiv_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                          float16_t rs1, unsigned int frm,
+                                          _Float16 rs1, unsigned int frm,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                             vfloat32mf2_t vs1, unsigned int frm,
@@ -4588,22 +4588,22 @@ vfloat64m8_t __riscv_vfdiv_vf_f64m8_rm_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
                                           float64_t rs1, unsigned int frm,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4_rm_tu(vfloat16mf4_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2_rm_tu(vfloat16mf2_t vd,
-                                             vfloat16mf2_t vs2, float16_t rs1,
+                                             vfloat16mf2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfrdiv_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16m2_t __riscv_vfrdiv_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16m4_t __riscv_vfrdiv_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat16m8_t __riscv_vfrdiv_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_vf_f32mf2_rm_tu(vfloat32mf2_t vd,
                                              vfloat32mf2_t vs2, float32_t rs1,
@@ -4638,38 +4638,38 @@ vfloat16mf4_t __riscv_vfmul_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmul_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmul_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs2,
                                              vfloat16mf2_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmul_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                             vfloat16mf2_t vs2, float16_t rs1,
+                                             vfloat16mf2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmul_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs2, vfloat16m1_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmul_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                           vfloat16m1_t vs2, float16_t rs1,
+                                           vfloat16m1_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmul_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs2, vfloat16m2_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmul_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                           vfloat16m2_t vs2, float16_t rs1,
+                                           vfloat16m2_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmul_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs2, vfloat16m4_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmul_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                           vfloat16m4_t vs2, float16_t rs1,
+                                           vfloat16m4_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmul_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs2, vfloat16m8_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmul_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                           vfloat16m8_t vs2, float16_t rs1,
+                                           vfloat16m8_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmul_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs2,
@@ -4731,38 +4731,38 @@ vfloat16mf4_t __riscv_vfdiv_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfdiv_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs2,
                                              vfloat16mf2_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                             vfloat16mf2_t vs2, float16_t rs1,
+                                             vfloat16mf2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfdiv_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs2, vfloat16m1_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfdiv_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                           vfloat16m1_t vs2, float16_t rs1,
+                                           vfloat16m1_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfdiv_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs2, vfloat16m2_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfdiv_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                           vfloat16m2_t vs2, float16_t rs1,
+                                           vfloat16m2_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfdiv_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs2, vfloat16m4_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfdiv_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                           vfloat16m4_t vs2, float16_t rs1,
+                                           vfloat16m4_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfdiv_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs2, vfloat16m8_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfdiv_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                           vfloat16m8_t vs2, float16_t rs1,
+                                           vfloat16m8_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs2,
@@ -4820,22 +4820,22 @@ vfloat64m8_t __riscv_vfdiv_vf_f64m8_rm_tum(vbool8_t vm, vfloat64m8_t vd,
                                            vfloat64m8_t vs2, float64_t rs1,
                                            unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                              vfloat16mf4_t vs2, float16_t rs1,
+                                              vfloat16mf4_t vs2, _Float16 rs1,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                              vfloat16mf2_t vs2, float16_t rs1,
+                                              vfloat16mf2_t vs2, _Float16 rs1,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfrdiv_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                            vfloat16m1_t vs2, float16_t rs1,
+                                            vfloat16m1_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfrdiv_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                            vfloat16m2_t vs2, float16_t rs1,
+                                            vfloat16m2_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfrdiv_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                            vfloat16m4_t vs2, float16_t rs1,
+                                            vfloat16m4_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfrdiv_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                            vfloat16m8_t vs2, float16_t rs1,
+                                            vfloat16m8_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat32mf2_t vs2, float32_t rs1,
@@ -4870,38 +4870,38 @@ vfloat16mf4_t __riscv_vfmul_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                               vfloat16mf4_t vs1,
                                               unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmul_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                              vfloat16mf4_t vs2, float16_t rs1,
+                                              vfloat16mf4_t vs2, _Float16 rs1,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmul_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                               vfloat16mf2_t vs2,
                                               vfloat16mf2_t vs1,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmul_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                              vfloat16mf2_t vs2, float16_t rs1,
+                                              vfloat16mf2_t vs2, _Float16 rs1,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmul_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
                                             vfloat16m1_t vs2, vfloat16m1_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmul_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                            vfloat16m1_t vs2, float16_t rs1,
+                                            vfloat16m1_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmul_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
                                             vfloat16m2_t vs2, vfloat16m2_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmul_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                            vfloat16m2_t vs2, float16_t rs1,
+                                            vfloat16m2_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmul_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
                                             vfloat16m4_t vs2, vfloat16m4_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmul_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                            vfloat16m4_t vs2, float16_t rs1,
+                                            vfloat16m4_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmul_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
                                             vfloat16m8_t vs2, vfloat16m8_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmul_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                            vfloat16m8_t vs2, float16_t rs1,
+                                            vfloat16m8_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmul_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat32mf2_t vs2,
@@ -4963,38 +4963,38 @@ vfloat16mf4_t __riscv_vfdiv_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                               vfloat16mf4_t vs1,
                                               unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfdiv_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                              vfloat16mf4_t vs2, float16_t rs1,
+                                              vfloat16mf4_t vs2, _Float16 rs1,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                               vfloat16mf2_t vs2,
                                               vfloat16mf2_t vs1,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                              vfloat16mf2_t vs2, float16_t rs1,
+                                              vfloat16mf2_t vs2, _Float16 rs1,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfdiv_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
                                             vfloat16m1_t vs2, vfloat16m1_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfdiv_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                            vfloat16m1_t vs2, float16_t rs1,
+                                            vfloat16m1_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfdiv_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
                                             vfloat16m2_t vs2, vfloat16m2_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfdiv_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                            vfloat16m2_t vs2, float16_t rs1,
+                                            vfloat16m2_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfdiv_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
                                             vfloat16m4_t vs2, vfloat16m4_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfdiv_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                            vfloat16m4_t vs2, float16_t rs1,
+                                            vfloat16m4_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfdiv_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
                                             vfloat16m8_t vs2, vfloat16m8_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfdiv_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                            vfloat16m8_t vs2, float16_t rs1,
+                                            vfloat16m8_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat32mf2_t vs2,
@@ -5052,22 +5052,22 @@ vfloat64m8_t __riscv_vfdiv_vf_f64m8_rm_tumu(vbool8_t vm, vfloat64m8_t vd,
                                             vfloat64m8_t vs2, float64_t rs1,
                                             unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                               vfloat16mf4_t vs2, float16_t rs1,
+                                               vfloat16mf4_t vs2, _Float16 rs1,
                                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                               vfloat16mf2_t vs2, float16_t rs1,
+                                               vfloat16mf2_t vs2, _Float16 rs1,
                                                unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfrdiv_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                             vfloat16m1_t vs2, float16_t rs1,
+                                             vfloat16m1_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfrdiv_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                             vfloat16m2_t vs2, float16_t rs1,
+                                             vfloat16m2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfrdiv_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                             vfloat16m4_t vs2, float16_t rs1,
+                                             vfloat16m4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfrdiv_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                             vfloat16m8_t vs2, float16_t rs1,
+                                             vfloat16m8_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat32mf2_t vs2, float32_t rs1,
@@ -5102,38 +5102,38 @@ vfloat16mf4_t __riscv_vfmul_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf4_t __riscv_vfmul_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmul_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs2,
                                             vfloat16mf2_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfmul_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                            vfloat16mf2_t vs2, float16_t rs1,
+                                            vfloat16mf2_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmul_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs2, vfloat16m1_t vs1,
                                           unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmul_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmul_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs2, vfloat16m2_t vs1,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmul_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmul_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs2, vfloat16m4_t vs1,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmul_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmul_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs2, vfloat16m8_t vs1,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmul_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                          vfloat16m8_t vs2, float16_t rs1,
+                                          vfloat16m8_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmul_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs2,
@@ -5195,38 +5195,38 @@ vfloat16mf4_t __riscv_vfdiv_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf4_t __riscv_vfdiv_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs2,
                                             vfloat16mf2_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfdiv_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                            vfloat16mf2_t vs2, float16_t rs1,
+                                            vfloat16mf2_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfdiv_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs2, vfloat16m1_t vs1,
                                           unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfdiv_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfdiv_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs2, vfloat16m2_t vs1,
                                           unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfdiv_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfdiv_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs2, vfloat16m4_t vs1,
                                           unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfdiv_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfdiv_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs2, vfloat16m8_t vs1,
                                           unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfdiv_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                          vfloat16m8_t vs2, float16_t rs1,
+                                          vfloat16m8_t vs2, _Float16 rs1,
                                           unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs2,
@@ -5284,22 +5284,22 @@ vfloat64m8_t __riscv_vfdiv_vf_f64m8_rm_mu(vbool8_t vm, vfloat64m8_t vd,
                                           vfloat64m8_t vs2, float64_t rs1,
                                           unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                             vfloat16mf2_t vs2, float16_t rs1,
+                                             vfloat16mf2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfrdiv_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                           vfloat16m1_t vs2, float16_t rs1,
+                                           vfloat16m1_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfrdiv_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                           vfloat16m2_t vs2, float16_t rs1,
+                                           vfloat16m2_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfrdiv_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                           vfloat16m4_t vs2, float16_t rs1,
+                                           vfloat16m4_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfrdiv_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                           vfloat16m8_t vs2, float16_t rs1,
+                                           vfloat16m8_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs2, float32_t rs1,
@@ -5338,23 +5338,23 @@ vfloat64m8_t __riscv_vfrdiv_vf_f64m8_rm_mu(vbool8_t vm, vfloat64m8_t vd,
 vfloat32mf2_t __riscv_vfwmul_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
                                           vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwmul_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl);
+                                          _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwmul_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
                                         vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwmul_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwmul_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
                                         vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwmul_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwmul_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
                                         vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwmul_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwmul_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
                                         vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwmul_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwmul_vv_f64m1_tu(vfloat64m1_t vd, vfloat32mf2_t vs2,
                                         vfloat32mf2_t vs1, size_t vl);
 vfloat64m1_t __riscv_vfwmul_vf_f64m1_tu(vfloat64m1_t vd, vfloat32mf2_t vs2,
@@ -5376,31 +5376,31 @@ vfloat32mf2_t __riscv_vfwmul_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfwmul_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwmul_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
                                          vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          size_t vl);
 vfloat32m1_t __riscv_vfwmul_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwmul_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
                                          vfloat16m1_t vs2, vfloat16m1_t vs1,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwmul_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwmul_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
                                          vfloat16m2_t vs2, vfloat16m2_t vs1,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwmul_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwmul_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
                                          vfloat16m4_t vs2, vfloat16m4_t vs1,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwmul_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat64m1_t __riscv_vfwmul_vv_f64m1_tum(vbool64_t vm, vfloat64m1_t vd,
                                          vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -5431,31 +5431,31 @@ vfloat32mf2_t __riscv_vfwmul_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat16mf4_t vs2,
                                             vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwmul_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwmul_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
                                           vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwmul_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwmul_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
                                           vfloat16m1_t vs2, vfloat16m1_t vs1,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwmul_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwmul_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
                                           vfloat16m2_t vs2, vfloat16m2_t vs1,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwmul_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwmul_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
                                           vfloat16m4_t vs2, vfloat16m4_t vs1,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwmul_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat64m1_t __riscv_vfwmul_vv_f64m1_tumu(vbool64_t vm, vfloat64m1_t vd,
                                           vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -5486,31 +5486,31 @@ vfloat32mf2_t __riscv_vfwmul_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfwmul_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwmul_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
                                         vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                         size_t vl);
 vfloat32m1_t __riscv_vfwmul_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32m2_t __riscv_vfwmul_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
                                         vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         size_t vl);
 vfloat32m2_t __riscv_vfwmul_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32m4_t __riscv_vfwmul_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
                                         vfloat16m2_t vs2, vfloat16m2_t vs1,
                                         size_t vl);
 vfloat32m4_t __riscv_vfwmul_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32m8_t __riscv_vfwmul_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
                                         vfloat16m4_t vs2, vfloat16m4_t vs1,
                                         size_t vl);
 vfloat32m8_t __riscv_vfwmul_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat64m1_t __riscv_vfwmul_vv_f64m1_mu(vbool64_t vm, vfloat64m1_t vd,
                                         vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -5541,31 +5541,31 @@ vfloat32mf2_t __riscv_vfwmul_vv_f32mf2_rm_tu(vfloat32mf2_t vd,
                                              vfloat16mf4_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmul_vf_f32mf2_rm_tu(vfloat32mf2_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmul_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
                                            vfloat16mf2_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwmul_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat32m2_t __riscv_vfwmul_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
                                            vfloat16m1_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m2_t __riscv_vfwmul_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat32m4_t __riscv_vfwmul_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
                                            vfloat16m2_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m4_t __riscv_vfwmul_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat32m8_t __riscv_vfwmul_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
                                            vfloat16m4_t vs1, unsigned int frm,
                                            size_t vl);
 vfloat32m8_t __riscv_vfwmul_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                           float16_t rs1, unsigned int frm,
+                                           _Float16 rs1, unsigned int frm,
                                            size_t vl);
 vfloat64m1_t __riscv_vfwmul_vv_f64m1_rm_tu(vfloat64m1_t vd, vfloat32mf2_t vs2,
                                            vfloat32mf2_t vs1, unsigned int frm,
@@ -5597,32 +5597,32 @@ vfloat32mf2_t __riscv_vfwmul_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat16mf4_t vs1,
                                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmul_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                              vfloat16mf4_t vs2, float16_t rs1,
+                                              vfloat16mf4_t vs2, _Float16 rs1,
                                               unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmul_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
                                             vfloat16mf2_t vs2,
                                             vfloat16mf2_t vs1, unsigned int frm,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwmul_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                            vfloat16mf2_t vs2, float16_t rs1,
+                                            vfloat16mf2_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmul_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
                                             vfloat16m1_t vs2, vfloat16m1_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmul_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                            vfloat16m1_t vs2, float16_t rs1,
+                                            vfloat16m1_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmul_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
                                             vfloat16m2_t vs2, vfloat16m2_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmul_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                            vfloat16m2_t vs2, float16_t rs1,
+                                            vfloat16m2_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmul_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
                                             vfloat16m4_t vs2, vfloat16m4_t vs1,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmul_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                            vfloat16m4_t vs2, float16_t rs1,
+                                            vfloat16m4_t vs2, _Float16 rs1,
                                             unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmul_vv_f64m1_rm_tum(vbool64_t vm, vfloat64m1_t vd,
                                             vfloat32mf2_t vs2,
@@ -5655,32 +5655,32 @@ vfloat32mf2_t __riscv_vfwmul_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat16mf4_t vs1,
                                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmul_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                               vfloat16mf4_t vs2, float16_t rs1,
+                                               vfloat16mf4_t vs2, _Float16 rs1,
                                                unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmul_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
                                              vfloat16mf2_t vs2,
                                              vfloat16mf2_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmul_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                             vfloat16mf2_t vs2, float16_t rs1,
+                                             vfloat16mf2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmul_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
                                              vfloat16m1_t vs2, vfloat16m1_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmul_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                             vfloat16m1_t vs2, float16_t rs1,
+                                             vfloat16m1_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmul_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
                                              vfloat16m2_t vs2, vfloat16m2_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmul_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                             vfloat16m2_t vs2, float16_t rs1,
+                                             vfloat16m2_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmul_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
                                              vfloat16m4_t vs2, vfloat16m4_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmul_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                             vfloat16m4_t vs2, float16_t rs1,
+                                             vfloat16m4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmul_vv_f64m1_rm_tumu(vbool64_t vm, vfloat64m1_t vd,
                                              vfloat32mf2_t vs2,
@@ -5713,31 +5713,31 @@ vfloat32mf2_t __riscv_vfwmul_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat16mf4_t vs1,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmul_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmul_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
                                            vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmul_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmul_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
                                            vfloat16m1_t vs2, vfloat16m1_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmul_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                           vfloat16m1_t vs2, float16_t rs1,
+                                           vfloat16m1_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmul_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
                                            vfloat16m2_t vs2, vfloat16m2_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmul_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                           vfloat16m2_t vs2, float16_t rs1,
+                                           vfloat16m2_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmul_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
                                            vfloat16m4_t vs2, vfloat16m4_t vs1,
                                            unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmul_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                           vfloat16m4_t vs2, float16_t rs1,
+                                           vfloat16m4_t vs2, _Float16 rs1,
                                            unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmul_vv_f64m1_rm_mu(vbool64_t vm, vfloat64m1_t vd,
                                            vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -5772,27 +5772,27 @@ vfloat64m8_t __riscv_vfwmul_vf_f64m8_rm_mu(vbool8_t vm, vfloat64m8_t vd,
 ----
 vfloat16mf4_t __riscv_vfmacc_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                           vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmacc_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmacc_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                           vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmacc_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmacc_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmacc_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                         vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmacc_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmacc_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmacc_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                         vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmacc_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmacc_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmacc_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                         vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmacc_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmacc_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmacc_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                         vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmacc_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmacc_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmacc_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                           vfloat32mf2_t vs2, size_t vl);
@@ -5832,27 +5832,27 @@ vfloat64m8_t __riscv_vfmacc_vf_f64m8_tu(vfloat64m8_t vd, float64_t rs1,
                                         vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmacc_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                            vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                            vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                          vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmacc_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmacc_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                          vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmacc_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmacc_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                          vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmacc_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmacc_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                          vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmacc_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmacc_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                            vfloat32mf2_t vs2, size_t vl);
@@ -5892,27 +5892,27 @@ vfloat64m8_t __riscv_vfnmacc_vf_f64m8_tu(vfloat64m8_t vd, float64_t rs1,
                                          vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmsac_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                           vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmsac_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsac_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                           vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmsac_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsac_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmsac_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                         vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmsac_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsac_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmsac_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                         vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmsac_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsac_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmsac_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                         vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmsac_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsac_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmsac_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                         vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmsac_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsac_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmsac_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                           vfloat32mf2_t vs2, size_t vl);
@@ -5952,27 +5952,27 @@ vfloat64m8_t __riscv_vfmsac_vf_f64m8_tu(vfloat64m8_t vd, float64_t rs1,
                                         vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmsac_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                            vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                            vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                          vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsac_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsac_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                          vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsac_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsac_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                          vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsac_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsac_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                          vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsac_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsac_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                            vfloat32mf2_t vs2, size_t vl);
@@ -6012,27 +6012,27 @@ vfloat64m8_t __riscv_vfnmsac_vf_f64m8_tu(vfloat64m8_t vd, float64_t rs1,
                                          vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmadd_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                           vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmadd_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmadd_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                           vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmadd_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmadd_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmadd_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                         vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmadd_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmadd_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmadd_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                         vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmadd_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmadd_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmadd_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                         vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmadd_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmadd_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmadd_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                         vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmadd_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmadd_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmadd_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                           vfloat32mf2_t vs2, size_t vl);
@@ -6072,27 +6072,27 @@ vfloat64m8_t __riscv_vfmadd_vf_f64m8_tu(vfloat64m8_t vd, float64_t rs1,
                                         vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmadd_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                            vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                            vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                          vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmadd_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmadd_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                          vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmadd_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmadd_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                          vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmadd_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmadd_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                          vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmadd_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmadd_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                            vfloat32mf2_t vs2, size_t vl);
@@ -6132,27 +6132,27 @@ vfloat64m8_t __riscv_vfnmadd_vf_f64m8_tu(vfloat64m8_t vd, float64_t rs1,
                                          vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmsub_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                           vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmsub_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsub_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                           vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmsub_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsub_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmsub_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                         vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmsub_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsub_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmsub_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                         vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmsub_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsub_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmsub_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                         vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmsub_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsub_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmsub_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                         vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmsub_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsub_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmsub_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                           vfloat32mf2_t vs2, size_t vl);
@@ -6192,27 +6192,27 @@ vfloat64m8_t __riscv_vfmsub_vf_f64m8_tu(vfloat64m8_t vd, float64_t rs1,
                                         vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmsub_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                            vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                            vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                          vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsub_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsub_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                          vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsub_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsub_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                          vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsub_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsub_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                          vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsub_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsub_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                            vfloat32mf2_t vs2, size_t vl);
@@ -6255,37 +6255,37 @@ vfloat16mf4_t __riscv_vfmacc_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
                                            vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfmacc_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
                                            vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat16m1_t __riscv_vfmacc_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
                                          vfloat16m1_t vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmacc_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat16m2_t __riscv_vfmacc_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
                                          vfloat16m2_t vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat16m2_t __riscv_vfmacc_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat16m4_t __riscv_vfmacc_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
                                          vfloat16m4_t vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat16m4_t __riscv_vfmacc_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat16m8_t __riscv_vfmacc_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
                                          vfloat16m8_t vs1, vfloat16m8_t vs2,
                                          size_t vl);
 vfloat16m8_t __riscv_vfmacc_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfmacc_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -6345,37 +6345,37 @@ vfloat16mf4_t __riscv_vfnmacc_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs1,
                                             vfloat16mf4_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs1, vfloat16m8_t vs2,
                                           size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs1,
@@ -6435,37 +6435,37 @@ vfloat16mf4_t __riscv_vfmsac_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
                                            vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfmsac_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
                                            vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat16m1_t __riscv_vfmsac_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
                                          vfloat16m1_t vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmsac_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat16m2_t __riscv_vfmsac_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
                                          vfloat16m2_t vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat16m2_t __riscv_vfmsac_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat16m4_t __riscv_vfmsac_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
                                          vfloat16m4_t vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat16m4_t __riscv_vfmsac_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat16m8_t __riscv_vfmsac_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
                                          vfloat16m8_t vs1, vfloat16m8_t vs2,
                                          size_t vl);
 vfloat16m8_t __riscv_vfmsac_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfmsac_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -6525,37 +6525,37 @@ vfloat16mf4_t __riscv_vfnmsac_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs1,
                                             vfloat16mf4_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs1, vfloat16m8_t vs2,
                                           size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs1,
@@ -6615,37 +6615,37 @@ vfloat16mf4_t __riscv_vfmadd_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
                                            vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfmadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
                                            vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat16m1_t __riscv_vfmadd_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
                                          vfloat16m1_t vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat16m2_t __riscv_vfmadd_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
                                          vfloat16m2_t vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat16m2_t __riscv_vfmadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat16m4_t __riscv_vfmadd_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
                                          vfloat16m4_t vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat16m4_t __riscv_vfmadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat16m8_t __riscv_vfmadd_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
                                          vfloat16m8_t vs1, vfloat16m8_t vs2,
                                          size_t vl);
 vfloat16m8_t __riscv_vfmadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfmadd_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -6705,37 +6705,37 @@ vfloat16mf4_t __riscv_vfnmadd_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs1,
                                             vfloat16mf4_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs1, vfloat16m8_t vs2,
                                           size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs1,
@@ -6795,37 +6795,37 @@ vfloat16mf4_t __riscv_vfmsub_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
                                            vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfmsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
                                            vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat16m1_t __riscv_vfmsub_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
                                          vfloat16m1_t vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat16m2_t __riscv_vfmsub_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
                                          vfloat16m2_t vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat16m2_t __riscv_vfmsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat16m4_t __riscv_vfmsub_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
                                          vfloat16m4_t vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat16m4_t __riscv_vfmsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat16m8_t __riscv_vfmsub_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
                                          vfloat16m8_t vs1, vfloat16m8_t vs2,
                                          size_t vl);
 vfloat16m8_t __riscv_vfmsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfmsub_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -6885,37 +6885,37 @@ vfloat16mf4_t __riscv_vfnmsub_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs1,
                                             vfloat16mf4_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs1, vfloat16m8_t vs2,
                                           size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs1,
@@ -6976,37 +6976,37 @@ vfloat16mf4_t __riscv_vfmacc_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs1,
                                             vfloat16mf4_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmacc_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl);
 vfloat16m1_t __riscv_vfmacc_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmacc_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat16m2_t __riscv_vfmacc_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat16m2_t __riscv_vfmacc_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat16m4_t __riscv_vfmacc_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat16m4_t __riscv_vfmacc_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat16m8_t __riscv_vfmacc_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs1, vfloat16m8_t vs2,
                                           size_t vl);
 vfloat16m8_t __riscv_vfmacc_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfmacc_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs1,
@@ -7066,37 +7066,37 @@ vfloat16mf4_t __riscv_vfnmacc_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs1,
                                              vfloat16mf4_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs1, vfloat16m8_t vs2,
                                            size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs1,
@@ -7156,37 +7156,37 @@ vfloat16mf4_t __riscv_vfmsac_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs1,
                                             vfloat16mf4_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmsac_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl);
 vfloat16m1_t __riscv_vfmsac_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmsac_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat16m2_t __riscv_vfmsac_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat16m2_t __riscv_vfmsac_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat16m4_t __riscv_vfmsac_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat16m4_t __riscv_vfmsac_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat16m8_t __riscv_vfmsac_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs1, vfloat16m8_t vs2,
                                           size_t vl);
 vfloat16m8_t __riscv_vfmsac_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfmsac_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs1,
@@ -7246,37 +7246,37 @@ vfloat16mf4_t __riscv_vfnmsac_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs1,
                                              vfloat16mf4_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs1, vfloat16m8_t vs2,
                                            size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs1,
@@ -7336,37 +7336,37 @@ vfloat16mf4_t __riscv_vfmadd_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs1,
                                             vfloat16mf4_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl);
 vfloat16m1_t __riscv_vfmadd_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat16m2_t __riscv_vfmadd_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat16m2_t __riscv_vfmadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat16m4_t __riscv_vfmadd_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat16m4_t __riscv_vfmadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat16m8_t __riscv_vfmadd_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs1, vfloat16m8_t vs2,
                                           size_t vl);
 vfloat16m8_t __riscv_vfmadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfmadd_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs1,
@@ -7426,37 +7426,37 @@ vfloat16mf4_t __riscv_vfnmadd_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs1,
                                              vfloat16mf4_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs1, vfloat16m8_t vs2,
                                            size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs1,
@@ -7516,37 +7516,37 @@ vfloat16mf4_t __riscv_vfmsub_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs1,
                                             vfloat16mf4_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl);
 vfloat16m1_t __riscv_vfmsub_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat16m2_t __riscv_vfmsub_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat16m2_t __riscv_vfmsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat16m4_t __riscv_vfmsub_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat16m4_t __riscv_vfmsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat16m8_t __riscv_vfmsub_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs1, vfloat16m8_t vs2,
                                           size_t vl);
 vfloat16m8_t __riscv_vfmsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfmsub_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs1,
@@ -7606,37 +7606,37 @@ vfloat16mf4_t __riscv_vfnmsub_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs1,
                                              vfloat16mf4_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs1, vfloat16m8_t vs2,
                                            size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs1,
@@ -7697,37 +7697,37 @@ vfloat16mf4_t __riscv_vfmacc_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
                                           vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfmacc_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
                                           vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmacc_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
                                         vfloat16m1_t vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m1_t __riscv_vfmacc_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmacc_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
                                         vfloat16m2_t vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmacc_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmacc_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
                                         vfloat16m4_t vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmacc_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmacc_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
                                         vfloat16m8_t vs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmacc_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfmacc_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -7787,37 +7787,37 @@ vfloat16mf4_t __riscv_vfnmacc_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
                                            vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
                                            vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
                                          vfloat16m1_t vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
                                          vfloat16m2_t vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
                                          vfloat16m4_t vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
                                          vfloat16m8_t vs1, vfloat16m8_t vs2,
                                          size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -7877,37 +7877,37 @@ vfloat16mf4_t __riscv_vfmsac_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
                                           vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfmsac_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
                                           vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmsac_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
                                         vfloat16m1_t vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m1_t __riscv_vfmsac_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmsac_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
                                         vfloat16m2_t vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmsac_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmsac_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
                                         vfloat16m4_t vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmsac_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmsac_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
                                         vfloat16m8_t vs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmsac_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfmsac_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -7967,37 +7967,37 @@ vfloat16mf4_t __riscv_vfnmsac_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
                                            vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
                                            vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
                                          vfloat16m1_t vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
                                          vfloat16m2_t vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
                                          vfloat16m4_t vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
                                          vfloat16m8_t vs1, vfloat16m8_t vs2,
                                          size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -8057,37 +8057,37 @@ vfloat16mf4_t __riscv_vfmadd_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
                                           vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfmadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
                                           vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmadd_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
                                         vfloat16m1_t vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m1_t __riscv_vfmadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmadd_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
                                         vfloat16m2_t vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmadd_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
                                         vfloat16m4_t vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmadd_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
                                         vfloat16m8_t vs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfmadd_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -8147,37 +8147,37 @@ vfloat16mf4_t __riscv_vfnmadd_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
                                            vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
                                            vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
                                          vfloat16m1_t vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
                                          vfloat16m2_t vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
                                          vfloat16m4_t vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
                                          vfloat16m8_t vs1, vfloat16m8_t vs2,
                                          size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -8237,37 +8237,37 @@ vfloat16mf4_t __riscv_vfmsub_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
                                           vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfmsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
                                           vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmsub_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
                                         vfloat16m1_t vs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m1_t __riscv_vfmsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmsub_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
                                         vfloat16m2_t vs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmsub_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
                                         vfloat16m4_t vs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmsub_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
                                         vfloat16m8_t vs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfmsub_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -8327,37 +8327,37 @@ vfloat16mf4_t __riscv_vfnmsub_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
                                            vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
                                            vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
                                          vfloat16m1_t vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
                                          vfloat16m2_t vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
                                          vfloat16m4_t vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
                                          vfloat16m8_t vs1, vfloat16m8_t vs2,
                                          size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -8417,38 +8417,38 @@ vfloat16mf4_t __riscv_vfmacc_vv_f16mf4_rm_tu(vfloat16mf4_t vd,
                                              vfloat16mf4_t vs1,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vv_f16mf2_rm_tu(vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmacc_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                            vfloat16m1_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16m1_t __riscv_vfmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                            vfloat16m1_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m2_t __riscv_vfmacc_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                            vfloat16m2_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16m2_t __riscv_vfmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                            vfloat16m2_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m4_t __riscv_vfmacc_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                            vfloat16m4_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16m4_t __riscv_vfmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                            vfloat16m4_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m8_t __riscv_vfmacc_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                            vfloat16m8_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16m8_t __riscv_vfmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                            vfloat16m8_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfmacc_vv_f32mf2_rm_tu(vfloat32mf2_t vd,
@@ -8510,38 +8510,38 @@ vfloat16mf4_t __riscv_vfnmacc_vv_f16mf4_rm_tu(vfloat16mf4_t vd,
                                               vfloat16mf4_t vs1,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vv_f16mf2_rm_tu(vfloat16mf2_t vd,
                                               vfloat16mf2_t vs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                             vfloat16m1_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat16m1_t __riscv_vfnmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                             vfloat16m1_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                             vfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat16m2_t __riscv_vfnmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                             vfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                             vfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat16m4_t __riscv_vfnmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                             vfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                             vfloat16m8_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat16m8_t __riscv_vfnmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                             vfloat16m8_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_vv_f32mf2_rm_tu(vfloat32mf2_t vd,
@@ -8603,38 +8603,38 @@ vfloat16mf4_t __riscv_vfmsac_vv_f16mf4_rm_tu(vfloat16mf4_t vd,
                                              vfloat16mf4_t vs1,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vv_f16mf2_rm_tu(vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsac_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                            vfloat16m1_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16m1_t __riscv_vfmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                            vfloat16m1_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m2_t __riscv_vfmsac_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                            vfloat16m2_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16m2_t __riscv_vfmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                            vfloat16m2_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m4_t __riscv_vfmsac_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                            vfloat16m4_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16m4_t __riscv_vfmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                            vfloat16m4_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m8_t __riscv_vfmsac_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                            vfloat16m8_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16m8_t __riscv_vfmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                            vfloat16m8_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfmsac_vv_f32mf2_rm_tu(vfloat32mf2_t vd,
@@ -8696,38 +8696,38 @@ vfloat16mf4_t __riscv_vfnmsac_vv_f16mf4_rm_tu(vfloat16mf4_t vd,
                                               vfloat16mf4_t vs1,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vv_f16mf2_rm_tu(vfloat16mf2_t vd,
                                               vfloat16mf2_t vs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                             vfloat16m1_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat16m1_t __riscv_vfnmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                             vfloat16m1_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                             vfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat16m2_t __riscv_vfnmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                             vfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                             vfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat16m4_t __riscv_vfnmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                             vfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                             vfloat16m8_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat16m8_t __riscv_vfnmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                             vfloat16m8_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_vv_f32mf2_rm_tu(vfloat32mf2_t vd,
@@ -8789,38 +8789,38 @@ vfloat16mf4_t __riscv_vfmadd_vv_f16mf4_rm_tu(vfloat16mf4_t vd,
                                              vfloat16mf4_t vs1,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vv_f16mf2_rm_tu(vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmadd_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                            vfloat16m1_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16m1_t __riscv_vfmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                            vfloat16m1_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m2_t __riscv_vfmadd_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                            vfloat16m2_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16m2_t __riscv_vfmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                            vfloat16m2_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m4_t __riscv_vfmadd_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                            vfloat16m4_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16m4_t __riscv_vfmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                            vfloat16m4_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m8_t __riscv_vfmadd_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                            vfloat16m8_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16m8_t __riscv_vfmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                            vfloat16m8_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfmadd_vv_f32mf2_rm_tu(vfloat32mf2_t vd,
@@ -8882,38 +8882,38 @@ vfloat16mf4_t __riscv_vfnmadd_vv_f16mf4_rm_tu(vfloat16mf4_t vd,
                                               vfloat16mf4_t vs1,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vv_f16mf2_rm_tu(vfloat16mf2_t vd,
                                               vfloat16mf2_t vs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                             vfloat16m1_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat16m1_t __riscv_vfnmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                             vfloat16m1_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                             vfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat16m2_t __riscv_vfnmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                             vfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                             vfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat16m4_t __riscv_vfnmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                             vfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                             vfloat16m8_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat16m8_t __riscv_vfnmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                             vfloat16m8_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_vv_f32mf2_rm_tu(vfloat32mf2_t vd,
@@ -8975,38 +8975,38 @@ vfloat16mf4_t __riscv_vfmsub_vv_f16mf4_rm_tu(vfloat16mf4_t vd,
                                              vfloat16mf4_t vs1,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vv_f16mf2_rm_tu(vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsub_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                            vfloat16m1_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16m1_t __riscv_vfmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                            vfloat16m1_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m2_t __riscv_vfmsub_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                            vfloat16m2_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16m2_t __riscv_vfmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                            vfloat16m2_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m4_t __riscv_vfmsub_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                            vfloat16m4_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16m4_t __riscv_vfmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                            vfloat16m4_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat16m8_t __riscv_vfmsub_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                            vfloat16m8_t vs2, unsigned int frm,
                                            size_t vl);
-vfloat16m8_t __riscv_vfmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                            vfloat16m8_t vs2, unsigned int frm,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfmsub_vv_f32mf2_rm_tu(vfloat32mf2_t vd,
@@ -9068,38 +9068,38 @@ vfloat16mf4_t __riscv_vfnmsub_vv_f16mf4_rm_tu(vfloat16mf4_t vd,
                                               vfloat16mf4_t vs1,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vv_f16mf2_rm_tu(vfloat16mf2_t vd,
                                               vfloat16mf2_t vs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                             vfloat16m1_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat16m1_t __riscv_vfnmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                             vfloat16m1_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                             vfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat16m2_t __riscv_vfnmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                             vfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                             vfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat16m4_t __riscv_vfnmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                             vfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                             vfloat16m8_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat16m8_t __riscv_vfnmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                             vfloat16m8_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_vv_f32mf2_rm_tu(vfloat32mf2_t vd,
@@ -9163,38 +9163,38 @@ vfloat16mf4_t __riscv_vfmacc_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmacc_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                              float16_t rs1, vfloat16mf4_t vs2,
+                                              _Float16 rs1, vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
                                               vfloat16mf2_t vs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                              float16_t rs1, vfloat16mf2_t vs2,
+                                              _Float16 rs1, vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmacc_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
                                             vfloat16m1_t vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmacc_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                            float16_t rs1, vfloat16m1_t vs2,
+                                            _Float16 rs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmacc_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
                                             vfloat16m2_t vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmacc_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                            float16_t rs1, vfloat16m2_t vs2,
+                                            _Float16 rs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmacc_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
                                             vfloat16m4_t vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmacc_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                            float16_t rs1, vfloat16m4_t vs2,
+                                            _Float16 rs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmacc_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
                                             vfloat16m8_t vs1, vfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmacc_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                            float16_t rs1, vfloat16m8_t vs2,
+                                            _Float16 rs1, vfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmacc_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat32mf2_t vs1,
@@ -9256,38 +9256,38 @@ vfloat16mf4_t __riscv_vfnmacc_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
                                                vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                               float16_t rs1, vfloat16mf4_t vs2,
+                                               _Float16 rs1, vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
                                                vfloat16mf2_t vs1,
                                                vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                               float16_t rs1, vfloat16mf2_t vs2,
+                                               _Float16 rs1, vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
                                              vfloat16m1_t vs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                             float16_t rs1, vfloat16m1_t vs2,
+                                             _Float16 rs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
                                              vfloat16m2_t vs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                             float16_t rs1, vfloat16m2_t vs2,
+                                             _Float16 rs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
                                              vfloat16m4_t vs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                             float16_t rs1, vfloat16m4_t vs2,
+                                             _Float16 rs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
                                              vfloat16m8_t vs1, vfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                             float16_t rs1, vfloat16m8_t vs2,
+                                             _Float16 rs1, vfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat32mf2_t vs1,
@@ -9349,38 +9349,38 @@ vfloat16mf4_t __riscv_vfmsac_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmsac_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                              float16_t rs1, vfloat16mf4_t vs2,
+                                              _Float16 rs1, vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
                                               vfloat16mf2_t vs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                              float16_t rs1, vfloat16mf2_t vs2,
+                                              _Float16 rs1, vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsac_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
                                             vfloat16m1_t vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsac_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                            float16_t rs1, vfloat16m1_t vs2,
+                                            _Float16 rs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsac_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
                                             vfloat16m2_t vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsac_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                            float16_t rs1, vfloat16m2_t vs2,
+                                            _Float16 rs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsac_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
                                             vfloat16m4_t vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsac_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                            float16_t rs1, vfloat16m4_t vs2,
+                                            _Float16 rs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsac_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
                                             vfloat16m8_t vs1, vfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsac_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                            float16_t rs1, vfloat16m8_t vs2,
+                                            _Float16 rs1, vfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsac_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat32mf2_t vs1,
@@ -9442,38 +9442,38 @@ vfloat16mf4_t __riscv_vfnmsac_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
                                                vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                               float16_t rs1, vfloat16mf4_t vs2,
+                                               _Float16 rs1, vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
                                                vfloat16mf2_t vs1,
                                                vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                               float16_t rs1, vfloat16mf2_t vs2,
+                                               _Float16 rs1, vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
                                              vfloat16m1_t vs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                             float16_t rs1, vfloat16m1_t vs2,
+                                             _Float16 rs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
                                              vfloat16m2_t vs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                             float16_t rs1, vfloat16m2_t vs2,
+                                             _Float16 rs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
                                              vfloat16m4_t vs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                             float16_t rs1, vfloat16m4_t vs2,
+                                             _Float16 rs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
                                              vfloat16m8_t vs1, vfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                             float16_t rs1, vfloat16m8_t vs2,
+                                             _Float16 rs1, vfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat32mf2_t vs1,
@@ -9535,38 +9535,38 @@ vfloat16mf4_t __riscv_vfmadd_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                              float16_t rs1, vfloat16mf4_t vs2,
+                                              _Float16 rs1, vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
                                               vfloat16mf2_t vs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                              float16_t rs1, vfloat16mf2_t vs2,
+                                              _Float16 rs1, vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmadd_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
                                             vfloat16m1_t vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                            float16_t rs1, vfloat16m1_t vs2,
+                                            _Float16 rs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmadd_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
                                             vfloat16m2_t vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                            float16_t rs1, vfloat16m2_t vs2,
+                                            _Float16 rs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmadd_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
                                             vfloat16m4_t vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                            float16_t rs1, vfloat16m4_t vs2,
+                                            _Float16 rs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmadd_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
                                             vfloat16m8_t vs1, vfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                            float16_t rs1, vfloat16m8_t vs2,
+                                            _Float16 rs1, vfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmadd_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat32mf2_t vs1,
@@ -9628,38 +9628,38 @@ vfloat16mf4_t __riscv_vfnmadd_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
                                                vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                               float16_t rs1, vfloat16mf4_t vs2,
+                                               _Float16 rs1, vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
                                                vfloat16mf2_t vs1,
                                                vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                               float16_t rs1, vfloat16mf2_t vs2,
+                                               _Float16 rs1, vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
                                              vfloat16m1_t vs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                             float16_t rs1, vfloat16m1_t vs2,
+                                             _Float16 rs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
                                              vfloat16m2_t vs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                             float16_t rs1, vfloat16m2_t vs2,
+                                             _Float16 rs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
                                              vfloat16m4_t vs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                             float16_t rs1, vfloat16m4_t vs2,
+                                             _Float16 rs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
                                              vfloat16m8_t vs1, vfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                             float16_t rs1, vfloat16m8_t vs2,
+                                             _Float16 rs1, vfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat32mf2_t vs1,
@@ -9721,38 +9721,38 @@ vfloat16mf4_t __riscv_vfmsub_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                              float16_t rs1, vfloat16mf4_t vs2,
+                                              _Float16 rs1, vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
                                               vfloat16mf2_t vs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                              float16_t rs1, vfloat16mf2_t vs2,
+                                              _Float16 rs1, vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsub_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
                                             vfloat16m1_t vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                            float16_t rs1, vfloat16m1_t vs2,
+                                            _Float16 rs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsub_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
                                             vfloat16m2_t vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                            float16_t rs1, vfloat16m2_t vs2,
+                                            _Float16 rs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsub_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
                                             vfloat16m4_t vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                            float16_t rs1, vfloat16m4_t vs2,
+                                            _Float16 rs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsub_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
                                             vfloat16m8_t vs1, vfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                            float16_t rs1, vfloat16m8_t vs2,
+                                            _Float16 rs1, vfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsub_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat32mf2_t vs1,
@@ -9814,38 +9814,38 @@ vfloat16mf4_t __riscv_vfnmsub_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
                                                vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                               float16_t rs1, vfloat16mf4_t vs2,
+                                               _Float16 rs1, vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
                                                vfloat16mf2_t vs1,
                                                vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                               float16_t rs1, vfloat16mf2_t vs2,
+                                               _Float16 rs1, vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
                                              vfloat16m1_t vs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                             float16_t rs1, vfloat16m1_t vs2,
+                                             _Float16 rs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
                                              vfloat16m2_t vs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                             float16_t rs1, vfloat16m2_t vs2,
+                                             _Float16 rs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
                                              vfloat16m4_t vs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                             float16_t rs1, vfloat16m4_t vs2,
+                                             _Float16 rs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
                                              vfloat16m8_t vs1, vfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                             float16_t rs1, vfloat16m8_t vs2,
+                                             _Float16 rs1, vfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat32mf2_t vs1,
@@ -9908,38 +9908,38 @@ vfloat16mf4_t __riscv_vfmacc_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                                vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmacc_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                               float16_t rs1, vfloat16mf4_t vs2,
+                                               _Float16 rs1, vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                                vfloat16mf2_t vs1,
                                                vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                               float16_t rs1, vfloat16mf2_t vs2,
+                                               _Float16 rs1, vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmacc_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
                                              vfloat16m1_t vs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmacc_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                             float16_t rs1, vfloat16m1_t vs2,
+                                             _Float16 rs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmacc_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
                                              vfloat16m2_t vs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmacc_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                             float16_t rs1, vfloat16m2_t vs2,
+                                             _Float16 rs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmacc_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
                                              vfloat16m4_t vs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmacc_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                             float16_t rs1, vfloat16m4_t vs2,
+                                             _Float16 rs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmacc_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
                                              vfloat16m8_t vs1, vfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmacc_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                             float16_t rs1, vfloat16m8_t vs2,
+                                             _Float16 rs1, vfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmacc_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat32mf2_t vs1,
@@ -10001,44 +10001,42 @@ vfloat16mf4_t __riscv_vfnmacc_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                                 vfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                                float16_t rs1,
-                                                vfloat16mf4_t vs2,
+                                                _Float16 rs1, vfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                                 vfloat16mf2_t vs1,
                                                 vfloat16mf2_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                                float16_t rs1,
-                                                vfloat16mf2_t vs2,
+                                                _Float16 rs1, vfloat16mf2_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
                                               vfloat16m1_t vs1,
                                               vfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                              float16_t rs1, vfloat16m1_t vs2,
+                                              _Float16 rs1, vfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
                                               vfloat16m2_t vs1,
                                               vfloat16m2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                              float16_t rs1, vfloat16m2_t vs2,
+                                              _Float16 rs1, vfloat16m2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
                                               vfloat16m4_t vs1,
                                               vfloat16m4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                              float16_t rs1, vfloat16m4_t vs2,
+                                              _Float16 rs1, vfloat16m4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
                                               vfloat16m8_t vs1,
                                               vfloat16m8_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                              float16_t rs1, vfloat16m8_t vs2,
+                                              _Float16 rs1, vfloat16m8_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                 vfloat32mf2_t vs1,
@@ -10109,38 +10107,38 @@ vfloat16mf4_t __riscv_vfmsac_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                                vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmsac_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                               float16_t rs1, vfloat16mf4_t vs2,
+                                               _Float16 rs1, vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                                vfloat16mf2_t vs1,
                                                vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                               float16_t rs1, vfloat16mf2_t vs2,
+                                               _Float16 rs1, vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsac_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
                                              vfloat16m1_t vs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsac_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                             float16_t rs1, vfloat16m1_t vs2,
+                                             _Float16 rs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsac_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
                                              vfloat16m2_t vs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsac_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                             float16_t rs1, vfloat16m2_t vs2,
+                                             _Float16 rs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsac_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
                                              vfloat16m4_t vs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsac_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                             float16_t rs1, vfloat16m4_t vs2,
+                                             _Float16 rs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsac_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
                                              vfloat16m8_t vs1, vfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsac_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                             float16_t rs1, vfloat16m8_t vs2,
+                                             _Float16 rs1, vfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsac_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat32mf2_t vs1,
@@ -10202,44 +10200,42 @@ vfloat16mf4_t __riscv_vfnmsac_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                                 vfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                                float16_t rs1,
-                                                vfloat16mf4_t vs2,
+                                                _Float16 rs1, vfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                                 vfloat16mf2_t vs1,
                                                 vfloat16mf2_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                                float16_t rs1,
-                                                vfloat16mf2_t vs2,
+                                                _Float16 rs1, vfloat16mf2_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
                                               vfloat16m1_t vs1,
                                               vfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                              float16_t rs1, vfloat16m1_t vs2,
+                                              _Float16 rs1, vfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
                                               vfloat16m2_t vs1,
                                               vfloat16m2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                              float16_t rs1, vfloat16m2_t vs2,
+                                              _Float16 rs1, vfloat16m2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
                                               vfloat16m4_t vs1,
                                               vfloat16m4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                              float16_t rs1, vfloat16m4_t vs2,
+                                              _Float16 rs1, vfloat16m4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
                                               vfloat16m8_t vs1,
                                               vfloat16m8_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                              float16_t rs1, vfloat16m8_t vs2,
+                                              _Float16 rs1, vfloat16m8_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                 vfloat32mf2_t vs1,
@@ -10310,38 +10306,38 @@ vfloat16mf4_t __riscv_vfmadd_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                                vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                               float16_t rs1, vfloat16mf4_t vs2,
+                                               _Float16 rs1, vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                                vfloat16mf2_t vs1,
                                                vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                               float16_t rs1, vfloat16mf2_t vs2,
+                                               _Float16 rs1, vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmadd_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
                                              vfloat16m1_t vs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                             float16_t rs1, vfloat16m1_t vs2,
+                                             _Float16 rs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmadd_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
                                              vfloat16m2_t vs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                             float16_t rs1, vfloat16m2_t vs2,
+                                             _Float16 rs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmadd_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
                                              vfloat16m4_t vs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                             float16_t rs1, vfloat16m4_t vs2,
+                                             _Float16 rs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmadd_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
                                              vfloat16m8_t vs1, vfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                             float16_t rs1, vfloat16m8_t vs2,
+                                             _Float16 rs1, vfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmadd_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat32mf2_t vs1,
@@ -10403,44 +10399,42 @@ vfloat16mf4_t __riscv_vfnmadd_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                                 vfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                                float16_t rs1,
-                                                vfloat16mf4_t vs2,
+                                                _Float16 rs1, vfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                                 vfloat16mf2_t vs1,
                                                 vfloat16mf2_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                                float16_t rs1,
-                                                vfloat16mf2_t vs2,
+                                                _Float16 rs1, vfloat16mf2_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
                                               vfloat16m1_t vs1,
                                               vfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                              float16_t rs1, vfloat16m1_t vs2,
+                                              _Float16 rs1, vfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
                                               vfloat16m2_t vs1,
                                               vfloat16m2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                              float16_t rs1, vfloat16m2_t vs2,
+                                              _Float16 rs1, vfloat16m2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
                                               vfloat16m4_t vs1,
                                               vfloat16m4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                              float16_t rs1, vfloat16m4_t vs2,
+                                              _Float16 rs1, vfloat16m4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
                                               vfloat16m8_t vs1,
                                               vfloat16m8_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                              float16_t rs1, vfloat16m8_t vs2,
+                                              _Float16 rs1, vfloat16m8_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                 vfloat32mf2_t vs1,
@@ -10511,38 +10505,38 @@ vfloat16mf4_t __riscv_vfmsub_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                                vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                               float16_t rs1, vfloat16mf4_t vs2,
+                                               _Float16 rs1, vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                                vfloat16mf2_t vs1,
                                                vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                               float16_t rs1, vfloat16mf2_t vs2,
+                                               _Float16 rs1, vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsub_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
                                              vfloat16m1_t vs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                             float16_t rs1, vfloat16m1_t vs2,
+                                             _Float16 rs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsub_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
                                              vfloat16m2_t vs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                             float16_t rs1, vfloat16m2_t vs2,
+                                             _Float16 rs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsub_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
                                              vfloat16m4_t vs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                             float16_t rs1, vfloat16m4_t vs2,
+                                             _Float16 rs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsub_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
                                              vfloat16m8_t vs1, vfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                             float16_t rs1, vfloat16m8_t vs2,
+                                             _Float16 rs1, vfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsub_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat32mf2_t vs1,
@@ -10604,44 +10598,42 @@ vfloat16mf4_t __riscv_vfnmsub_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                                 vfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                                float16_t rs1,
-                                                vfloat16mf4_t vs2,
+                                                _Float16 rs1, vfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                                 vfloat16mf2_t vs1,
                                                 vfloat16mf2_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                                float16_t rs1,
-                                                vfloat16mf2_t vs2,
+                                                _Float16 rs1, vfloat16mf2_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
                                               vfloat16m1_t vs1,
                                               vfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                              float16_t rs1, vfloat16m1_t vs2,
+                                              _Float16 rs1, vfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
                                               vfloat16m2_t vs1,
                                               vfloat16m2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                              float16_t rs1, vfloat16m2_t vs2,
+                                              _Float16 rs1, vfloat16m2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
                                               vfloat16m4_t vs1,
                                               vfloat16m4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                              float16_t rs1, vfloat16m4_t vs2,
+                                              _Float16 rs1, vfloat16m4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
                                               vfloat16m8_t vs1,
                                               vfloat16m8_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                              float16_t rs1, vfloat16m8_t vs2,
+                                              _Float16 rs1, vfloat16m8_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                 vfloat32mf2_t vs1,
@@ -10713,38 +10705,38 @@ vfloat16mf4_t __riscv_vfmacc_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmacc_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmacc_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmacc_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmacc_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmacc_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmacc_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmacc_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmacc_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmacc_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmacc_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmacc_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs1,
@@ -10806,38 +10798,38 @@ vfloat16mf4_t __riscv_vfnmacc_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmacc_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                              float16_t rs1, vfloat16mf4_t vs2,
+                                              _Float16 rs1, vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
                                               vfloat16mf2_t vs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                              float16_t rs1, vfloat16mf2_t vs2,
+                                              _Float16 rs1, vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
                                             vfloat16m1_t vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmacc_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                            float16_t rs1, vfloat16m1_t vs2,
+                                            _Float16 rs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
                                             vfloat16m2_t vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmacc_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                            float16_t rs1, vfloat16m2_t vs2,
+                                            _Float16 rs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
                                             vfloat16m4_t vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmacc_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                            float16_t rs1, vfloat16m4_t vs2,
+                                            _Float16 rs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
                                             vfloat16m8_t vs1, vfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmacc_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                            float16_t rs1, vfloat16m8_t vs2,
+                                            _Float16 rs1, vfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat32mf2_t vs1,
@@ -10899,38 +10891,38 @@ vfloat16mf4_t __riscv_vfmsac_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmsac_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsac_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsac_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsac_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsac_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsac_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsac_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsac_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsac_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsac_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsac_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs1,
@@ -10992,38 +10984,38 @@ vfloat16mf4_t __riscv_vfnmsac_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmsac_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                              float16_t rs1, vfloat16mf4_t vs2,
+                                              _Float16 rs1, vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
                                               vfloat16mf2_t vs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                              float16_t rs1, vfloat16mf2_t vs2,
+                                              _Float16 rs1, vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
                                             vfloat16m1_t vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsac_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                            float16_t rs1, vfloat16m1_t vs2,
+                                            _Float16 rs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
                                             vfloat16m2_t vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsac_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                            float16_t rs1, vfloat16m2_t vs2,
+                                            _Float16 rs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
                                             vfloat16m4_t vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsac_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                            float16_t rs1, vfloat16m4_t vs2,
+                                            _Float16 rs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
                                             vfloat16m8_t vs1, vfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsac_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                            float16_t rs1, vfloat16m8_t vs2,
+                                            _Float16 rs1, vfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat32mf2_t vs1,
@@ -11085,38 +11077,38 @@ vfloat16mf4_t __riscv_vfmadd_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmadd_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmadd_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmadd_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmadd_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmadd_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs1,
@@ -11178,38 +11170,38 @@ vfloat16mf4_t __riscv_vfnmadd_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                              float16_t rs1, vfloat16mf4_t vs2,
+                                              _Float16 rs1, vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
                                               vfloat16mf2_t vs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                              float16_t rs1, vfloat16mf2_t vs2,
+                                              _Float16 rs1, vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
                                             vfloat16m1_t vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                            float16_t rs1, vfloat16m1_t vs2,
+                                            _Float16 rs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
                                             vfloat16m2_t vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                            float16_t rs1, vfloat16m2_t vs2,
+                                            _Float16 rs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
                                             vfloat16m4_t vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                            float16_t rs1, vfloat16m4_t vs2,
+                                            _Float16 rs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
                                             vfloat16m8_t vs1, vfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                            float16_t rs1, vfloat16m8_t vs2,
+                                            _Float16 rs1, vfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat32mf2_t vs1,
@@ -11271,38 +11263,38 @@ vfloat16mf4_t __riscv_vfmsub_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsub_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsub_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsub_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsub_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsub_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs1,
@@ -11364,38 +11356,38 @@ vfloat16mf4_t __riscv_vfnmsub_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfnmsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                              float16_t rs1, vfloat16mf4_t vs2,
+                                              _Float16 rs1, vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
                                               vfloat16mf2_t vs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                              float16_t rs1, vfloat16mf2_t vs2,
+                                              _Float16 rs1, vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
                                             vfloat16m1_t vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfnmsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                            float16_t rs1, vfloat16m1_t vs2,
+                                            _Float16 rs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
                                             vfloat16m2_t vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                            float16_t rs1, vfloat16m2_t vs2,
+                                            _Float16 rs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
                                             vfloat16m4_t vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                            float16_t rs1, vfloat16m4_t vs2,
+                                            _Float16 rs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
                                             vfloat16m8_t vs1, vfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                            float16_t rs1, vfloat16m8_t vs2,
+                                            _Float16 rs1, vfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat32mf2_t vs1,
@@ -11461,23 +11453,23 @@ vfloat64m8_t __riscv_vfnmsub_vf_f64m8_rm_mu(vbool8_t vm, vfloat64m8_t vd,
 ----
 vfloat32mf2_t __riscv_vfwmacc_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                            vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1,
                                            vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                          vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwmacc_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmacc_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1,
                                          vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
                                          vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmacc_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmacc_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1,
                                          vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
                                          vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmacc_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmacc_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1,
                                          vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
                                          vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmacc_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmacc_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1,
                                          vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwmacc_vv_f64m1_tu(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                          vfloat32mf2_t vs2, size_t vl);
@@ -11497,23 +11489,23 @@ vfloat64m8_t __riscv_vfwmacc_vf_f64m8_tu(vfloat64m8_t vd, float32_t vs1,
                                          vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                             vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1,
                                             vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                           vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwnmacc_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmacc_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1,
                                           vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
                                           vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwnmacc_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmacc_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1,
                                           vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
                                           vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwnmacc_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmacc_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1,
                                           vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
                                           vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwnmacc_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmacc_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1,
                                           vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_vv_f64m1_tu(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                           vfloat32mf2_t vs2, size_t vl);
@@ -11533,23 +11525,23 @@ vfloat64m8_t __riscv_vfwnmacc_vf_f64m8_tu(vfloat64m8_t vd, float32_t vs1,
                                           vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwmsac_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                            vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1,
                                            vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                          vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwmsac_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmsac_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1,
                                          vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
                                          vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmsac_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmsac_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1,
                                          vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
                                          vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmsac_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmsac_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1,
                                          vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
                                          vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmsac_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmsac_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1,
                                          vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwmsac_vv_f64m1_tu(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                          vfloat32mf2_t vs2, size_t vl);
@@ -11569,23 +11561,23 @@ vfloat64m8_t __riscv_vfwmsac_vf_f64m8_tu(vfloat64m8_t vd, float32_t vs1,
                                          vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                             vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1,
                                             vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                           vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwnmsac_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmsac_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1,
                                           vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
                                           vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwnmsac_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmsac_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1,
                                           vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
                                           vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwnmsac_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmsac_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1,
                                           vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
                                           vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwnmsac_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmsac_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1,
                                           vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_vv_f64m1_tu(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                           vfloat32mf2_t vs2, size_t vl);
@@ -11608,31 +11600,31 @@ vfloat32mf2_t __riscv_vfwmacc_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat16mf4_t vs1,
                                             vfloat16mf4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                            float16_t vs1, vfloat16mf4_t vs2,
+                                            _Float16 vs1, vfloat16mf4_t vs2,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
                                           vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                          float16_t vs1, vfloat16mf2_t vs2,
+                                          _Float16 vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                          float16_t vs1, vfloat16m1_t vs2,
+                                          _Float16 vs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                          float16_t vs1, vfloat16m2_t vs2,
+                                          _Float16 vs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                          float16_t vs1, vfloat16m4_t vs2,
+                                          _Float16 vs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat64m1_t __riscv_vfwmacc_vv_f64m1_tum(vbool64_t vm, vfloat64m1_t vd,
                                           vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -11662,31 +11654,31 @@ vfloat32mf2_t __riscv_vfwnmacc_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat16mf4_t vs1,
                                              vfloat16mf4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                             float16_t vs1, vfloat16mf4_t vs2,
+                                             _Float16 vs1, vfloat16mf4_t vs2,
                                              size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
                                            vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                           float16_t vs1, vfloat16mf2_t vs2,
+                                           _Float16 vs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                           float16_t vs1, vfloat16m1_t vs2,
+                                           _Float16 vs1, vfloat16m1_t vs2,
                                            size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                           float16_t vs1, vfloat16m2_t vs2,
+                                           _Float16 vs1, vfloat16m2_t vs2,
                                            size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                           float16_t vs1, vfloat16m4_t vs2,
+                                           _Float16 vs1, vfloat16m4_t vs2,
                                            size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_vv_f64m1_tum(vbool64_t vm, vfloat64m1_t vd,
                                            vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -11716,31 +11708,31 @@ vfloat32mf2_t __riscv_vfwmsac_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat16mf4_t vs1,
                                             vfloat16mf4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                            float16_t vs1, vfloat16mf4_t vs2,
+                                            _Float16 vs1, vfloat16mf4_t vs2,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
                                           vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                          float16_t vs1, vfloat16mf2_t vs2,
+                                          _Float16 vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                          float16_t vs1, vfloat16m1_t vs2,
+                                          _Float16 vs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                          float16_t vs1, vfloat16m2_t vs2,
+                                          _Float16 vs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                          float16_t vs1, vfloat16m4_t vs2,
+                                          _Float16 vs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat64m1_t __riscv_vfwmsac_vv_f64m1_tum(vbool64_t vm, vfloat64m1_t vd,
                                           vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -11770,31 +11762,31 @@ vfloat32mf2_t __riscv_vfwnmsac_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat16mf4_t vs1,
                                              vfloat16mf4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                             float16_t vs1, vfloat16mf4_t vs2,
+                                             _Float16 vs1, vfloat16mf4_t vs2,
                                              size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
                                            vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                           float16_t vs1, vfloat16mf2_t vs2,
+                                           _Float16 vs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                           float16_t vs1, vfloat16m1_t vs2,
+                                           _Float16 vs1, vfloat16m1_t vs2,
                                            size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                           float16_t vs1, vfloat16m2_t vs2,
+                                           _Float16 vs1, vfloat16m2_t vs2,
                                            size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                           float16_t vs1, vfloat16m4_t vs2,
+                                           _Float16 vs1, vfloat16m4_t vs2,
                                            size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_vv_f64m1_tum(vbool64_t vm, vfloat64m1_t vd,
                                            vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -11825,31 +11817,31 @@ vfloat32mf2_t __riscv_vfwmacc_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat16mf4_t vs1,
                                              vfloat16mf4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                             float16_t vs1, vfloat16mf4_t vs2,
+                                             _Float16 vs1, vfloat16mf4_t vs2,
                                              size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
                                            vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                           float16_t vs1, vfloat16mf2_t vs2,
+                                           _Float16 vs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                           float16_t vs1, vfloat16m1_t vs2,
+                                           _Float16 vs1, vfloat16m1_t vs2,
                                            size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                           float16_t vs1, vfloat16m2_t vs2,
+                                           _Float16 vs1, vfloat16m2_t vs2,
                                            size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                           float16_t vs1, vfloat16m4_t vs2,
+                                           _Float16 vs1, vfloat16m4_t vs2,
                                            size_t vl);
 vfloat64m1_t __riscv_vfwmacc_vv_f64m1_tumu(vbool64_t vm, vfloat64m1_t vd,
                                            vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -11879,31 +11871,31 @@ vfloat32mf2_t __riscv_vfwnmacc_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat16mf4_t vs1,
                                               vfloat16mf4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                              float16_t vs1, vfloat16mf4_t vs2,
+                                              _Float16 vs1, vfloat16mf4_t vs2,
                                               size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                            float16_t vs1, vfloat16mf2_t vs2,
+                                            _Float16 vs1, vfloat16mf2_t vs2,
                                             size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
                                             vfloat16m1_t vs1, vfloat16m1_t vs2,
                                             size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                            float16_t vs1, vfloat16m1_t vs2,
+                                            _Float16 vs1, vfloat16m1_t vs2,
                                             size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
                                             vfloat16m2_t vs1, vfloat16m2_t vs2,
                                             size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                            float16_t vs1, vfloat16m2_t vs2,
+                                            _Float16 vs1, vfloat16m2_t vs2,
                                             size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
                                             vfloat16m4_t vs1, vfloat16m4_t vs2,
                                             size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                            float16_t vs1, vfloat16m4_t vs2,
+                                            _Float16 vs1, vfloat16m4_t vs2,
                                             size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_vv_f64m1_tumu(vbool64_t vm, vfloat64m1_t vd,
                                             vfloat32mf2_t vs1,
@@ -11933,31 +11925,31 @@ vfloat32mf2_t __riscv_vfwmsac_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat16mf4_t vs1,
                                              vfloat16mf4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                             float16_t vs1, vfloat16mf4_t vs2,
+                                             _Float16 vs1, vfloat16mf4_t vs2,
                                              size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
                                            vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                           float16_t vs1, vfloat16mf2_t vs2,
+                                           _Float16 vs1, vfloat16mf2_t vs2,
                                            size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
                                            vfloat16m1_t vs1, vfloat16m1_t vs2,
                                            size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                           float16_t vs1, vfloat16m1_t vs2,
+                                           _Float16 vs1, vfloat16m1_t vs2,
                                            size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
                                            vfloat16m2_t vs1, vfloat16m2_t vs2,
                                            size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                           float16_t vs1, vfloat16m2_t vs2,
+                                           _Float16 vs1, vfloat16m2_t vs2,
                                            size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
                                            vfloat16m4_t vs1, vfloat16m4_t vs2,
                                            size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                           float16_t vs1, vfloat16m4_t vs2,
+                                           _Float16 vs1, vfloat16m4_t vs2,
                                            size_t vl);
 vfloat64m1_t __riscv_vfwmsac_vv_f64m1_tumu(vbool64_t vm, vfloat64m1_t vd,
                                            vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -11987,31 +11979,31 @@ vfloat32mf2_t __riscv_vfwnmsac_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat16mf4_t vs1,
                                               vfloat16mf4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                              float16_t vs1, vfloat16mf4_t vs2,
+                                              _Float16 vs1, vfloat16mf4_t vs2,
                                               size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                            float16_t vs1, vfloat16mf2_t vs2,
+                                            _Float16 vs1, vfloat16mf2_t vs2,
                                             size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
                                             vfloat16m1_t vs1, vfloat16m1_t vs2,
                                             size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                            float16_t vs1, vfloat16m1_t vs2,
+                                            _Float16 vs1, vfloat16m1_t vs2,
                                             size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
                                             vfloat16m2_t vs1, vfloat16m2_t vs2,
                                             size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                            float16_t vs1, vfloat16m2_t vs2,
+                                            _Float16 vs1, vfloat16m2_t vs2,
                                             size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
                                             vfloat16m4_t vs1, vfloat16m4_t vs2,
                                             size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                            float16_t vs1, vfloat16m4_t vs2,
+                                            _Float16 vs1, vfloat16m4_t vs2,
                                             size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_vv_f64m1_tumu(vbool64_t vm, vfloat64m1_t vd,
                                             vfloat32mf2_t vs1,
@@ -12042,31 +12034,31 @@ vfloat32mf2_t __riscv_vfwmacc_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                           float16_t vs1, vfloat16mf4_t vs2,
+                                           _Float16 vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
                                          vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                         float16_t vs1, vfloat16mf2_t vs2,
+                                         _Float16 vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
                                          vfloat16m1_t vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                         float16_t vs1, vfloat16m1_t vs2,
+                                         _Float16 vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
                                          vfloat16m2_t vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                         float16_t vs1, vfloat16m2_t vs2,
+                                         _Float16 vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
                                          vfloat16m4_t vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                         float16_t vs1, vfloat16m4_t vs2,
+                                         _Float16 vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat64m1_t __riscv_vfwmacc_vv_f64m1_mu(vbool64_t vm, vfloat64m1_t vd,
                                          vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -12096,31 +12088,31 @@ vfloat32mf2_t __riscv_vfwnmacc_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat16mf4_t vs1,
                                             vfloat16mf4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                            float16_t vs1, vfloat16mf4_t vs2,
+                                            _Float16 vs1, vfloat16mf4_t vs2,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
                                           vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                          float16_t vs1, vfloat16mf2_t vs2,
+                                          _Float16 vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                          float16_t vs1, vfloat16m1_t vs2,
+                                          _Float16 vs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                          float16_t vs1, vfloat16m2_t vs2,
+                                          _Float16 vs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                          float16_t vs1, vfloat16m4_t vs2,
+                                          _Float16 vs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_vv_f64m1_mu(vbool64_t vm, vfloat64m1_t vd,
                                           vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -12150,31 +12142,31 @@ vfloat32mf2_t __riscv_vfwmsac_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                           float16_t vs1, vfloat16mf4_t vs2,
+                                           _Float16 vs1, vfloat16mf4_t vs2,
                                            size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
                                          vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                         float16_t vs1, vfloat16mf2_t vs2,
+                                         _Float16 vs1, vfloat16mf2_t vs2,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
                                          vfloat16m1_t vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                         float16_t vs1, vfloat16m1_t vs2,
+                                         _Float16 vs1, vfloat16m1_t vs2,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
                                          vfloat16m2_t vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                         float16_t vs1, vfloat16m2_t vs2,
+                                         _Float16 vs1, vfloat16m2_t vs2,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
                                          vfloat16m4_t vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                         float16_t vs1, vfloat16m4_t vs2,
+                                         _Float16 vs1, vfloat16m4_t vs2,
                                          size_t vl);
 vfloat64m1_t __riscv_vfwmsac_vv_f64m1_mu(vbool64_t vm, vfloat64m1_t vd,
                                          vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -12204,31 +12196,31 @@ vfloat32mf2_t __riscv_vfwnmsac_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat16mf4_t vs1,
                                             vfloat16mf4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                            float16_t vs1, vfloat16mf4_t vs2,
+                                            _Float16 vs1, vfloat16mf4_t vs2,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
                                           vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                          float16_t vs1, vfloat16mf2_t vs2,
+                                          _Float16 vs1, vfloat16mf2_t vs2,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
                                           vfloat16m1_t vs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                          float16_t vs1, vfloat16m1_t vs2,
+                                          _Float16 vs1, vfloat16m1_t vs2,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
                                           vfloat16m2_t vs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                          float16_t vs1, vfloat16m2_t vs2,
+                                          _Float16 vs1, vfloat16m2_t vs2,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
                                           vfloat16m4_t vs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                          float16_t vs1, vfloat16m4_t vs2,
+                                          _Float16 vs1, vfloat16m4_t vs2,
                                           size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_vv_f64m1_mu(vbool64_t vm, vfloat64m1_t vd,
                                           vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -12258,31 +12250,31 @@ vfloat32mf2_t __riscv_vfwmacc_vv_f32mf2_rm_tu(vfloat32mf2_t vd,
                                               vfloat16mf4_t vs1,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat32m1_t __riscv_vfwmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1,
                                             vfloat16mf2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
                                             vfloat16m1_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat32m2_t __riscv_vfwmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1,
                                             vfloat16m1_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
                                             vfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat32m4_t __riscv_vfwmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1,
                                             vfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
                                             vfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat32m8_t __riscv_vfwmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1,
                                             vfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat64m1_t __riscv_vfwmacc_vv_f64m1_rm_tu(vfloat64m1_t vd, vfloat32mf2_t vs1,
@@ -12313,31 +12305,31 @@ vfloat32mf2_t __riscv_vfwnmacc_vv_f32mf2_rm_tu(vfloat32mf2_t vd,
                                                vfloat16mf4_t vs1,
                                                vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1,
                                                vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwnmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
                                              vfloat16m1_t vs2, unsigned int frm,
                                              size_t vl);
-vfloat32m2_t __riscv_vfwnmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1,
                                              vfloat16m1_t vs2, unsigned int frm,
                                              size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
                                              vfloat16m2_t vs2, unsigned int frm,
                                              size_t vl);
-vfloat32m4_t __riscv_vfwnmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1,
                                              vfloat16m2_t vs2, unsigned int frm,
                                              size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
                                              vfloat16m4_t vs2, unsigned int frm,
                                              size_t vl);
-vfloat32m8_t __riscv_vfwnmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1,
                                              vfloat16m4_t vs2, unsigned int frm,
                                              size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_vv_f64m1_rm_tu(vfloat64m1_t vd, vfloat32mf2_t vs1,
@@ -12368,31 +12360,31 @@ vfloat32mf2_t __riscv_vfwmsac_vv_f32mf2_rm_tu(vfloat32mf2_t vd,
                                               vfloat16mf4_t vs1,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat32m1_t __riscv_vfwmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1,
                                             vfloat16mf2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
                                             vfloat16m1_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat32m2_t __riscv_vfwmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1,
                                             vfloat16m1_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
                                             vfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat32m4_t __riscv_vfwmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1,
                                             vfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
                                             vfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
-vfloat32m8_t __riscv_vfwmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1,
                                             vfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat64m1_t __riscv_vfwmsac_vv_f64m1_rm_tu(vfloat64m1_t vd, vfloat32mf2_t vs1,
@@ -12423,31 +12415,31 @@ vfloat32mf2_t __riscv_vfwnmsac_vv_f32mf2_rm_tu(vfloat32mf2_t vd,
                                                vfloat16mf4_t vs1,
                                                vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1,
                                                vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwnmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
                                              vfloat16m1_t vs2, unsigned int frm,
                                              size_t vl);
-vfloat32m2_t __riscv_vfwnmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1,
                                              vfloat16m1_t vs2, unsigned int frm,
                                              size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
                                              vfloat16m2_t vs2, unsigned int frm,
                                              size_t vl);
-vfloat32m4_t __riscv_vfwnmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1,
                                              vfloat16m2_t vs2, unsigned int frm,
                                              size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
                                              vfloat16m4_t vs2, unsigned int frm,
                                              size_t vl);
-vfloat32m8_t __riscv_vfwnmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1,
                                              vfloat16m4_t vs2, unsigned int frm,
                                              size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_vv_f64m1_rm_tu(vfloat64m1_t vd, vfloat32mf2_t vs1,
@@ -12480,32 +12472,32 @@ vfloat32mf2_t __riscv_vfwmacc_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                               float16_t vs1, vfloat16mf4_t vs2,
+                                               _Float16 vs1, vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                             float16_t vs1, vfloat16mf2_t vs2,
+                                             _Float16 vs1, vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
                                              vfloat16m1_t vs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                             float16_t vs1, vfloat16m1_t vs2,
+                                             _Float16 vs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
                                              vfloat16m2_t vs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                             float16_t vs1, vfloat16m2_t vs2,
+                                             _Float16 vs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
                                              vfloat16m4_t vs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                             float16_t vs1, vfloat16m4_t vs2,
+                                             _Float16 vs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmacc_vv_f64m1_rm_tum(vbool64_t vm, vfloat64m1_t vd,
                                              vfloat32mf2_t vs1,
@@ -12537,36 +12529,35 @@ vfloat32mf2_t __riscv_vfwnmacc_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                                 vfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                                float16_t vs1,
-                                                vfloat16mf4_t vs2,
+                                                _Float16 vs1, vfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
                                               vfloat16mf2_t vs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                              float16_t vs1, vfloat16mf2_t vs2,
+                                              _Float16 vs1, vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
                                               vfloat16m1_t vs1,
                                               vfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                              float16_t vs1, vfloat16m1_t vs2,
+                                              _Float16 vs1, vfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
                                               vfloat16m2_t vs1,
                                               vfloat16m2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                              float16_t vs1, vfloat16m2_t vs2,
+                                              _Float16 vs1, vfloat16m2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
                                               vfloat16m4_t vs1,
                                               vfloat16m4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                              float16_t vs1, vfloat16m4_t vs2,
+                                              _Float16 vs1, vfloat16m4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_vv_f64m1_rm_tum(vbool64_t vm, vfloat64m1_t vd,
                                               vfloat32mf2_t vs1,
@@ -12601,32 +12592,32 @@ vfloat32mf2_t __riscv_vfwmsac_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                               float16_t vs1, vfloat16mf4_t vs2,
+                                               _Float16 vs1, vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                             float16_t vs1, vfloat16mf2_t vs2,
+                                             _Float16 vs1, vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
                                              vfloat16m1_t vs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                             float16_t vs1, vfloat16m1_t vs2,
+                                             _Float16 vs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
                                              vfloat16m2_t vs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                             float16_t vs1, vfloat16m2_t vs2,
+                                             _Float16 vs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
                                              vfloat16m4_t vs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                             float16_t vs1, vfloat16m4_t vs2,
+                                             _Float16 vs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmsac_vv_f64m1_rm_tum(vbool64_t vm, vfloat64m1_t vd,
                                              vfloat32mf2_t vs1,
@@ -12658,36 +12649,35 @@ vfloat32mf2_t __riscv_vfwnmsac_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
                                                 vfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                                float16_t vs1,
-                                                vfloat16mf4_t vs2,
+                                                _Float16 vs1, vfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
                                               vfloat16mf2_t vs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                              float16_t vs1, vfloat16mf2_t vs2,
+                                              _Float16 vs1, vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
                                               vfloat16m1_t vs1,
                                               vfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                              float16_t vs1, vfloat16m1_t vs2,
+                                              _Float16 vs1, vfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
                                               vfloat16m2_t vs1,
                                               vfloat16m2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                              float16_t vs1, vfloat16m2_t vs2,
+                                              _Float16 vs1, vfloat16m2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
                                               vfloat16m4_t vs1,
                                               vfloat16m4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                              float16_t vs1, vfloat16m4_t vs2,
+                                              _Float16 vs1, vfloat16m4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_vv_f64m1_rm_tum(vbool64_t vm, vfloat64m1_t vd,
                                               vfloat32mf2_t vs1,
@@ -12723,36 +12713,35 @@ vfloat32mf2_t __riscv_vfwmacc_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                 vfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                                float16_t vs1,
-                                                vfloat16mf4_t vs2,
+                                                _Float16 vs1, vfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
                                               vfloat16mf2_t vs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                              float16_t vs1, vfloat16mf2_t vs2,
+                                              _Float16 vs1, vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
                                               vfloat16m1_t vs1,
                                               vfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                              float16_t vs1, vfloat16m1_t vs2,
+                                              _Float16 vs1, vfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
                                               vfloat16m2_t vs1,
                                               vfloat16m2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                              float16_t vs1, vfloat16m2_t vs2,
+                                              _Float16 vs1, vfloat16m2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
                                               vfloat16m4_t vs1,
                                               vfloat16m4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                              float16_t vs1, vfloat16m4_t vs2,
+                                              _Float16 vs1, vfloat16m4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmacc_vv_f64m1_rm_tumu(vbool64_t vm, vfloat64m1_t vd,
                                               vfloat32mf2_t vs1,
@@ -12787,7 +12776,7 @@ vfloat32mf2_t __riscv_vfwnmacc_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                  vfloat16mf4_t vs2,
                                                  unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                                 float16_t vs1,
+                                                 _Float16 vs1,
                                                  vfloat16mf4_t vs2,
                                                  unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
@@ -12795,28 +12784,28 @@ vfloat32m1_t __riscv_vfwnmacc_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
                                                vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                               float16_t vs1, vfloat16mf2_t vs2,
+                                               _Float16 vs1, vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
                                                vfloat16m1_t vs1,
                                                vfloat16m1_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                               float16_t vs1, vfloat16m1_t vs2,
+                                               _Float16 vs1, vfloat16m1_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
                                                vfloat16m2_t vs1,
                                                vfloat16m2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                               float16_t vs1, vfloat16m2_t vs2,
+                                               _Float16 vs1, vfloat16m2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
                                                vfloat16m4_t vs1,
                                                vfloat16m4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                               float16_t vs1, vfloat16m4_t vs2,
+                                               _Float16 vs1, vfloat16m4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_vv_f64m1_rm_tumu(vbool64_t vm, vfloat64m1_t vd,
                                                vfloat32mf2_t vs1,
@@ -12851,36 +12840,35 @@ vfloat32mf2_t __riscv_vfwmsac_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                 vfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                                float16_t vs1,
-                                                vfloat16mf4_t vs2,
+                                                _Float16 vs1, vfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
                                               vfloat16mf2_t vs1,
                                               vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                              float16_t vs1, vfloat16mf2_t vs2,
+                                              _Float16 vs1, vfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
                                               vfloat16m1_t vs1,
                                               vfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                              float16_t vs1, vfloat16m1_t vs2,
+                                              _Float16 vs1, vfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
                                               vfloat16m2_t vs1,
                                               vfloat16m2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                              float16_t vs1, vfloat16m2_t vs2,
+                                              _Float16 vs1, vfloat16m2_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
                                               vfloat16m4_t vs1,
                                               vfloat16m4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                              float16_t vs1, vfloat16m4_t vs2,
+                                              _Float16 vs1, vfloat16m4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmsac_vv_f64m1_rm_tumu(vbool64_t vm, vfloat64m1_t vd,
                                               vfloat32mf2_t vs1,
@@ -12915,7 +12903,7 @@ vfloat32mf2_t __riscv_vfwnmsac_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                  vfloat16mf4_t vs2,
                                                  unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                                 float16_t vs1,
+                                                 _Float16 vs1,
                                                  vfloat16mf4_t vs2,
                                                  unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
@@ -12923,28 +12911,28 @@ vfloat32m1_t __riscv_vfwnmsac_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
                                                vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                               float16_t vs1, vfloat16mf2_t vs2,
+                                               _Float16 vs1, vfloat16mf2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
                                                vfloat16m1_t vs1,
                                                vfloat16m1_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                               float16_t vs1, vfloat16m1_t vs2,
+                                               _Float16 vs1, vfloat16m1_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
                                                vfloat16m2_t vs1,
                                                vfloat16m2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                               float16_t vs1, vfloat16m2_t vs2,
+                                               _Float16 vs1, vfloat16m2_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
                                                vfloat16m4_t vs1,
                                                vfloat16m4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                               float16_t vs1, vfloat16m4_t vs2,
+                                               _Float16 vs1, vfloat16m4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_vv_f64m1_rm_tumu(vbool64_t vm, vfloat64m1_t vd,
                                                vfloat32mf2_t vs1,
@@ -12980,32 +12968,32 @@ vfloat32mf2_t __riscv_vfwmacc_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmacc_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                              float16_t vs1, vfloat16mf4_t vs2,
+                                              _Float16 vs1, vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwmacc_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                            float16_t vs1, vfloat16mf2_t vs2,
+                                            _Float16 vs1, vfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
                                             vfloat16m1_t vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmacc_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                            float16_t vs1, vfloat16m1_t vs2,
+                                            _Float16 vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
                                             vfloat16m2_t vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmacc_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                            float16_t vs1, vfloat16m2_t vs2,
+                                            _Float16 vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
                                             vfloat16m4_t vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmacc_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                            float16_t vs1, vfloat16m4_t vs2,
+                                            _Float16 vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmacc_vv_f64m1_rm_mu(vbool64_t vm, vfloat64m1_t vd,
                                             vfloat32mf2_t vs1,
@@ -13037,32 +13025,32 @@ vfloat32mf2_t __riscv_vfwnmacc_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                               float16_t vs1, vfloat16mf4_t vs2,
+                                               _Float16 vs1, vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                             float16_t vs1, vfloat16mf2_t vs2,
+                                             _Float16 vs1, vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
                                              vfloat16m1_t vs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                             float16_t vs1, vfloat16m1_t vs2,
+                                             _Float16 vs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
                                              vfloat16m2_t vs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                             float16_t vs1, vfloat16m2_t vs2,
+                                             _Float16 vs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
                                              vfloat16m4_t vs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                             float16_t vs1, vfloat16m4_t vs2,
+                                             _Float16 vs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_vv_f64m1_rm_mu(vbool64_t vm, vfloat64m1_t vd,
                                              vfloat32mf2_t vs1,
@@ -13094,32 +13082,32 @@ vfloat32mf2_t __riscv_vfwmsac_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmsac_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                              float16_t vs1, vfloat16mf4_t vs2,
+                                              _Float16 vs1, vfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
                                             vfloat16mf2_t vs1,
                                             vfloat16mf2_t vs2, unsigned int frm,
                                             size_t vl);
 vfloat32m1_t __riscv_vfwmsac_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                            float16_t vs1, vfloat16mf2_t vs2,
+                                            _Float16 vs1, vfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
                                             vfloat16m1_t vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmsac_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                            float16_t vs1, vfloat16m1_t vs2,
+                                            _Float16 vs1, vfloat16m1_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
                                             vfloat16m2_t vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmsac_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                            float16_t vs1, vfloat16m2_t vs2,
+                                            _Float16 vs1, vfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
                                             vfloat16m4_t vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmsac_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                            float16_t vs1, vfloat16m4_t vs2,
+                                            _Float16 vs1, vfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmsac_vv_f64m1_rm_mu(vbool64_t vm, vfloat64m1_t vd,
                                             vfloat32mf2_t vs1,
@@ -13151,32 +13139,32 @@ vfloat32mf2_t __riscv_vfwnmsac_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                               float16_t vs1, vfloat16mf4_t vs2,
+                                               _Float16 vs1, vfloat16mf4_t vs2,
                                                unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
                                              vfloat16mf2_t vs1,
                                              vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                             float16_t vs1, vfloat16mf2_t vs2,
+                                             _Float16 vs1, vfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
                                              vfloat16m1_t vs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                             float16_t vs1, vfloat16m1_t vs2,
+                                             _Float16 vs1, vfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
                                              vfloat16m2_t vs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                             float16_t vs1, vfloat16m2_t vs2,
+                                             _Float16 vs1, vfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
                                              vfloat16m4_t vs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                             float16_t vs1, vfloat16m4_t vs2,
+                                             _Float16 vs1, vfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_vv_f64m1_rm_mu(vbool64_t vm, vfloat64m1_t vd,
                                              vfloat32mf2_t vs1,
@@ -13939,27 +13927,27 @@ vfloat64m8_t __riscv_vfrec7_v_f64m8_rm_mu(vbool8_t vm, vfloat64m8_t vd,
 vfloat16mf4_t __riscv_vfmin_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                          vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfmin_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmin_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                          vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfmin_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmin_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfmin_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmin_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                                        vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfmin_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmin_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                                        vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfmin_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmin_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                                        vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfmin_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmin_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                          vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmin_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
@@ -13999,27 +13987,27 @@ vfloat64m8_t __riscv_vfmin_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfmax_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                          vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfmax_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmax_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                          vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfmax_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmax_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                                        vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfmax_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmax_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                                        vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfmax_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmax_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                                        vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfmax_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmax_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                                        vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfmax_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl);
+                                       _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmax_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                          vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmax_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
@@ -14061,37 +14049,37 @@ vfloat16mf4_t __riscv_vfmin_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
                                           vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfmin_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmin_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
                                           vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmin_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmin_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
                                         vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         size_t vl);
 vfloat16m1_t __riscv_vfmin_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmin_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
                                         vfloat16m2_t vs2, vfloat16m2_t vs1,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmin_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmin_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
                                         vfloat16m4_t vs2, vfloat16m4_t vs1,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmin_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmin_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
                                         vfloat16m8_t vs2, vfloat16m8_t vs1,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmin_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfmin_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -14151,37 +14139,37 @@ vfloat16mf4_t __riscv_vfmax_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
                                           vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfmax_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmax_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
                                           vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfmax_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m1_t __riscv_vfmax_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
                                         vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         size_t vl);
 vfloat16m1_t __riscv_vfmax_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmax_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
                                         vfloat16m2_t vs2, vfloat16m2_t vs1,
                                         size_t vl);
 vfloat16m2_t __riscv_vfmax_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmax_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
                                         vfloat16m4_t vs2, vfloat16m4_t vs1,
                                         size_t vl);
 vfloat16m4_t __riscv_vfmax_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmax_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
                                         vfloat16m8_t vs2, vfloat16m8_t vs1,
                                         size_t vl);
 vfloat16m8_t __riscv_vfmax_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfmax_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -14242,37 +14230,37 @@ vfloat16mf4_t __riscv_vfmin_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                            vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfmin_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfmin_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                            vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfmin_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16m1_t __riscv_vfmin_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
                                          vfloat16m1_t vs2, vfloat16m1_t vs1,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmin_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfmin_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
                                          vfloat16m2_t vs2, vfloat16m2_t vs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfmin_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfmin_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
                                          vfloat16m4_t vs2, vfloat16m4_t vs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfmin_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfmin_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
                                          vfloat16m8_t vs2, vfloat16m8_t vs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfmin_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfmin_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -14332,37 +14320,37 @@ vfloat16mf4_t __riscv_vfmax_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                            vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfmax_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfmax_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                            vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfmax_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16m1_t __riscv_vfmax_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
                                          vfloat16m1_t vs2, vfloat16m1_t vs1,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmax_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfmax_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
                                          vfloat16m2_t vs2, vfloat16m2_t vs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfmax_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfmax_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
                                          vfloat16m4_t vs2, vfloat16m4_t vs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfmax_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfmax_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
                                          vfloat16m8_t vs2, vfloat16m8_t vs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfmax_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfmax_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -14423,37 +14411,37 @@ vfloat16mf4_t __riscv_vfmin_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
                                          vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfmin_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmin_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
                                          vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmin_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmin_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
                                        vfloat16m1_t vs2, vfloat16m1_t vs1,
                                        size_t vl);
 vfloat16m1_t __riscv_vfmin_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmin_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
                                        vfloat16m2_t vs2, vfloat16m2_t vs1,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmin_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmin_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
                                        vfloat16m4_t vs2, vfloat16m4_t vs1,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmin_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmin_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
                                        vfloat16m8_t vs2, vfloat16m8_t vs1,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmin_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfmin_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                          vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -14513,37 +14501,37 @@ vfloat16mf4_t __riscv_vfmax_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
                                          vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          size_t vl);
 vfloat16mf4_t __riscv_vfmax_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmax_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
                                          vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          size_t vl);
 vfloat16mf2_t __riscv_vfmax_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmax_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
                                        vfloat16m1_t vs2, vfloat16m1_t vs1,
                                        size_t vl);
 vfloat16m1_t __riscv_vfmax_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmax_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
                                        vfloat16m2_t vs2, vfloat16m2_t vs1,
                                        size_t vl);
 vfloat16m2_t __riscv_vfmax_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmax_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
                                        vfloat16m4_t vs2, vfloat16m4_t vs1,
                                        size_t vl);
 vfloat16m4_t __riscv_vfmax_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmax_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
                                        vfloat16m8_t vs2, vfloat16m8_t vs1,
                                        size_t vl);
 vfloat16m8_t __riscv_vfmax_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfmax_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                          vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -14609,27 +14597,27 @@ vfloat64m8_t __riscv_vfmax_vf_f64m8_mu(vbool8_t vm, vfloat64m8_t vd,
 vfloat16mf4_t __riscv_vfsgnj_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                           vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnj_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl);
+                                          _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                           vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                          float16_t rs1, size_t vl);
+                                          _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnj_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                                         vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnj_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnj_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                                         vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnj_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnj_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                                         vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnj_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnj_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                                         vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnj_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                        float16_t rs1, size_t vl);
+                                        _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnj_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                           vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnj_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
@@ -14669,27 +14657,27 @@ vfloat64m8_t __riscv_vfsgnj_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfsgnjn_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                            vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnjn_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                           float16_t rs1, size_t vl);
+                                           _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                            vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                           float16_t rs1, size_t vl);
+                                           _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                                          vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                                          vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                                          vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                                          vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                            vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
@@ -14729,27 +14717,27 @@ vfloat64m8_t __riscv_vfsgnjn_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfsgnjx_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                            vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnjx_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                           float16_t rs1, size_t vl);
+                                           _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                            vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                           float16_t rs1, size_t vl);
+                                           _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                                          vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                                          vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                                          vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                                          vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                         float16_t rs1, size_t vl);
+                                         _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                            vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
@@ -14791,37 +14779,37 @@ vfloat16mf4_t __riscv_vfsgnj_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
                                            vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfsgnj_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
                                            vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16m1_t __riscv_vfsgnj_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
                                          vfloat16m1_t vs2, vfloat16m1_t vs1,
                                          size_t vl);
 vfloat16m1_t __riscv_vfsgnj_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfsgnj_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
                                          vfloat16m2_t vs2, vfloat16m2_t vs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfsgnj_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfsgnj_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
                                          vfloat16m4_t vs2, vfloat16m4_t vs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfsgnj_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfsgnj_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
                                          vfloat16m8_t vs2, vfloat16m8_t vs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfsgnj_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfsgnj_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -14881,37 +14869,37 @@ vfloat16mf4_t __riscv_vfsgnjn_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs2,
                                             vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnjn_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs2,
                                             vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                            vfloat16mf2_t vs2, float16_t rs1,
+                                            vfloat16mf2_t vs2, _Float16 rs1,
                                             size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs2, vfloat16m1_t vs1,
                                           size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs2, vfloat16m2_t vs1,
                                           size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs2, vfloat16m4_t vs1,
                                           size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs2, vfloat16m8_t vs1,
                                           size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                          vfloat16m8_t vs2, float16_t rs1,
+                                          vfloat16m8_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs2,
@@ -14971,37 +14959,37 @@ vfloat16mf4_t __riscv_vfsgnjx_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs2,
                                             vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnjx_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs2,
                                             vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                            vfloat16mf2_t vs2, float16_t rs1,
+                                            vfloat16mf2_t vs2, _Float16 rs1,
                                             size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs2, vfloat16m1_t vs1,
                                           size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs2, vfloat16m2_t vs1,
                                           size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs2, vfloat16m4_t vs1,
                                           size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs2, vfloat16m8_t vs1,
                                           size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                          vfloat16m8_t vs2, float16_t rs1,
+                                          vfloat16m8_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs2,
@@ -15062,37 +15050,37 @@ vfloat16mf4_t __riscv_vfsgnj_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                             vfloat16mf4_t vs2,
                                             vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnj_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                             vfloat16mf2_t vs2,
                                             vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                            vfloat16mf2_t vs2, float16_t rs1,
+                                            vfloat16mf2_t vs2, _Float16 rs1,
                                             size_t vl);
 vfloat16m1_t __riscv_vfsgnj_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
                                           vfloat16m1_t vs2, vfloat16m1_t vs1,
                                           size_t vl);
 vfloat16m1_t __riscv_vfsgnj_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m2_t __riscv_vfsgnj_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
                                           vfloat16m2_t vs2, vfloat16m2_t vs1,
                                           size_t vl);
 vfloat16m2_t __riscv_vfsgnj_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m4_t __riscv_vfsgnj_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
                                           vfloat16m4_t vs2, vfloat16m4_t vs1,
                                           size_t vl);
 vfloat16m4_t __riscv_vfsgnj_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m8_t __riscv_vfsgnj_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
                                           vfloat16m8_t vs2, vfloat16m8_t vs1,
                                           size_t vl);
 vfloat16m8_t __riscv_vfsgnj_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                          vfloat16m8_t vs2, float16_t rs1,
+                                          vfloat16m8_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat32mf2_t __riscv_vfsgnj_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                             vfloat32mf2_t vs2,
@@ -15152,37 +15140,37 @@ vfloat16mf4_t __riscv_vfsgnjn_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs2,
                                              vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnjn_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs2,
                                              vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                             vfloat16mf2_t vs2, float16_t rs1,
+                                             vfloat16mf2_t vs2, _Float16 rs1,
                                              size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs2, vfloat16m1_t vs1,
                                            size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                           vfloat16m1_t vs2, float16_t rs1,
+                                           vfloat16m1_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs2, vfloat16m2_t vs1,
                                            size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                           vfloat16m2_t vs2, float16_t rs1,
+                                           vfloat16m2_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs2, vfloat16m4_t vs1,
                                            size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                           vfloat16m4_t vs2, float16_t rs1,
+                                           vfloat16m4_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs2, vfloat16m8_t vs1,
                                            size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                           vfloat16m8_t vs2, float16_t rs1,
+                                           vfloat16m8_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs2,
@@ -15242,37 +15230,37 @@ vfloat16mf4_t __riscv_vfsgnjx_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                              vfloat16mf4_t vs2,
                                              vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnjx_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                              vfloat16mf2_t vs2,
                                              vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                             vfloat16mf2_t vs2, float16_t rs1,
+                                             vfloat16mf2_t vs2, _Float16 rs1,
                                              size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
                                            vfloat16m1_t vs2, vfloat16m1_t vs1,
                                            size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                           vfloat16m1_t vs2, float16_t rs1,
+                                           vfloat16m1_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
                                            vfloat16m2_t vs2, vfloat16m2_t vs1,
                                            size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                           vfloat16m2_t vs2, float16_t rs1,
+                                           vfloat16m2_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
                                            vfloat16m4_t vs2, vfloat16m4_t vs1,
                                            size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                           vfloat16m4_t vs2, float16_t rs1,
+                                           vfloat16m4_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
                                            vfloat16m8_t vs2, vfloat16m8_t vs1,
                                            size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                           vfloat16m8_t vs2, float16_t rs1,
+                                           vfloat16m8_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                              vfloat32mf2_t vs2,
@@ -15333,37 +15321,37 @@ vfloat16mf4_t __riscv_vfsgnj_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
                                           vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                           size_t vl);
 vfloat16mf4_t __riscv_vfsgnj_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
                                           vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                           size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl);
 vfloat16m1_t __riscv_vfsgnj_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
                                         vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         size_t vl);
 vfloat16m1_t __riscv_vfsgnj_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m2_t __riscv_vfsgnj_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
                                         vfloat16m2_t vs2, vfloat16m2_t vs1,
                                         size_t vl);
 vfloat16m2_t __riscv_vfsgnj_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m4_t __riscv_vfsgnj_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
                                         vfloat16m4_t vs2, vfloat16m4_t vs1,
                                         size_t vl);
 vfloat16m4_t __riscv_vfsgnj_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m8_t __riscv_vfsgnj_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
                                         vfloat16m8_t vs2, vfloat16m8_t vs1,
                                         size_t vl);
 vfloat16m8_t __riscv_vfsgnj_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat32mf2_t __riscv_vfsgnj_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                           vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -15423,37 +15411,37 @@ vfloat16mf4_t __riscv_vfsgnjn_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
                                            vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfsgnjn_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
                                            vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
                                          vfloat16m1_t vs2, vfloat16m1_t vs1,
                                          size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
                                          vfloat16m2_t vs2, vfloat16m2_t vs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
                                          vfloat16m4_t vs2, vfloat16m4_t vs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
                                          vfloat16m8_t vs2, vfloat16m8_t vs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -15513,37 +15501,37 @@ vfloat16mf4_t __riscv_vfsgnjx_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
                                            vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfsgnjx_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
                                            vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
                                          vfloat16m1_t vs2, vfloat16m1_t vs1,
                                          size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
                                          vfloat16m2_t vs2, vfloat16m2_t vs1,
                                          size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
                                          vfloat16m4_t vs2, vfloat16m4_t vs1,
                                          size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
                                          vfloat16m8_t vs2, vfloat16m8_t vs1,
                                          size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                            vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -15741,37 +15729,37 @@ vbool64_t __riscv_vmfeq_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
                                          vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          size_t vl);
 vbool64_t __riscv_vmfeq_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl);
 vbool32_t __riscv_vmfeq_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
                                          vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          size_t vl);
 vbool32_t __riscv_vmfeq_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl);
 vbool16_t __riscv_vmfeq_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
                                         vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         size_t vl);
 vbool16_t __riscv_vmfeq_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vbool8_t __riscv_vmfeq_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd,
                                       vfloat16m2_t vs2, vfloat16m2_t vs1,
                                       size_t vl);
 vbool8_t __riscv_vmfeq_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool4_t __riscv_vmfeq_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd,
                                       vfloat16m4_t vs2, vfloat16m4_t vs1,
                                       size_t vl);
 vbool4_t __riscv_vmfeq_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool2_t __riscv_vmfeq_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd,
                                       vfloat16m8_t vs2, vfloat16m8_t vs1,
                                       size_t vl);
 vbool2_t __riscv_vmfeq_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool64_t __riscv_vmfeq_vv_f32mf2_b64_mu(vbool64_t vm, vbool64_t vd,
                                          vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -15831,37 +15819,37 @@ vbool64_t __riscv_vmfne_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
                                          vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          size_t vl);
 vbool64_t __riscv_vmfne_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl);
 vbool32_t __riscv_vmfne_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
                                          vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          size_t vl);
 vbool32_t __riscv_vmfne_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl);
 vbool16_t __riscv_vmfne_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
                                         vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         size_t vl);
 vbool16_t __riscv_vmfne_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vbool8_t __riscv_vmfne_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd,
                                       vfloat16m2_t vs2, vfloat16m2_t vs1,
                                       size_t vl);
 vbool8_t __riscv_vmfne_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool4_t __riscv_vmfne_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd,
                                       vfloat16m4_t vs2, vfloat16m4_t vs1,
                                       size_t vl);
 vbool4_t __riscv_vmfne_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool2_t __riscv_vmfne_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd,
                                       vfloat16m8_t vs2, vfloat16m8_t vs1,
                                       size_t vl);
 vbool2_t __riscv_vmfne_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool64_t __riscv_vmfne_vv_f32mf2_b64_mu(vbool64_t vm, vbool64_t vd,
                                          vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -15921,37 +15909,37 @@ vbool64_t __riscv_vmflt_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
                                          vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          size_t vl);
 vbool64_t __riscv_vmflt_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl);
 vbool32_t __riscv_vmflt_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
                                          vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          size_t vl);
 vbool32_t __riscv_vmflt_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl);
 vbool16_t __riscv_vmflt_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
                                         vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         size_t vl);
 vbool16_t __riscv_vmflt_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vbool8_t __riscv_vmflt_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd,
                                       vfloat16m2_t vs2, vfloat16m2_t vs1,
                                       size_t vl);
 vbool8_t __riscv_vmflt_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool4_t __riscv_vmflt_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd,
                                       vfloat16m4_t vs2, vfloat16m4_t vs1,
                                       size_t vl);
 vbool4_t __riscv_vmflt_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool2_t __riscv_vmflt_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd,
                                       vfloat16m8_t vs2, vfloat16m8_t vs1,
                                       size_t vl);
 vbool2_t __riscv_vmflt_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool64_t __riscv_vmflt_vv_f32mf2_b64_mu(vbool64_t vm, vbool64_t vd,
                                          vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -16011,37 +15999,37 @@ vbool64_t __riscv_vmfle_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
                                          vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          size_t vl);
 vbool64_t __riscv_vmfle_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl);
 vbool32_t __riscv_vmfle_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
                                          vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          size_t vl);
 vbool32_t __riscv_vmfle_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl);
 vbool16_t __riscv_vmfle_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
                                         vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         size_t vl);
 vbool16_t __riscv_vmfle_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vbool8_t __riscv_vmfle_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd,
                                       vfloat16m2_t vs2, vfloat16m2_t vs1,
                                       size_t vl);
 vbool8_t __riscv_vmfle_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool4_t __riscv_vmfle_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd,
                                       vfloat16m4_t vs2, vfloat16m4_t vs1,
                                       size_t vl);
 vbool4_t __riscv_vmfle_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool2_t __riscv_vmfle_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd,
                                       vfloat16m8_t vs2, vfloat16m8_t vs1,
                                       size_t vl);
 vbool2_t __riscv_vmfle_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool64_t __riscv_vmfle_vv_f32mf2_b64_mu(vbool64_t vm, vbool64_t vd,
                                          vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -16101,37 +16089,37 @@ vbool64_t __riscv_vmfgt_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
                                          vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          size_t vl);
 vbool64_t __riscv_vmfgt_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl);
 vbool32_t __riscv_vmfgt_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
                                          vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          size_t vl);
 vbool32_t __riscv_vmfgt_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl);
 vbool16_t __riscv_vmfgt_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
                                         vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         size_t vl);
 vbool16_t __riscv_vmfgt_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vbool8_t __riscv_vmfgt_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd,
                                       vfloat16m2_t vs2, vfloat16m2_t vs1,
                                       size_t vl);
 vbool8_t __riscv_vmfgt_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool4_t __riscv_vmfgt_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd,
                                       vfloat16m4_t vs2, vfloat16m4_t vs1,
                                       size_t vl);
 vbool4_t __riscv_vmfgt_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool2_t __riscv_vmfgt_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd,
                                       vfloat16m8_t vs2, vfloat16m8_t vs1,
                                       size_t vl);
 vbool2_t __riscv_vmfgt_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool64_t __riscv_vmfgt_vv_f32mf2_b64_mu(vbool64_t vm, vbool64_t vd,
                                          vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -16191,37 +16179,37 @@ vbool64_t __riscv_vmfge_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
                                          vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                          size_t vl);
 vbool64_t __riscv_vmfge_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl);
 vbool32_t __riscv_vmfge_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
                                          vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                          size_t vl);
 vbool32_t __riscv_vmfge_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl);
 vbool16_t __riscv_vmfge_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
                                         vfloat16m1_t vs2, vfloat16m1_t vs1,
                                         size_t vl);
 vbool16_t __riscv_vmfge_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl);
 vbool8_t __riscv_vmfge_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd,
                                       vfloat16m2_t vs2, vfloat16m2_t vs1,
                                       size_t vl);
 vbool8_t __riscv_vmfge_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool4_t __riscv_vmfge_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd,
                                       vfloat16m4_t vs2, vfloat16m4_t vs1,
                                       size_t vl);
 vbool4_t __riscv_vmfge_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool2_t __riscv_vmfge_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd,
                                       vfloat16m8_t vs2, vfloat16m8_t vs1,
                                       size_t vl);
 vbool2_t __riscv_vmfge_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl);
 vbool64_t __riscv_vmfge_vv_f32mf2_b64_mu(vbool64_t vm, vbool64_t vd,
                                          vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -16418,38 +16406,35 @@ vfloat16mf4_t __riscv_vmerge_vvm_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                            vfloat16mf4_t vs1, vbool64_t v0,
                                            size_t vl);
 vfloat16mf4_t __riscv_vfmerge_vfm_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                            float16_t rs1, vbool64_t v0,
+                                            _Float16 rs1, vbool64_t v0,
                                             size_t vl);
 vfloat16mf2_t __riscv_vmerge_vvm_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                            vfloat16mf2_t vs1, vbool32_t v0,
                                            size_t vl);
 vfloat16mf2_t __riscv_vfmerge_vfm_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                            float16_t rs1, vbool32_t v0,
+                                            _Float16 rs1, vbool32_t v0,
                                             size_t vl);
 vfloat16m1_t __riscv_vmerge_vvm_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                                          vfloat16m1_t vs1, vbool16_t v0,
                                          size_t vl);
 vfloat16m1_t __riscv_vfmerge_vfm_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                          float16_t rs1, vbool16_t v0,
+                                          _Float16 rs1, vbool16_t v0,
                                           size_t vl);
 vfloat16m2_t __riscv_vmerge_vvm_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                                          vfloat16m2_t vs1, vbool8_t v0,
                                          size_t vl);
 vfloat16m2_t __riscv_vfmerge_vfm_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                          float16_t rs1, vbool8_t v0,
-                                          size_t vl);
+                                          _Float16 rs1, vbool8_t v0, size_t vl);
 vfloat16m4_t __riscv_vmerge_vvm_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                                          vfloat16m4_t vs1, vbool4_t v0,
                                          size_t vl);
 vfloat16m4_t __riscv_vfmerge_vfm_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                          float16_t rs1, vbool4_t v0,
-                                          size_t vl);
+                                          _Float16 rs1, vbool4_t v0, size_t vl);
 vfloat16m8_t __riscv_vmerge_vvm_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                                          vfloat16m8_t vs1, vbool2_t v0,
                                          size_t vl);
 vfloat16m8_t __riscv_vfmerge_vfm_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                          float16_t rs1, vbool2_t v0,
-                                          size_t vl);
+                                          _Float16 rs1, vbool2_t v0, size_t vl);
 vfloat32mf2_t __riscv_vmerge_vvm_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                            vfloat32mf2_t vs1, vbool64_t v0,
                                            size_t vl);
@@ -16513,27 +16498,27 @@ vfloat64m8_t __riscv_vfmerge_vfm_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 ----
 vfloat16mf4_t __riscv_vmv_v_v_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                         size_t vl);
-vfloat16mf4_t __riscv_vfmv_v_f_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmv_v_f_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                          size_t vl);
 vfloat16mf2_t __riscv_vmv_v_v_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                         size_t vl);
-vfloat16mf2_t __riscv_vfmv_v_f_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmv_v_f_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                          size_t vl);
 vfloat16m1_t __riscv_vmv_v_v_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                       size_t vl);
-vfloat16m1_t __riscv_vfmv_v_f_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmv_v_f_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                        size_t vl);
 vfloat16m2_t __riscv_vmv_v_v_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                       size_t vl);
-vfloat16m2_t __riscv_vfmv_v_f_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmv_v_f_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                        size_t vl);
 vfloat16m4_t __riscv_vmv_v_v_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                       size_t vl);
-vfloat16m4_t __riscv_vfmv_v_f_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmv_v_f_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                        size_t vl);
 vfloat16m8_t __riscv_vmv_v_v_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                       size_t vl);
-vfloat16m8_t __riscv_vfmv_v_f_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmv_v_f_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                        size_t vl);
 vfloat32mf2_t __riscv_vmv_v_v_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                         size_t vl);

--- a/auto-generated/policy_funcs/intrinsic_funcs/07_vector_permutation_instructions.adoc
+++ b/auto-generated/policy_funcs/intrinsic_funcs/07_vector_permutation_instructions.adoc
@@ -6,17 +6,17 @@
 
 [,c]
 ----
-vfloat16mf4_t __riscv_vfmv_s_f_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmv_s_f_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                          size_t vl);
-vfloat16mf2_t __riscv_vfmv_s_f_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmv_s_f_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                          size_t vl);
-vfloat16m1_t __riscv_vfmv_s_f_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmv_s_f_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                        size_t vl);
-vfloat16m2_t __riscv_vfmv_s_f_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmv_s_f_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                        size_t vl);
-vfloat16m4_t __riscv_vfmv_s_f_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmv_s_f_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                        size_t vl);
-vfloat16m8_t __riscv_vfmv_s_f_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmv_s_f_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfmv_s_f_f32mf2_tu(vfloat32mf2_t vd, float32_t rs1,
                                          size_t vl);
@@ -1342,19 +1342,19 @@ vuint64m8_t __riscv_vslidedown_vx_u64m8_mu(vbool8_t vm, vuint64m8_t vd,
 [,c]
 ----
 vfloat16mf4_t __riscv_vfslide1up_vf_f16mf4_tu(vfloat16mf4_t vd,
-                                              vfloat16mf4_t vs2, float16_t rs1,
+                                              vfloat16mf4_t vs2, _Float16 rs1,
                                               size_t vl);
 vfloat16mf2_t __riscv_vfslide1up_vf_f16mf2_tu(vfloat16mf2_t vd,
-                                              vfloat16mf2_t vs2, float16_t rs1,
+                                              vfloat16mf2_t vs2, _Float16 rs1,
                                               size_t vl);
 vfloat16m1_t __riscv_vfslide1up_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                            float16_t rs1, size_t vl);
+                                            _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfslide1up_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                            float16_t rs1, size_t vl);
+                                            _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfslide1up_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                            float16_t rs1, size_t vl);
+                                            _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfslide1up_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                            float16_t rs1, size_t vl);
+                                            _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfslide1up_vf_f32mf2_tu(vfloat32mf2_t vd,
                                               vfloat32mf2_t vs2, float32_t rs1,
                                               size_t vl);
@@ -1375,19 +1375,19 @@ vfloat64m4_t __riscv_vfslide1up_vf_f64m4_tu(vfloat64m4_t vd, vfloat64m4_t vs2,
 vfloat64m8_t __riscv_vfslide1up_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
                                             float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfslide1down_vf_f16mf4_tu(vfloat16mf4_t vd,
-                                                vfloat16mf4_t vs2,
-                                                float16_t rs1, size_t vl);
+                                                vfloat16mf4_t vs2, _Float16 rs1,
+                                                size_t vl);
 vfloat16mf2_t __riscv_vfslide1down_vf_f16mf2_tu(vfloat16mf2_t vd,
-                                                vfloat16mf2_t vs2,
-                                                float16_t rs1, size_t vl);
+                                                vfloat16mf2_t vs2, _Float16 rs1,
+                                                size_t vl);
 vfloat16m1_t __riscv_vfslide1down_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                              float16_t rs1, size_t vl);
+                                              _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfslide1down_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                              float16_t rs1, size_t vl);
+                                              _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfslide1down_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                              float16_t rs1, size_t vl);
+                                              _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfslide1down_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                              float16_t rs1, size_t vl);
+                                              _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfslide1down_vf_f32mf2_tu(vfloat32mf2_t vd,
                                                 vfloat32mf2_t vs2,
                                                 float32_t rs1, size_t vl);
@@ -1585,22 +1585,22 @@ vuint64m8_t __riscv_vslide1down_vx_u64m8_tu(vuint64m8_t vd, vuint64m8_t vs2,
                                             uint64_t rs1, size_t vl);
 // masked functions
 vfloat16mf4_t __riscv_vfslide1up_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                               vfloat16mf4_t vs2, float16_t rs1,
+                                               vfloat16mf4_t vs2, _Float16 rs1,
                                                size_t vl);
 vfloat16mf2_t __riscv_vfslide1up_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                               vfloat16mf2_t vs2, float16_t rs1,
+                                               vfloat16mf2_t vs2, _Float16 rs1,
                                                size_t vl);
 vfloat16m1_t __riscv_vfslide1up_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                             vfloat16m1_t vs2, float16_t rs1,
+                                             vfloat16m1_t vs2, _Float16 rs1,
                                              size_t vl);
 vfloat16m2_t __riscv_vfslide1up_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                             vfloat16m2_t vs2, float16_t rs1,
+                                             vfloat16m2_t vs2, _Float16 rs1,
                                              size_t vl);
 vfloat16m4_t __riscv_vfslide1up_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                             vfloat16m4_t vs2, float16_t rs1,
+                                             vfloat16m4_t vs2, _Float16 rs1,
                                              size_t vl);
 vfloat16m8_t __riscv_vfslide1up_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                             vfloat16m8_t vs2, float16_t rs1,
+                                             vfloat16m8_t vs2, _Float16 rs1,
                                              size_t vl);
 vfloat32mf2_t __riscv_vfslide1up_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                                vfloat32mf2_t vs2, float32_t rs1,
@@ -1631,21 +1631,21 @@ vfloat64m8_t __riscv_vfslide1up_vf_f64m8_tum(vbool8_t vm, vfloat64m8_t vd,
                                              size_t vl);
 vfloat16mf4_t __riscv_vfslide1down_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
                                                  vfloat16mf4_t vs2,
-                                                 float16_t rs1, size_t vl);
+                                                 _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfslide1down_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
                                                  vfloat16mf2_t vs2,
-                                                 float16_t rs1, size_t vl);
+                                                 _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfslide1down_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                               vfloat16m1_t vs2, float16_t rs1,
+                                               vfloat16m1_t vs2, _Float16 rs1,
                                                size_t vl);
 vfloat16m2_t __riscv_vfslide1down_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                               vfloat16m2_t vs2, float16_t rs1,
+                                               vfloat16m2_t vs2, _Float16 rs1,
                                                size_t vl);
 vfloat16m4_t __riscv_vfslide1down_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                               vfloat16m4_t vs2, float16_t rs1,
+                                               vfloat16m4_t vs2, _Float16 rs1,
                                                size_t vl);
 vfloat16m8_t __riscv_vfslide1down_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                               vfloat16m8_t vs2, float16_t rs1,
+                                               vfloat16m8_t vs2, _Float16 rs1,
                                                size_t vl);
 vfloat32mf2_t __riscv_vfslide1down_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
                                                  vfloat32mf2_t vs2,
@@ -1932,22 +1932,22 @@ vuint64m8_t __riscv_vslide1down_vx_u64m8_tum(vbool8_t vm, vuint64m8_t vd,
                                              size_t vl);
 // masked functions
 vfloat16mf4_t __riscv_vfslide1up_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                                vfloat16mf4_t vs2,
-                                                float16_t rs1, size_t vl);
+                                                vfloat16mf4_t vs2, _Float16 rs1,
+                                                size_t vl);
 vfloat16mf2_t __riscv_vfslide1up_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                                vfloat16mf2_t vs2,
-                                                float16_t rs1, size_t vl);
+                                                vfloat16mf2_t vs2, _Float16 rs1,
+                                                size_t vl);
 vfloat16m1_t __riscv_vfslide1up_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                              vfloat16m1_t vs2, float16_t rs1,
+                                              vfloat16m1_t vs2, _Float16 rs1,
                                               size_t vl);
 vfloat16m2_t __riscv_vfslide1up_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                              vfloat16m2_t vs2, float16_t rs1,
+                                              vfloat16m2_t vs2, _Float16 rs1,
                                               size_t vl);
 vfloat16m4_t __riscv_vfslide1up_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                              vfloat16m4_t vs2, float16_t rs1,
+                                              vfloat16m4_t vs2, _Float16 rs1,
                                               size_t vl);
 vfloat16m8_t __riscv_vfslide1up_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                              vfloat16m8_t vs2, float16_t rs1,
+                                              vfloat16m8_t vs2, _Float16 rs1,
                                               size_t vl);
 vfloat32mf2_t __riscv_vfslide1up_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                                 vfloat32mf2_t vs2,
@@ -1979,22 +1979,22 @@ vfloat64m8_t __riscv_vfslide1up_vf_f64m8_tumu(vbool8_t vm, vfloat64m8_t vd,
 vfloat16mf4_t __riscv_vfslide1down_vf_f16mf4_tumu(vbool64_t vm,
                                                   vfloat16mf4_t vd,
                                                   vfloat16mf4_t vs2,
-                                                  float16_t rs1, size_t vl);
+                                                  _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfslide1down_vf_f16mf2_tumu(vbool32_t vm,
                                                   vfloat16mf2_t vd,
                                                   vfloat16mf2_t vs2,
-                                                  float16_t rs1, size_t vl);
+                                                  _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfslide1down_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                                vfloat16m1_t vs2, float16_t rs1,
+                                                vfloat16m1_t vs2, _Float16 rs1,
                                                 size_t vl);
 vfloat16m2_t __riscv_vfslide1down_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                                vfloat16m2_t vs2, float16_t rs1,
+                                                vfloat16m2_t vs2, _Float16 rs1,
                                                 size_t vl);
 vfloat16m4_t __riscv_vfslide1down_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                                vfloat16m4_t vs2, float16_t rs1,
+                                                vfloat16m4_t vs2, _Float16 rs1,
                                                 size_t vl);
 vfloat16m8_t __riscv_vfslide1down_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                                vfloat16m8_t vs2, float16_t rs1,
+                                                vfloat16m8_t vs2, _Float16 rs1,
                                                 size_t vl);
 vfloat32mf2_t __riscv_vfslide1down_vf_f32mf2_tumu(vbool64_t vm,
                                                   vfloat32mf2_t vd,
@@ -2286,22 +2286,22 @@ vuint64m8_t __riscv_vslide1down_vx_u64m8_tumu(vbool8_t vm, vuint64m8_t vd,
                                               size_t vl);
 // masked functions
 vfloat16mf4_t __riscv_vfslide1up_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                              vfloat16mf4_t vs2, float16_t rs1,
+                                              vfloat16mf4_t vs2, _Float16 rs1,
                                               size_t vl);
 vfloat16mf2_t __riscv_vfslide1up_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                              vfloat16mf2_t vs2, float16_t rs1,
+                                              vfloat16mf2_t vs2, _Float16 rs1,
                                               size_t vl);
 vfloat16m1_t __riscv_vfslide1up_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                            vfloat16m1_t vs2, float16_t rs1,
+                                            vfloat16m1_t vs2, _Float16 rs1,
                                             size_t vl);
 vfloat16m2_t __riscv_vfslide1up_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                            vfloat16m2_t vs2, float16_t rs1,
+                                            vfloat16m2_t vs2, _Float16 rs1,
                                             size_t vl);
 vfloat16m4_t __riscv_vfslide1up_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                            vfloat16m4_t vs2, float16_t rs1,
+                                            vfloat16m4_t vs2, _Float16 rs1,
                                             size_t vl);
 vfloat16m8_t __riscv_vfslide1up_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                            vfloat16m8_t vs2, float16_t rs1,
+                                            vfloat16m8_t vs2, _Float16 rs1,
                                             size_t vl);
 vfloat32mf2_t __riscv_vfslide1up_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                               vfloat32mf2_t vs2, float32_t rs1,
@@ -2331,22 +2331,22 @@ vfloat64m8_t __riscv_vfslide1up_vf_f64m8_mu(vbool8_t vm, vfloat64m8_t vd,
                                             vfloat64m8_t vs2, float64_t rs1,
                                             size_t vl);
 vfloat16mf4_t __riscv_vfslide1down_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                                vfloat16mf4_t vs2,
-                                                float16_t rs1, size_t vl);
+                                                vfloat16mf4_t vs2, _Float16 rs1,
+                                                size_t vl);
 vfloat16mf2_t __riscv_vfslide1down_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                                vfloat16mf2_t vs2,
-                                                float16_t rs1, size_t vl);
+                                                vfloat16mf2_t vs2, _Float16 rs1,
+                                                size_t vl);
 vfloat16m1_t __riscv_vfslide1down_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                              vfloat16m1_t vs2, float16_t rs1,
+                                              vfloat16m1_t vs2, _Float16 rs1,
                                               size_t vl);
 vfloat16m2_t __riscv_vfslide1down_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                              vfloat16m2_t vs2, float16_t rs1,
+                                              vfloat16m2_t vs2, _Float16 rs1,
                                               size_t vl);
 vfloat16m4_t __riscv_vfslide1down_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                              vfloat16m4_t vs2, float16_t rs1,
+                                              vfloat16m4_t vs2, _Float16 rs1,
                                               size_t vl);
 vfloat16m8_t __riscv_vfslide1down_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                              vfloat16m8_t vs2, float16_t rs1,
+                                              vfloat16m8_t vs2, _Float16 rs1,
                                               size_t vl);
 vfloat32mf2_t __riscv_vfslide1down_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
                                                 vfloat32mf2_t vs2,

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfadd.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfadd.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfadd_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfadd_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfadd_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfadd_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, vl);
 }
 
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
+                                     vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, vl);
 }
@@ -546,8 +546,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                    vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -558,8 +557,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                    vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -570,8 +568,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                    vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -582,8 +579,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                    vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -701,7 +697,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -711,7 +707,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -721,7 +717,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfadd_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +727,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfadd_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -741,7 +737,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfadd_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -751,7 +747,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfadd_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfadd_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -852,7 +848,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +860,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +872,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +884,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +896,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +908,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfadd_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1028,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1040,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1052,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1064,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1076,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1088,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfadd_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1212,7 +1208,7 @@ vfloat16mf4_t test_vfadd_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1224,7 +1220,7 @@ vfloat16mf2_t test_vfadd_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1236,7 +1232,7 @@ vfloat16m1_t test_vfadd_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1248,7 +1244,7 @@ vfloat16m2_t test_vfadd_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1256,7 @@ vfloat16m4_t test_vfadd_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1268,7 @@ vfloat16m8_t test_vfadd_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfadd_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfdiv.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfdiv.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfdiv_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfdiv_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfdiv_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfdiv_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, vl);
 }
 
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfdiv_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfdiv_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfdiv_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfdiv_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
+                                     vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfdiv_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfdiv_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfdiv_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfdiv_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, vl);
 }
@@ -546,8 +546,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfdiv_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                    vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -558,8 +557,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfdiv_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                    vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -570,8 +568,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfdiv_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                    vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -582,8 +579,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfdiv_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                    vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -701,7 +697,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -711,7 +707,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -721,7 +717,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfdiv_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +727,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfdiv_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -741,7 +737,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfdiv_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -751,7 +747,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfdiv_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -852,7 +848,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +860,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +872,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfdiv_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +884,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfdiv_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +896,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfdiv_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +908,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfdiv_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1028,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1040,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1052,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfdiv_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1064,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfdiv_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1076,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfdiv_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1088,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfdiv_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1212,7 +1208,7 @@ vfloat16mf4_t test_vfdiv_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfdiv_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1224,7 +1220,7 @@ vfloat16mf2_t test_vfdiv_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfdiv_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1236,7 +1232,7 @@ vfloat16m1_t test_vfdiv_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfdiv_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1248,7 +1244,7 @@ vfloat16m2_t test_vfdiv_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfdiv_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1256,7 @@ vfloat16m4_t test_vfdiv_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfdiv_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1268,7 @@ vfloat16m8_t test_vfdiv_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfdiv_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfmacc.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfmacc.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmacc_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmacc_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmacc_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmacc_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmacc_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmacc_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmacc_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                        float16_t rs1, vfloat16mf4_t vs2,
+                                        _Float16 rs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmacc_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                        float16_t rs1, vfloat16mf2_t vs2,
+                                        _Float16 rs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmacc_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                      float16_t rs1, vfloat16m1_t vs2,
+                                      _Float16 rs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmacc_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                      float16_t rs1, vfloat16m2_t vs2,
+                                      _Float16 rs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmacc_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                      float16_t rs1, vfloat16m4_t vs2,
+                                      _Float16 rs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmacc_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                      float16_t rs1, vfloat16m8_t vs2,
+                                      _Float16 rs1, vfloat16m8_t vs2,
                                       size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmacc_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmacc_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmacc_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmacc_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmacc_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmacc_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmacc_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                       float16_t rs1, vfloat16mf4_t vs2,
+                                       _Float16 rs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmacc_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                       float16_t rs1, vfloat16mf2_t vs2,
+                                       _Float16 rs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmacc_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                     float16_t rs1, vfloat16m1_t vs2,
+                                     _Float16 rs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, vl);
 }
@@ -557,9 +557,8 @@ vfloat16m2_t test_vfmacc_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                     float16_t rs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat16m2_t test_vfmacc_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -569,9 +568,8 @@ vfloat16m4_t test_vfmacc_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                     float16_t rs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat16m4_t test_vfmacc_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -581,9 +579,8 @@ vfloat16m8_t test_vfmacc_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfmacc_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                     float16_t rs1, vfloat16m8_t vs2,
-                                     size_t vl) {
+vfloat16m8_t test_vfmacc_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
+                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -700,7 +697,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -710,7 +707,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -720,7 +717,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -730,7 +727,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -740,7 +737,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -750,7 +747,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -852,7 +849,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +861,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +873,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmacc_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +885,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmacc_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +897,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmacc_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +909,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmacc_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl) {
   return __riscv_vfmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1029,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1041,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1053,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmacc_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1065,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmacc_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1077,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmacc_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1089,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmacc_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl) {
   return __riscv_vfmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1212,7 +1209,7 @@ vfloat16mf4_t test_vfmacc_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmacc_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1224,7 +1221,7 @@ vfloat16mf2_t test_vfmacc_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmacc_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1236,7 +1233,7 @@ vfloat16m1_t test_vfmacc_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmacc_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1248,7 +1245,7 @@ vfloat16m2_t test_vfmacc_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmacc_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1257,7 @@ vfloat16m4_t test_vfmacc_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmacc_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1269,7 @@ vfloat16m8_t test_vfmacc_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmacc_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfmadd.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfmadd.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmadd_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmadd_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmadd_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmadd_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmadd_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmadd_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                        float16_t rs1, vfloat16mf4_t vs2,
+                                        _Float16 rs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                        float16_t rs1, vfloat16mf2_t vs2,
+                                        _Float16 rs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                      float16_t rs1, vfloat16m1_t vs2,
+                                      _Float16 rs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                      float16_t rs1, vfloat16m2_t vs2,
+                                      _Float16 rs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                      float16_t rs1, vfloat16m4_t vs2,
+                                      _Float16 rs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                      float16_t rs1, vfloat16m8_t vs2,
+                                      _Float16 rs1, vfloat16m8_t vs2,
                                       size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                       float16_t rs1, vfloat16mf4_t vs2,
+                                       _Float16 rs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                       float16_t rs1, vfloat16mf2_t vs2,
+                                       _Float16 rs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                     float16_t rs1, vfloat16m1_t vs2,
+                                     _Float16 rs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, vl);
 }
@@ -557,9 +557,8 @@ vfloat16m2_t test_vfmadd_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfmadd_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                     float16_t rs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat16m2_t test_vfmadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -569,9 +568,8 @@ vfloat16m4_t test_vfmadd_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfmadd_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                     float16_t rs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat16m4_t test_vfmadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -581,9 +579,8 @@ vfloat16m8_t test_vfmadd_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfmadd_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                     float16_t rs1, vfloat16m8_t vs2,
-                                     size_t vl) {
+vfloat16m8_t test_vfmadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
+                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -700,7 +697,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -710,7 +707,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -720,7 +717,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -730,7 +727,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -740,7 +737,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -750,7 +747,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -852,7 +849,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +861,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +873,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +885,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +897,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +909,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl) {
   return __riscv_vfmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1029,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1041,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1053,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1065,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1077,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1089,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl) {
   return __riscv_vfmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1212,7 +1209,7 @@ vfloat16mf4_t test_vfmadd_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1224,7 +1221,7 @@ vfloat16mf2_t test_vfmadd_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1236,7 +1233,7 @@ vfloat16m1_t test_vfmadd_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1248,7 +1245,7 @@ vfloat16m2_t test_vfmadd_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1257,7 @@ vfloat16m4_t test_vfmadd_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1269,7 @@ vfloat16m8_t test_vfmadd_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfmax.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfmax.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfmax_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfmax_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat16m1_t test_vfmax_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfmax_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfmax_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfmax_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfmax_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmax_tu(vd, vs2, rs1, vl);
 }
 
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmax_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmax_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmax_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmax_tum(vm, vd, vs2, rs1, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfmax_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmax_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmax_tum(vm, vd, vs2, rs1, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmax_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmax_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmax_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmax_tum(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmax_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
+                                     vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmax_tum(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmax_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmax_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmax_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmax_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfmax_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmax_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmax_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmax_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmax_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmax_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmax_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmax_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmax_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfmax_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmax_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmax_mu(vm, vd, vs2, rs1, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfmax_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmax_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmax_mu(vm, vd, vs2, rs1, vl);
 }
@@ -546,8 +546,7 @@ vfloat16m1_t test_vfmax_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmax_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                    vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -558,8 +557,7 @@ vfloat16m2_t test_vfmax_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmax_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                    vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -570,8 +568,7 @@ vfloat16m4_t test_vfmax_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmax_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                    vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -582,8 +579,7 @@ vfloat16m8_t test_vfmax_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmax_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                    vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmax_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfmerge.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfmerge.c
@@ -6,34 +6,34 @@ typedef float float32_t;
 typedef double float64_t;
 
 vfloat16mf4_t test_vfmerge_vfm_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                         float16_t rs1, vbool64_t v0,
+                                         _Float16 rs1, vbool64_t v0,
                                          size_t vl) {
   return __riscv_vfmerge_tu(vd, vs2, rs1, v0, vl);
 }
 
 vfloat16mf2_t test_vfmerge_vfm_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                         float16_t rs1, vbool32_t v0,
+                                         _Float16 rs1, vbool32_t v0,
                                          size_t vl) {
   return __riscv_vfmerge_tu(vd, vs2, rs1, v0, vl);
 }
 
 vfloat16m1_t test_vfmerge_vfm_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                       float16_t rs1, vbool16_t v0, size_t vl) {
+                                       _Float16 rs1, vbool16_t v0, size_t vl) {
   return __riscv_vfmerge_tu(vd, vs2, rs1, v0, vl);
 }
 
 vfloat16m2_t test_vfmerge_vfm_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                       float16_t rs1, vbool8_t v0, size_t vl) {
+                                       _Float16 rs1, vbool8_t v0, size_t vl) {
   return __riscv_vfmerge_tu(vd, vs2, rs1, v0, vl);
 }
 
 vfloat16m4_t test_vfmerge_vfm_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                       float16_t rs1, vbool4_t v0, size_t vl) {
+                                       _Float16 rs1, vbool4_t v0, size_t vl) {
   return __riscv_vfmerge_tu(vd, vs2, rs1, v0, vl);
 }
 
 vfloat16m8_t test_vfmerge_vfm_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                       float16_t rs1, vbool2_t v0, size_t vl) {
+                                       _Float16 rs1, vbool2_t v0, size_t vl) {
   return __riscv_vfmerge_tu(vd, vs2, rs1, v0, vl);
 }
 

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfmin.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfmin.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfmin_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfmin_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat16m1_t test_vfmin_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfmin_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfmin_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfmin_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfmin_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmin_tu(vd, vs2, rs1, vl);
 }
 
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmin_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmin_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmin_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmin_tum(vm, vd, vs2, rs1, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfmin_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmin_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmin_tum(vm, vd, vs2, rs1, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmin_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmin_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmin_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmin_tum(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmin_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
+                                     vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmin_tum(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmin_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmin_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmin_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmin_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfmin_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmin_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmin_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmin_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmin_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmin_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmin_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmin_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmin_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfmin_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmin_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmin_mu(vm, vd, vs2, rs1, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfmin_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmin_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmin_mu(vm, vd, vs2, rs1, vl);
 }
@@ -546,8 +546,7 @@ vfloat16m1_t test_vfmin_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmin_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                    vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -558,8 +557,7 @@ vfloat16m2_t test_vfmin_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmin_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                    vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -570,8 +568,7 @@ vfloat16m4_t test_vfmin_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmin_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                    vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -582,8 +579,7 @@ vfloat16m8_t test_vfmin_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmin_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                    vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmin_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfmsac.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfmsac.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmsac_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmsac_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmsac_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsac_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsac_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsac_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsac_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                        float16_t rs1, vfloat16mf4_t vs2,
+                                        _Float16 rs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsac_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                        float16_t rs1, vfloat16mf2_t vs2,
+                                        _Float16 rs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsac_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                      float16_t rs1, vfloat16m1_t vs2,
+                                      _Float16 rs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsac_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                      float16_t rs1, vfloat16m2_t vs2,
+                                      _Float16 rs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsac_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                      float16_t rs1, vfloat16m4_t vs2,
+                                      _Float16 rs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsac_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                      float16_t rs1, vfloat16m8_t vs2,
+                                      _Float16 rs1, vfloat16m8_t vs2,
                                       size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsac_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsac_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsac_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsac_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsac_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsac_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsac_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                       float16_t rs1, vfloat16mf4_t vs2,
+                                       _Float16 rs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsac_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                       float16_t rs1, vfloat16mf2_t vs2,
+                                       _Float16 rs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsac_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                     float16_t rs1, vfloat16m1_t vs2,
+                                     _Float16 rs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, vl);
 }
@@ -557,9 +557,8 @@ vfloat16m2_t test_vfmsac_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                     float16_t rs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat16m2_t test_vfmsac_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -569,9 +568,8 @@ vfloat16m4_t test_vfmsac_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                     float16_t rs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat16m4_t test_vfmsac_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -581,9 +579,8 @@ vfloat16m8_t test_vfmsac_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfmsac_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                     float16_t rs1, vfloat16m8_t vs2,
-                                     size_t vl) {
+vfloat16m8_t test_vfmsac_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
+                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -700,7 +697,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -710,7 +707,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -720,7 +717,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -730,7 +727,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -740,7 +737,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -750,7 +747,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -852,7 +849,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +861,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +873,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsac_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +885,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsac_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +897,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsac_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +909,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsac_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl) {
   return __riscv_vfmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1029,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1041,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1053,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsac_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1065,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsac_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1077,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsac_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1089,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsac_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl) {
   return __riscv_vfmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1212,7 +1209,7 @@ vfloat16mf4_t test_vfmsac_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsac_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1224,7 +1221,7 @@ vfloat16mf2_t test_vfmsac_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsac_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1236,7 +1233,7 @@ vfloat16m1_t test_vfmsac_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsac_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1248,7 +1245,7 @@ vfloat16m2_t test_vfmsac_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsac_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1257,7 @@ vfloat16m4_t test_vfmsac_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsac_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1269,7 @@ vfloat16m8_t test_vfmsac_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsac_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfmsub.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfmsub.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmsub_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                        vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmsub_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmsub_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                      vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsub_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                      vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsub_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                      vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsub_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                      vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                        float16_t rs1, vfloat16mf4_t vs2,
+                                        _Float16 rs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                        float16_t rs1, vfloat16mf2_t vs2,
+                                        _Float16 rs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                      float16_t rs1, vfloat16m1_t vs2,
+                                      _Float16 rs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                      float16_t rs1, vfloat16m2_t vs2,
+                                      _Float16 rs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                      float16_t rs1, vfloat16m4_t vs2,
+                                      _Float16 rs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                      float16_t rs1, vfloat16m8_t vs2,
+                                      _Float16 rs1, vfloat16m8_t vs2,
                                       size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                       float16_t rs1, vfloat16mf4_t vs2,
+                                       _Float16 rs1, vfloat16mf4_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                       float16_t rs1, vfloat16mf2_t vs2,
+                                       _Float16 rs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                     float16_t rs1, vfloat16m1_t vs2,
+                                     _Float16 rs1, vfloat16m1_t vs2,
                                      size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, vl);
 }
@@ -557,9 +557,8 @@ vfloat16m2_t test_vfmsub_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
   return __riscv_vfmsub_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                     float16_t rs1, vfloat16m2_t vs2,
-                                     size_t vl) {
+vfloat16m2_t test_vfmsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
+                                     vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -569,9 +568,8 @@ vfloat16m4_t test_vfmsub_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
   return __riscv_vfmsub_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                     float16_t rs1, vfloat16m4_t vs2,
-                                     size_t vl) {
+vfloat16m4_t test_vfmsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
+                                     vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -581,9 +579,8 @@ vfloat16m8_t test_vfmsub_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
   return __riscv_vfmsub_mu(vm, vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                     float16_t rs1, vfloat16m8_t vs2,
-                                     size_t vl) {
+vfloat16m8_t test_vfmsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
+                                     vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, vl);
 }
 
@@ -700,7 +697,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                           vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -710,7 +707,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                           vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -720,7 +717,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                         vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -730,7 +727,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                         vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -740,7 +737,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                         vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -750,7 +747,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                         vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -852,7 +849,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +861,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +873,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +885,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +897,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +909,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl) {
   return __riscv_vfmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1029,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1041,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1053,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1065,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1077,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1089,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl) {
   return __riscv_vfmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1212,7 +1209,7 @@ vfloat16mf4_t test_vfmsub_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1224,7 +1221,7 @@ vfloat16mf2_t test_vfmsub_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1236,7 +1233,7 @@ vfloat16m1_t test_vfmsub_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1248,7 +1245,7 @@ vfloat16m2_t test_vfmsub_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1257,7 @@ vfloat16m4_t test_vfmsub_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1269,7 @@ vfloat16m8_t test_vfmsub_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfmul.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfmul.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfmul_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfmul_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfmul_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfmul_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmul_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmul_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmul_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmul_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
+                                     vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmul_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmul_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmul_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmul_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, vl);
 }
@@ -546,8 +546,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmul_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                    vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -558,8 +557,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmul_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                    vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -570,8 +568,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmul_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                    vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -582,8 +579,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmul_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                    vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -701,7 +697,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -711,7 +707,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -721,7 +717,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfmul_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +727,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfmul_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -741,7 +737,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfmul_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -751,7 +747,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfmul_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -852,7 +848,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +860,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +872,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmul_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +884,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmul_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +896,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmul_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +908,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmul_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1028,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1040,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1052,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmul_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1064,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmul_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1076,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmul_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1088,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmul_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1212,7 +1208,7 @@ vfloat16mf4_t test_vfmul_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfmul_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1224,7 +1220,7 @@ vfloat16mf2_t test_vfmul_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfmul_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1236,7 +1232,7 @@ vfloat16m1_t test_vfmul_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfmul_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1248,7 +1244,7 @@ vfloat16m2_t test_vfmul_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfmul_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1256,7 @@ vfloat16m4_t test_vfmul_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfmul_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1268,7 @@ vfloat16m8_t test_vfmul_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfmul_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfmv.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfmv.c
@@ -5,29 +5,29 @@ typedef _Float16 float16_t;
 typedef float float32_t;
 typedef double float64_t;
 
-vfloat16mf4_t test_vfmv_v_f_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmv_v_f_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmv_v_tu(vd, rs1, vl);
 }
 
-vfloat16mf2_t test_vfmv_v_f_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmv_v_f_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmv_v_tu(vd, rs1, vl);
 }
 
-vfloat16m1_t test_vfmv_v_f_f16m1_tu(vfloat16m1_t vd, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmv_v_f_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_tu(vd, rs1, vl);
 }
 
-vfloat16m2_t test_vfmv_v_f_f16m2_tu(vfloat16m2_t vd, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmv_v_f_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_tu(vd, rs1, vl);
 }
 
-vfloat16m4_t test_vfmv_v_f_f16m4_tu(vfloat16m4_t vd, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmv_v_f_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_tu(vd, rs1, vl);
 }
 
-vfloat16m8_t test_vfmv_v_f_f16m8_tu(vfloat16m8_t vd, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmv_v_f_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_v_tu(vd, rs1, vl);
 }
 
@@ -68,29 +68,29 @@ vfloat64m8_t test_vfmv_v_f_f64m8_tu(vfloat64m8_t vd, float64_t rs1, size_t vl) {
   return __riscv_vfmv_v_tu(vd, rs1, vl);
 }
 
-vfloat16mf4_t test_vfmv_s_f_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfmv_s_f_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmv_s_tu(vd, rs1, vl);
 }
 
-vfloat16mf2_t test_vfmv_s_f_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfmv_s_f_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfmv_s_tu(vd, rs1, vl);
 }
 
-vfloat16m1_t test_vfmv_s_f_f16m1_tu(vfloat16m1_t vd, float16_t rs1, size_t vl) {
+vfloat16m1_t test_vfmv_s_f_f16m1_tu(vfloat16m1_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_tu(vd, rs1, vl);
 }
 
-vfloat16m2_t test_vfmv_s_f_f16m2_tu(vfloat16m2_t vd, float16_t rs1, size_t vl) {
+vfloat16m2_t test_vfmv_s_f_f16m2_tu(vfloat16m2_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_tu(vd, rs1, vl);
 }
 
-vfloat16m4_t test_vfmv_s_f_f16m4_tu(vfloat16m4_t vd, float16_t rs1, size_t vl) {
+vfloat16m4_t test_vfmv_s_f_f16m4_tu(vfloat16m4_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_tu(vd, rs1, vl);
 }
 
-vfloat16m8_t test_vfmv_s_f_f16m8_tu(vfloat16m8_t vd, float16_t rs1, size_t vl) {
+vfloat16m8_t test_vfmv_s_f_f16m8_tu(vfloat16m8_t vd, _Float16 rs1, size_t vl) {
   return __riscv_vfmv_s_tu(vd, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfnmacc.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfnmacc.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmacc_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmacc_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmacc_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmacc_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmacc_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmacc_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmacc_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmacc_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmacc_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmacc_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmacc_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmacc_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmacc_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmacc_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmacc_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmacc_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmacc_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                        float16_t rs1, vfloat16mf4_t vs2,
+                                        _Float16 rs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmacc_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                        float16_t rs1, vfloat16mf2_t vs2,
+                                        _Float16 rs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmacc_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                      float16_t rs1, vfloat16m1_t vs2,
+                                      _Float16 rs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, vl);
 }
@@ -558,7 +558,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmacc_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                      float16_t rs1, vfloat16m2_t vs2,
+                                      _Float16 rs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, vl);
 }
@@ -570,7 +570,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmacc_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                      float16_t rs1, vfloat16m4_t vs2,
+                                      _Float16 rs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, vl);
 }
@@ -582,7 +582,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmacc_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                      float16_t rs1, vfloat16m8_t vs2,
+                                      _Float16 rs1, vfloat16m8_t vs2,
                                       size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, vl);
 }
@@ -700,7 +700,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -710,7 +710,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -720,7 +720,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -730,7 +730,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -740,7 +740,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -750,7 +750,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmacc_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -852,7 +852,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +864,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +876,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +888,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +900,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +912,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl) {
   return __riscv_vfnmacc_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1032,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1044,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1056,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmacc_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1068,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmacc_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1080,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmacc_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1092,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmacc_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            size_t vl) {
   return __riscv_vfnmacc_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1212,7 +1212,7 @@ vfloat16mf4_t test_vfnmacc_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmacc_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1224,7 +1224,7 @@ vfloat16mf2_t test_vfnmacc_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmacc_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1236,7 +1236,7 @@ vfloat16m1_t test_vfnmacc_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmacc_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1248,7 +1248,7 @@ vfloat16m2_t test_vfnmacc_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmacc_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1260,7 @@ vfloat16m4_t test_vfnmacc_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmacc_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1272,7 @@ vfloat16m8_t test_vfnmacc_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmacc_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl) {
   return __riscv_vfnmacc_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfnmadd.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfnmadd.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmadd_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmadd_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmadd_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmadd_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmadd_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmadd_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmadd_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmadd_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmadd_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmadd_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmadd_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmadd_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmadd_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmadd_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmadd_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmadd_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmadd_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmadd_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                        float16_t rs1, vfloat16mf4_t vs2,
+                                        _Float16 rs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmadd_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                        float16_t rs1, vfloat16mf2_t vs2,
+                                        _Float16 rs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmadd_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                      float16_t rs1, vfloat16m1_t vs2,
+                                      _Float16 rs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, vl);
 }
@@ -558,7 +558,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmadd_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                      float16_t rs1, vfloat16m2_t vs2,
+                                      _Float16 rs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, vl);
 }
@@ -570,7 +570,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmadd_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                      float16_t rs1, vfloat16m4_t vs2,
+                                      _Float16 rs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, vl);
 }
@@ -582,7 +582,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmadd_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                      float16_t rs1, vfloat16m8_t vs2,
+                                      _Float16 rs1, vfloat16m8_t vs2,
                                       size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, vl);
 }
@@ -700,7 +700,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -710,7 +710,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -720,7 +720,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -730,7 +730,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -740,7 +740,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -750,7 +750,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmadd_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmadd_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -852,7 +852,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +864,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +876,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +888,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +900,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +912,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl) {
   return __riscv_vfnmadd_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1032,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1044,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1056,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmadd_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1068,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmadd_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1080,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmadd_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1092,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmadd_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            size_t vl) {
   return __riscv_vfnmadd_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1212,7 +1212,7 @@ vfloat16mf4_t test_vfnmadd_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmadd_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1224,7 +1224,7 @@ vfloat16mf2_t test_vfnmadd_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmadd_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1236,7 +1236,7 @@ vfloat16m1_t test_vfnmadd_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmadd_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1248,7 +1248,7 @@ vfloat16m2_t test_vfnmadd_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmadd_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1260,7 @@ vfloat16m4_t test_vfnmadd_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmadd_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1272,7 @@ vfloat16m8_t test_vfnmadd_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmadd_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl) {
   return __riscv_vfnmadd_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfnmsac.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfnmsac.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmsac_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmsac_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmsac_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmsac_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsac_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsac_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsac_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsac_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsac_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsac_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsac_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsac_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsac_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsac_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsac_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsac_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsac_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                        float16_t rs1, vfloat16mf4_t vs2,
+                                        _Float16 rs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsac_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                        float16_t rs1, vfloat16mf2_t vs2,
+                                        _Float16 rs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsac_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                      float16_t rs1, vfloat16m1_t vs2,
+                                      _Float16 rs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, vl);
 }
@@ -558,7 +558,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsac_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                      float16_t rs1, vfloat16m2_t vs2,
+                                      _Float16 rs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, vl);
 }
@@ -570,7 +570,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsac_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                      float16_t rs1, vfloat16m4_t vs2,
+                                      _Float16 rs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, vl);
 }
@@ -582,7 +582,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsac_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                      float16_t rs1, vfloat16m8_t vs2,
+                                      _Float16 rs1, vfloat16m8_t vs2,
                                       size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, vl);
 }
@@ -700,7 +700,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -710,7 +710,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -720,7 +720,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -730,7 +730,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -740,7 +740,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -750,7 +750,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsac_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -852,7 +852,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +864,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +876,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +888,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +900,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +912,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsac_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1032,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1044,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1056,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsac_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1068,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsac_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1080,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsac_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1092,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsac_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsac_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1212,7 +1212,7 @@ vfloat16mf4_t test_vfnmsac_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsac_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1224,7 +1224,7 @@ vfloat16mf2_t test_vfnmsac_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsac_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1236,7 +1236,7 @@ vfloat16m1_t test_vfnmsac_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsac_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1248,7 +1248,7 @@ vfloat16m2_t test_vfnmsac_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsac_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1260,7 @@ vfloat16m4_t test_vfnmsac_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsac_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1272,7 @@ vfloat16m8_t test_vfnmsac_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsac_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsac_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfnmsub.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfnmsub.c
@@ -10,7 +10,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_tu(vfloat16mf4_t vd, _Float16 rs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_tu(vfloat16mf2_t vd, _Float16 rs1,
                                         vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmsub_vf_f16m1_tu(vfloat16m1_t vd, _Float16 rs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmsub_vf_f16m2_tu(vfloat16m2_t vd, _Float16 rs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmsub_vf_f16m4_tu(vfloat16m4_t vd, _Float16 rs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, vl);
 }
@@ -60,7 +60,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmsub_tu(vd, vs1, vs2, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmsub_vf_f16m8_tu(vfloat16m8_t vd, _Float16 rs1,
                                       vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, vl);
 }
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                         float16_t rs1, vfloat16mf4_t vs2,
+                                         _Float16 rs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                         float16_t rs1, vfloat16mf2_t vs2,
+                                         _Float16 rs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                       float16_t rs1, vfloat16m1_t vs2,
+                                       _Float16 rs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                       float16_t rs1, vfloat16m2_t vs2,
+                                       _Float16 rs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                       float16_t rs1, vfloat16m4_t vs2,
+                                       _Float16 rs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                       float16_t rs1, vfloat16m8_t vs2,
+                                       _Float16 rs1, vfloat16m8_t vs2,
                                        size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                          float16_t rs1, vfloat16mf4_t vs2,
+                                          _Float16 rs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                          float16_t rs1, vfloat16mf2_t vs2,
+                                          _Float16 rs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                        float16_t rs1, vfloat16m1_t vs2,
+                                        _Float16 rs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                        float16_t rs1, vfloat16m2_t vs2,
+                                        _Float16 rs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                        float16_t rs1, vfloat16m4_t vs2,
+                                        _Float16 rs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                        float16_t rs1, vfloat16m8_t vs2,
+                                        _Float16 rs1, vfloat16m8_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                        float16_t rs1, vfloat16mf4_t vs2,
+                                        _Float16 rs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                        float16_t rs1, vfloat16mf2_t vs2,
+                                        _Float16 rs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                      float16_t rs1, vfloat16m1_t vs2,
+                                      _Float16 rs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, vl);
 }
@@ -558,7 +558,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                      float16_t rs1, vfloat16m2_t vs2,
+                                      _Float16 rs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, vl);
 }
@@ -570,7 +570,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                      float16_t rs1, vfloat16m4_t vs2,
+                                      _Float16 rs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, vl);
 }
@@ -582,7 +582,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                      float16_t rs1, vfloat16m8_t vs2,
+                                      _Float16 rs1, vfloat16m8_t vs2,
                                       size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, vl);
 }
@@ -700,7 +700,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
   return __riscv_vfnmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, _Float16 rs1,
                                            vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -710,7 +710,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
   return __riscv_vfnmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, _Float16 rs1,
                                            vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -720,7 +720,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
   return __riscv_vfnmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tu(vfloat16m1_t vd, _Float16 rs1,
                                          vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -730,7 +730,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
   return __riscv_vfnmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tu(vfloat16m2_t vd, _Float16 rs1,
                                          vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -740,7 +740,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
   return __riscv_vfnmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tu(vfloat16m4_t vd, _Float16 rs1,
                                          vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -750,7 +750,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
   return __riscv_vfnmsub_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tu(vfloat16m8_t vd, _Float16 rs1,
                                          vfloat16m8_t vs2, size_t vl) {
   return __riscv_vfnmsub_tu(vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -852,7 +852,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                            float16_t rs1, vfloat16mf4_t vs2,
+                                            _Float16 rs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +864,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                            float16_t rs1, vfloat16mf2_t vs2,
+                                            _Float16 rs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +876,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                          float16_t rs1, vfloat16m1_t vs2,
+                                          _Float16 rs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +888,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                          float16_t rs1, vfloat16m2_t vs2,
+                                          _Float16 rs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +900,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                          float16_t rs1, vfloat16m4_t vs2,
+                                          _Float16 rs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +912,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                          float16_t rs1, vfloat16m8_t vs2,
+                                          _Float16 rs1, vfloat16m8_t vs2,
                                           size_t vl) {
   return __riscv_vfnmsub_tum(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1032,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                             float16_t rs1, vfloat16mf4_t vs2,
+                                             _Float16 rs1, vfloat16mf4_t vs2,
                                              size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1044,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                             float16_t rs1, vfloat16mf2_t vs2,
+                                             _Float16 rs1, vfloat16mf2_t vs2,
                                              size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1056,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                           float16_t rs1, vfloat16m1_t vs2,
+                                           _Float16 rs1, vfloat16m1_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1068,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                           float16_t rs1, vfloat16m2_t vs2,
+                                           _Float16 rs1, vfloat16m2_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1080,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                           float16_t rs1, vfloat16m4_t vs2,
+                                           _Float16 rs1, vfloat16m4_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1092,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                           float16_t rs1, vfloat16m8_t vs2,
+                                           _Float16 rs1, vfloat16m8_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsub_tumu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1212,7 +1212,7 @@ vfloat16mf4_t test_vfnmsub_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfnmsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                           float16_t rs1, vfloat16mf4_t vs2,
+                                           _Float16 rs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1224,7 +1224,7 @@ vfloat16mf2_t test_vfnmsub_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfnmsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                           float16_t rs1, vfloat16mf2_t vs2,
+                                           _Float16 rs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1236,7 +1236,7 @@ vfloat16m1_t test_vfnmsub_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfnmsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                         float16_t rs1, vfloat16m1_t vs2,
+                                         _Float16 rs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1248,7 +1248,7 @@ vfloat16m2_t test_vfnmsub_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfnmsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                         float16_t rs1, vfloat16m2_t vs2,
+                                         _Float16 rs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1260,7 @@ vfloat16m4_t test_vfnmsub_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfnmsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                         float16_t rs1, vfloat16m4_t vs2,
+                                         _Float16 rs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1272,7 @@ vfloat16m8_t test_vfnmsub_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfnmsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                         float16_t rs1, vfloat16m8_t vs2,
+                                         _Float16 rs1, vfloat16m8_t vs2,
                                          size_t vl) {
   return __riscv_vfnmsub_mu(vm, vd, rs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfrdiv.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfrdiv.c
@@ -6,32 +6,32 @@ typedef float float32_t;
 typedef double float64_t;
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfrdiv_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfrdiv_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfrdiv_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, vl);
 }
 
@@ -81,37 +81,37 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 }
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfrdiv_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfrdiv_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfrdiv_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, vl);
 }
@@ -171,37 +171,37 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_tum(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfrdiv_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfrdiv_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfrdiv_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -261,37 +261,37 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_tumu(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfrdiv_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfrdiv_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfrdiv_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
+                                     vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, vl);
 }
@@ -351,32 +351,32 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_mu(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrdiv_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrdiv_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrdiv_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfrdiv_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -426,37 +426,37 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_rm_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 }
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrdiv_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrdiv_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrdiv_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrdiv_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -516,37 +516,37 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_rm_tum(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                            vfloat16mf2_t vs2, float16_t rs1,
+                                            vfloat16mf2_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrdiv_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrdiv_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrdiv_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                          vfloat16m8_t vs2, float16_t rs1,
+                                          vfloat16m8_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrdiv_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -606,37 +606,37 @@ vfloat64m8_t test_vfrdiv_vf_f64m8_rm_tumu(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrdiv_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16mf2_t test_vfrdiv_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m1_t test_vfrdiv_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrdiv_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrdiv_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrdiv_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrdiv_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfrsub.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfrsub.c
@@ -6,32 +6,32 @@ typedef float float32_t;
 typedef double float64_t;
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfrsub_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfrsub_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfrsub_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, vl);
 }
 
@@ -81,37 +81,37 @@ vfloat64m8_t test_vfrsub_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 }
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfrsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfrsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfrsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, vl);
 }
@@ -171,37 +171,37 @@ vfloat64m8_t test_vfrsub_vf_f64m8_tum(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfrsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfrsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfrsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -261,37 +261,37 @@ vfloat64m8_t test_vfrsub_vf_f64m8_tumu(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfrsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfrsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfrsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
+                                     vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, vl);
 }
@@ -351,32 +351,32 @@ vfloat64m8_t test_vfrsub_vf_f64m8_mu(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrsub_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrsub_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrsub_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfrsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -426,37 +426,37 @@ vfloat64m8_t test_vfrsub_vf_f64m8_rm_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 }
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfrsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -516,37 +516,37 @@ vfloat64m8_t test_vfrsub_vf_f64m8_rm_tum(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                            vfloat16mf2_t vs2, float16_t rs1,
+                                            vfloat16mf2_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                          vfloat16m8_t vs2, float16_t rs1,
+                                          vfloat16m8_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -606,37 +606,37 @@ vfloat64m8_t test_vfrsub_vf_f64m8_rm_tumu(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfrsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16mf2_t test_vfrsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m1_t test_vfrsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m2_t test_vfrsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m4_t test_vfrsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
 vfloat16m8_t test_vfrsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfrsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfsgnj.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfsgnj.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsgnj_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsgnj_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfsgnj_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfsgnj_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfsgnj_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfsgnj_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfsgnj_tu(vd, vs2, rs1, vl);
 }
 
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsgnj_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnj_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsgnj_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnj_tum(vm, vd, vs2, rs1, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsgnj_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnj_tum(vm, vd, vs2, rs1, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsgnj_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnj_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsgnj_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnj_tum(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsgnj_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnj_tum(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsgnj_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsgnj_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsgnj_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsgnj_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsgnj_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnj_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsgnj_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnj_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsgnj_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnj_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsgnj_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnj_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfsgnj_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsgnj_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnj_mu(vm, vd, vs2, rs1, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfsgnj_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsgnj_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnj_mu(vm, vd, vs2, rs1, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfsgnj_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsgnj_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsgnj_mu(vm, vd, vs2, rs1, vl);
 }
@@ -558,7 +558,7 @@ vfloat16m2_t test_vfsgnj_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsgnj_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsgnj_mu(vm, vd, vs2, rs1, vl);
 }
@@ -570,7 +570,7 @@ vfloat16m4_t test_vfsgnj_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsgnj_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsgnj_mu(vm, vd, vs2, rs1, vl);
 }
@@ -582,7 +582,7 @@ vfloat16m8_t test_vfsgnj_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsgnj_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
+                                     vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsgnj_mu(vm, vd, vs2, rs1, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfsgnjn.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfsgnjn.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsgnjn_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsgnjn_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfsgnjn_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfsgnjn_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfsgnjn_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfsgnjn_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjn_tu(vd, vs2, rs1, vl);
 }
 
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsgnjn_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsgnjn_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsgnjn_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsgnjn_tum(vm, vd, vs2, rs1, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsgnjn_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnjn_tum(vm, vd, vs2, rs1, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsgnjn_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnjn_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsgnjn_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnjn_tum(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsgnjn_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnjn_tum(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsgnjn_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfsgnjn_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsgnjn_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfsgnjn_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsgnjn_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjn_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsgnjn_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjn_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsgnjn_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjn_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsgnjn_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjn_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfsgnjn_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsgnjn_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjn_mu(vm, vd, vs2, rs1, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfsgnjn_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsgnjn_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjn_mu(vm, vd, vs2, rs1, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfsgnjn_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsgnjn_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnjn_mu(vm, vd, vs2, rs1, vl);
 }
@@ -558,7 +558,7 @@ vfloat16m2_t test_vfsgnjn_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsgnjn_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnjn_mu(vm, vd, vs2, rs1, vl);
 }
@@ -570,7 +570,7 @@ vfloat16m4_t test_vfsgnjn_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsgnjn_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnjn_mu(vm, vd, vs2, rs1, vl);
 }
@@ -582,7 +582,7 @@ vfloat16m8_t test_vfsgnjn_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsgnjn_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnjn_mu(vm, vd, vs2, rs1, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfsgnjx.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfsgnjx.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsgnjx_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsgnjx_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfsgnjx_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfsgnjx_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfsgnjx_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfsgnjx_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsgnjx_tu(vd, vs2, rs1, vl);
 }
 
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsgnjx_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsgnjx_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsgnjx_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsgnjx_tum(vm, vd, vs2, rs1, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsgnjx_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnjx_tum(vm, vd, vs2, rs1, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsgnjx_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnjx_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsgnjx_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnjx_tum(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsgnjx_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsgnjx_tum(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsgnjx_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfsgnjx_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsgnjx_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfsgnjx_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsgnjx_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjx_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsgnjx_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjx_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsgnjx_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjx_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsgnjx_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjx_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfsgnjx_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsgnjx_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjx_mu(vm, vd, vs2, rs1, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfsgnjx_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsgnjx_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsgnjx_mu(vm, vd, vs2, rs1, vl);
 }
@@ -546,7 +546,7 @@ vfloat16m1_t test_vfsgnjx_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsgnjx_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnjx_mu(vm, vd, vs2, rs1, vl);
 }
@@ -558,7 +558,7 @@ vfloat16m2_t test_vfsgnjx_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsgnjx_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnjx_mu(vm, vd, vs2, rs1, vl);
 }
@@ -570,7 +570,7 @@ vfloat16m4_t test_vfsgnjx_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsgnjx_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnjx_mu(vm, vd, vs2, rs1, vl);
 }
@@ -582,7 +582,7 @@ vfloat16m8_t test_vfsgnjx_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsgnjx_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsgnjx_mu(vm, vd, vs2, rs1, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfslide1down.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfslide1down.c
@@ -6,34 +6,34 @@ typedef float float32_t;
 typedef double float64_t;
 
 vfloat16mf4_t test_vfslide1down_vf_f16mf4_tu(vfloat16mf4_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1down_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1down_vf_f16mf2_tu(vfloat16mf2_t vd,
-                                             vfloat16mf2_t vs2, float16_t rs1,
+                                             vfloat16mf2_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1down_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1down_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                           float16_t rs1, size_t vl) {
+                                           _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1down_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                           float16_t rs1, size_t vl) {
+                                           _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1down_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                           float16_t rs1, size_t vl) {
+                                           _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1down_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                           float16_t rs1, size_t vl) {
+                                           _Float16 rs1, size_t vl) {
   return __riscv_vfslide1down_tu(vd, vs2, rs1, vl);
 }
 
@@ -84,37 +84,37 @@ vfloat64m8_t test_vfslide1down_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 }
 
 vfloat16mf4_t test_vfslide1down_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                              vfloat16mf4_t vs2, float16_t rs1,
+                                              vfloat16mf4_t vs2, _Float16 rs1,
                                               size_t vl) {
   return __riscv_vfslide1down_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1down_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                              vfloat16mf2_t vs2, float16_t rs1,
+                                              vfloat16mf2_t vs2, _Float16 rs1,
                                               size_t vl) {
   return __riscv_vfslide1down_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1down_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                            vfloat16m1_t vs2, float16_t rs1,
+                                            vfloat16m1_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfslide1down_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1down_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                            vfloat16m2_t vs2, float16_t rs1,
+                                            vfloat16m2_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfslide1down_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1down_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                            vfloat16m4_t vs2, float16_t rs1,
+                                            vfloat16m4_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfslide1down_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1down_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                            vfloat16m8_t vs2, float16_t rs1,
+                                            vfloat16m8_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfslide1down_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,37 +174,37 @@ vfloat64m8_t test_vfslide1down_vf_f64m8_tum(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfslide1down_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                               vfloat16mf4_t vs2, float16_t rs1,
+                                               vfloat16mf4_t vs2, _Float16 rs1,
                                                size_t vl) {
   return __riscv_vfslide1down_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1down_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                               vfloat16mf2_t vs2, float16_t rs1,
+                                               vfloat16mf2_t vs2, _Float16 rs1,
                                                size_t vl) {
   return __riscv_vfslide1down_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1down_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                             vfloat16m1_t vs2, float16_t rs1,
+                                             vfloat16m1_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1down_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1down_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                             vfloat16m2_t vs2, float16_t rs1,
+                                             vfloat16m2_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1down_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1down_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                             vfloat16m4_t vs2, float16_t rs1,
+                                             vfloat16m4_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1down_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1down_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                             vfloat16m8_t vs2, float16_t rs1,
+                                             vfloat16m8_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1down_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -264,37 +264,37 @@ vfloat64m8_t test_vfslide1down_vf_f64m8_tumu(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfslide1down_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1down_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1down_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                             vfloat16mf2_t vs2, float16_t rs1,
+                                             vfloat16mf2_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1down_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1down_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                           vfloat16m1_t vs2, float16_t rs1,
+                                           vfloat16m1_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1down_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1down_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                           vfloat16m2_t vs2, float16_t rs1,
+                                           vfloat16m2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1down_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1down_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                           vfloat16m4_t vs2, float16_t rs1,
+                                           vfloat16m4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1down_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1down_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                           vfloat16m8_t vs2, float16_t rs1,
+                                           vfloat16m8_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1down_mu(vm, vd, vs2, rs1, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfslide1up.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfslide1up.c
@@ -6,32 +6,32 @@ typedef float float32_t;
 typedef double float64_t;
 
 vfloat16mf4_t test_vfslide1up_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                           float16_t rs1, size_t vl) {
+                                           _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1up_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                           float16_t rs1, size_t vl) {
+                                           _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1up_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1up_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1up_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tu(vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1up_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfslide1up_tu(vd, vs2, rs1, vl);
 }
 
@@ -81,37 +81,37 @@ vfloat64m8_t test_vfslide1up_vf_f64m8_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 }
 
 vfloat16mf4_t test_vfslide1up_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfslide1up_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1up_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                            vfloat16mf2_t vs2, float16_t rs1,
+                                            vfloat16mf2_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfslide1up_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1up_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfslide1up_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1up_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfslide1up_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1up_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfslide1up_tum(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1up_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                          vfloat16m8_t vs2, float16_t rs1,
+                                          vfloat16m8_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfslide1up_tum(vm, vd, vs2, rs1, vl);
 }
@@ -171,37 +171,37 @@ vfloat64m8_t test_vfslide1up_vf_f64m8_tum(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfslide1up_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                             vfloat16mf4_t vs2, float16_t rs1,
+                                             vfloat16mf4_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1up_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1up_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                             vfloat16mf2_t vs2, float16_t rs1,
+                                             vfloat16mf2_t vs2, _Float16 rs1,
                                              size_t vl) {
   return __riscv_vfslide1up_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1up_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                           vfloat16m1_t vs2, float16_t rs1,
+                                           vfloat16m1_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1up_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1up_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                           vfloat16m2_t vs2, float16_t rs1,
+                                           vfloat16m2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1up_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1up_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                           vfloat16m4_t vs2, float16_t rs1,
+                                           vfloat16m4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1up_tumu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1up_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                           vfloat16m8_t vs2, float16_t rs1,
+                                           vfloat16m8_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1up_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -261,37 +261,37 @@ vfloat64m8_t test_vfslide1up_vf_f64m8_tumu(vbool8_t vm, vfloat64m8_t vd,
 }
 
 vfloat16mf4_t test_vfslide1up_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1up_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16mf2_t test_vfslide1up_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfslide1up_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m1_t test_vfslide1up_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfslide1up_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m2_t test_vfslide1up_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfslide1up_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m4_t test_vfslide1up_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfslide1up_mu(vm, vd, vs2, rs1, vl);
 }
 
 vfloat16m8_t test_vfslide1up_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfslide1up_mu(vm, vd, vs2, rs1, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfsub.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfsub.c
@@ -11,7 +11,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                      float16_t rs1, size_t vl) {
+                                      _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfsub_vf_f16m1_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfsub_vf_f16m2_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfsub_vf_f16m4_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfsub_vf_f16m8_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                    float16_t rs1, size_t vl) {
+                                    _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, vl);
 }
 
@@ -162,7 +162,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, vl);
 }
@@ -174,7 +174,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, vl);
 }
@@ -186,7 +186,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsub_vf_f16m1_tum(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, vl);
 }
@@ -198,7 +198,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsub_vf_f16m2_tum(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsub_vf_f16m4_tum(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsub_vf_f16m8_tum(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
+                                     vfloat16m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsub_vf_f16m1_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -378,7 +378,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsub_vf_f16m2_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -390,7 +390,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsub_vf_f16m4_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -402,7 +402,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsub_vf_f16m8_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -522,7 +522,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, vl);
 }
@@ -534,7 +534,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, vl);
 }
@@ -546,8 +546,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsub_vf_f16m1_mu(vbool16_t vm, vfloat16m1_t vd,
-                                    vfloat16m1_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m1_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -558,8 +557,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsub_vf_f16m2_mu(vbool8_t vm, vfloat16m2_t vd,
-                                    vfloat16m2_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m2_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -570,8 +568,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsub_vf_f16m4_mu(vbool4_t vm, vfloat16m4_t vd,
-                                    vfloat16m4_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m4_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -582,8 +579,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsub_vf_f16m8_mu(vbool2_t vm, vfloat16m8_t vd,
-                                    vfloat16m8_t vs2, float16_t rs1,
-                                    size_t vl) {
+                                    vfloat16m8_t vs2, _Float16 rs1, size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -701,7 +697,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_rm_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -711,7 +707,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_rm_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                         float16_t rs1, size_t vl) {
+                                         _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -721,7 +717,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
 }
 
 vfloat16m1_t test_vfsub_vf_f16m1_rm_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -731,7 +727,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
 }
 
 vfloat16m2_t test_vfsub_vf_f16m2_rm_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -741,7 +737,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
 }
 
 vfloat16m4_t test_vfsub_vf_f16m4_rm_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -751,7 +747,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
 }
 
 vfloat16m8_t test_vfsub_vf_f16m8_rm_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfsub_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -852,7 +848,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_rm_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -864,7 +860,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_rm_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -876,7 +872,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsub_vf_f16m1_rm_tum(vbool16_t vm, vfloat16m1_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -888,7 +884,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsub_vf_f16m2_rm_tum(vbool8_t vm, vfloat16m2_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -900,7 +896,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsub_vf_f16m4_rm_tum(vbool4_t vm, vfloat16m4_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -912,7 +908,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsub_vf_f16m8_rm_tum(vbool2_t vm, vfloat16m8_t vd,
-                                        vfloat16m8_t vs2, float16_t rs1,
+                                        vfloat16m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfsub_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1028,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_rm_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1040,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_rm_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                           vfloat16mf2_t vs2, float16_t rs1,
+                                           vfloat16mf2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1052,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsub_vf_f16m1_rm_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1064,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsub_vf_f16m2_rm_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1076,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsub_vf_f16m4_rm_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1088,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsub_vf_f16m8_rm_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                         vfloat16m8_t vs2, float16_t rs1,
+                                         vfloat16m8_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsub_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1212,7 +1208,7 @@ vfloat16mf4_t test_vfsub_vv_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
 }
 
 vfloat16mf4_t test_vfsub_vf_f16mf4_rm_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1224,7 +1220,7 @@ vfloat16mf2_t test_vfsub_vv_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
 }
 
 vfloat16mf2_t test_vfsub_vf_f16mf2_rm_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1236,7 +1232,7 @@ vfloat16m1_t test_vfsub_vv_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
 }
 
 vfloat16m1_t test_vfsub_vf_f16m1_rm_mu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1248,7 +1244,7 @@ vfloat16m2_t test_vfsub_vv_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
 }
 
 vfloat16m2_t test_vfsub_vf_f16m2_rm_mu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1256,7 @@ vfloat16m4_t test_vfsub_vv_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
 }
 
 vfloat16m4_t test_vfsub_vf_f16m4_rm_mu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1268,7 @@ vfloat16m8_t test_vfsub_vv_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
 }
 
 vfloat16m8_t test_vfsub_vf_f16m8_rm_mu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfsub_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfwadd.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfwadd.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -71,7 +71,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
 }
 
 vfloat32m4_t test_vfwadd_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -81,7 +81,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
 }
 
 vfloat32m4_t test_vfwadd_wf_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
 }
 
 vfloat32m8_t test_vfwadd_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -101,7 +101,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
 }
 
 vfloat32m8_t test_vfwadd_wf_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -192,7 +192,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -204,7 +204,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                        vfloat32mf2_t vs2, float16_t rs1,
+                                        vfloat32mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -216,7 +216,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -228,7 +228,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                      vfloat32m1_t vs2, float16_t rs1,
+                                      vfloat32m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -240,7 +240,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -252,7 +252,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                      vfloat32m2_t vs2, float16_t rs1,
+                                      vfloat32m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -264,7 +264,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -276,7 +276,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_wf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                      vfloat32m4_t vs2, float16_t rs1,
+                                      vfloat32m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -288,7 +288,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -300,7 +300,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_wf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                      vfloat32m8_t vs2, float16_t rs1,
+                                      vfloat32m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -408,7 +408,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -420,7 +420,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                         vfloat32mf2_t vs2, float16_t rs1,
+                                         vfloat32mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -432,7 +432,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -444,7 +444,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                       vfloat32m1_t vs2, float16_t rs1,
+                                       vfloat32m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -456,7 +456,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -468,7 +468,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                       vfloat32m2_t vs2, float16_t rs1,
+                                       vfloat32m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -480,7 +480,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -492,7 +492,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_wf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                       vfloat32m4_t vs2, float16_t rs1,
+                                       vfloat32m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -504,7 +504,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -516,7 +516,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_wf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                       vfloat32m8_t vs2, float16_t rs1,
+                                       vfloat32m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -624,7 +624,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -636,7 +636,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                       vfloat32mf2_t vs2, float16_t rs1,
+                                       vfloat32mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -648,7 +648,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                     vfloat16mf2_t vs2, float16_t rs1,
+                                     vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -660,7 +660,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                     vfloat32m1_t vs2, float16_t rs1,
+                                     vfloat32m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -672,7 +672,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -684,7 +684,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                     vfloat32m2_t vs2, float16_t rs1,
+                                     vfloat32m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -696,7 +696,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -708,7 +708,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_wf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                     vfloat32m4_t vs2, float16_t rs1,
+                                     vfloat32m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -720,7 +720,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -732,7 +732,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_wf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                     vfloat32m8_t vs2, float16_t rs1,
+                                     vfloat32m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -839,7 +839,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -849,7 +849,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -869,7 +869,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -879,7 +879,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -889,7 +889,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -899,7 +899,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
 }
 
 vfloat32m4_t test_vfwadd_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -909,7 +909,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
 }
 
 vfloat32m4_t test_vfwadd_wf_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -919,7 +919,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
 }
 
 vfloat32m8_t test_vfwadd_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -929,7 +929,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
 }
 
 vfloat32m8_t test_vfwadd_wf_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwadd_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1020,7 +1020,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1032,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                           vfloat32mf2_t vs2, float16_t rs1,
+                                           vfloat32mf2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1044,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1056,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                         vfloat32m1_t vs2, float16_t rs1,
+                                         vfloat32m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1068,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1080,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                         vfloat32m2_t vs2, float16_t rs1,
+                                         vfloat32m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1092,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1104,7 +1104,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_wf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                         vfloat32m4_t vs2, float16_t rs1,
+                                         vfloat32m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1116,7 +1116,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1128,7 +1128,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_wf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                         vfloat32m8_t vs2, float16_t rs1,
+                                         vfloat32m8_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwadd_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1236,7 +1236,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1248,7 +1248,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                            vfloat32mf2_t vs2, float16_t rs1,
+                                            vfloat32mf2_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1260,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1272,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                          vfloat32m1_t vs2, float16_t rs1,
+                                          vfloat32m1_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1284,7 +1284,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1296,7 +1296,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                          vfloat32m2_t vs2, float16_t rs1,
+                                          vfloat32m2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1308,7 +1308,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1320,7 +1320,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_wf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                          vfloat32m4_t vs2, float16_t rs1,
+                                          vfloat32m4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1332,7 +1332,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1344,7 +1344,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_wf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                          vfloat32m8_t vs2, float16_t rs1,
+                                          vfloat32m8_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1452,7 +1452,7 @@ vfloat32mf2_t test_vfwadd_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1464,7 +1464,7 @@ vfloat32mf2_t test_vfwadd_wv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwadd_wf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                          vfloat32mf2_t vs2, float16_t rs1,
+                                          vfloat32mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1476,7 +1476,7 @@ vfloat32m1_t test_vfwadd_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1488,7 +1488,7 @@ vfloat32m1_t test_vfwadd_wv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwadd_wf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                        vfloat32m1_t vs2, float16_t rs1,
+                                        vfloat32m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1500,7 +1500,7 @@ vfloat32m2_t test_vfwadd_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1512,7 +1512,7 @@ vfloat32m2_t test_vfwadd_wv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwadd_wf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                        vfloat32m2_t vs2, float16_t rs1,
+                                        vfloat32m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1524,7 +1524,7 @@ vfloat32m4_t test_vfwadd_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1536,7 +1536,7 @@ vfloat32m4_t test_vfwadd_wv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwadd_wf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                        vfloat32m4_t vs2, float16_t rs1,
+                                        vfloat32m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1548,7 +1548,7 @@ vfloat32m8_t test_vfwadd_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1560,7 +1560,7 @@ vfloat32m8_t test_vfwadd_wv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwadd_wf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                        vfloat32m8_t vs2, float16_t rs1,
+                                        vfloat32m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwadd_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfwmacc.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfwmacc.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwmacc_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1,
                                       vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwmacc_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwmacc_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwmacc_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, vl);
 }
@@ -102,7 +102,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmacc_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                         float16_t vs1, vfloat16mf4_t vs2,
+                                         _Float16 vs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, vl);
 }
@@ -114,7 +114,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmacc_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                       float16_t vs1, vfloat16mf2_t vs2,
+                                       _Float16 vs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, vl);
 }
@@ -126,7 +126,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmacc_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                       float16_t vs1, vfloat16m1_t vs2,
+                                       _Float16 vs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, vl);
 }
@@ -138,7 +138,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmacc_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                       float16_t vs1, vfloat16m2_t vs2,
+                                       _Float16 vs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, vl);
 }
@@ -150,7 +150,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmacc_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                       float16_t vs1, vfloat16m4_t vs2,
+                                       _Float16 vs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmacc_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                          float16_t vs1, vfloat16mf4_t vs2,
+                                          _Float16 vs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmacc_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                        float16_t vs1, vfloat16mf2_t vs2,
+                                        _Float16 vs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -234,7 +234,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmacc_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                        float16_t vs1, vfloat16m1_t vs2,
+                                        _Float16 vs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -246,7 +246,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmacc_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                        float16_t vs1, vfloat16m2_t vs2,
+                                        _Float16 vs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -258,7 +258,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmacc_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                        float16_t vs1, vfloat16m4_t vs2,
+                                        _Float16 vs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -318,7 +318,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmacc_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                        float16_t vs1, vfloat16mf4_t vs2,
+                                        _Float16 vs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, vl);
 }
@@ -330,7 +330,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmacc_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                      float16_t vs1, vfloat16mf2_t vs2,
+                                      _Float16 vs1, vfloat16mf2_t vs2,
                                       size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmacc_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                      float16_t vs1, vfloat16m1_t vs2,
+                                      _Float16 vs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmacc_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                      float16_t vs1, vfloat16m2_t vs2,
+                                      _Float16 vs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmacc_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                      float16_t vs1, vfloat16m4_t vs2,
+                                      _Float16 vs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, vl);
 }
@@ -424,7 +424,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1,
                                            vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -434,7 +434,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1,
                                          vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -444,7 +444,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1,
                                          vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -454,7 +454,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1,
                                          vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -464,7 +464,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1,
                                          vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -516,7 +516,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                            float16_t vs1, vfloat16mf4_t vs2,
+                                            _Float16 vs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -528,7 +528,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                          float16_t vs1, vfloat16mf2_t vs2,
+                                          _Float16 vs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -540,7 +540,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                          float16_t vs1, vfloat16m1_t vs2,
+                                          _Float16 vs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -552,7 +552,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                          float16_t vs1, vfloat16m2_t vs2,
+                                          _Float16 vs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -564,7 +564,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                          float16_t vs1, vfloat16m4_t vs2,
+                                          _Float16 vs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfwmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -624,7 +624,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                             float16_t vs1, vfloat16mf4_t vs2,
+                                             _Float16 vs1, vfloat16mf4_t vs2,
                                              size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -636,7 +636,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmacc_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                           float16_t vs1, vfloat16mf2_t vs2,
+                                           _Float16 vs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -648,7 +648,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmacc_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                           float16_t vs1, vfloat16m1_t vs2,
+                                           _Float16 vs1, vfloat16m1_t vs2,
                                            size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -660,7 +660,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmacc_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                           float16_t vs1, vfloat16m2_t vs2,
+                                           _Float16 vs1, vfloat16m2_t vs2,
                                            size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -672,7 +672,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmacc_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                           float16_t vs1, vfloat16m4_t vs2,
+                                           _Float16 vs1, vfloat16m4_t vs2,
                                            size_t vl) {
   return __riscv_vfwmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -732,7 +732,7 @@ vfloat32mf2_t test_vfwmacc_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmacc_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                           float16_t vs1, vfloat16mf4_t vs2,
+                                           _Float16 vs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -744,7 +744,7 @@ vfloat32m1_t test_vfwmacc_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmacc_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                         float16_t vs1, vfloat16mf2_t vs2,
+                                         _Float16 vs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -756,7 +756,7 @@ vfloat32m2_t test_vfwmacc_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmacc_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                         float16_t vs1, vfloat16m1_t vs2,
+                                         _Float16 vs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -768,7 +768,7 @@ vfloat32m4_t test_vfwmacc_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmacc_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                         float16_t vs1, vfloat16m2_t vs2,
+                                         _Float16 vs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -780,7 +780,7 @@ vfloat32m8_t test_vfwmacc_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmacc_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                         float16_t vs1, vfloat16m4_t vs2,
+                                         _Float16 vs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfwmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfwmsac.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfwmsac.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1,
                                         vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwmsac_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1,
                                       vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwmsac_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1,
                                       vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwmsac_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1,
                                       vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwmsac_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1,
                                       vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, vl);
 }
@@ -102,7 +102,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmsac_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                         float16_t vs1, vfloat16mf4_t vs2,
+                                         _Float16 vs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, vl);
 }
@@ -114,7 +114,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmsac_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                       float16_t vs1, vfloat16mf2_t vs2,
+                                       _Float16 vs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, vl);
 }
@@ -126,7 +126,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmsac_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                       float16_t vs1, vfloat16m1_t vs2,
+                                       _Float16 vs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, vl);
 }
@@ -138,7 +138,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmsac_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                       float16_t vs1, vfloat16m2_t vs2,
+                                       _Float16 vs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, vl);
 }
@@ -150,7 +150,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmsac_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                       float16_t vs1, vfloat16m4_t vs2,
+                                       _Float16 vs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmsac_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                          float16_t vs1, vfloat16mf4_t vs2,
+                                          _Float16 vs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmsac_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                        float16_t vs1, vfloat16mf2_t vs2,
+                                        _Float16 vs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -234,7 +234,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmsac_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                        float16_t vs1, vfloat16m1_t vs2,
+                                        _Float16 vs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -246,7 +246,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmsac_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                        float16_t vs1, vfloat16m2_t vs2,
+                                        _Float16 vs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -258,7 +258,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmsac_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                        float16_t vs1, vfloat16m4_t vs2,
+                                        _Float16 vs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -318,7 +318,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmsac_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                        float16_t vs1, vfloat16mf4_t vs2,
+                                        _Float16 vs1, vfloat16mf4_t vs2,
                                         size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, vl);
 }
@@ -330,7 +330,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmsac_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                      float16_t vs1, vfloat16mf2_t vs2,
+                                      _Float16 vs1, vfloat16mf2_t vs2,
                                       size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmsac_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                      float16_t vs1, vfloat16m1_t vs2,
+                                      _Float16 vs1, vfloat16m1_t vs2,
                                       size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmsac_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                      float16_t vs1, vfloat16m2_t vs2,
+                                      _Float16 vs1, vfloat16m2_t vs2,
                                       size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmsac_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                      float16_t vs1, vfloat16m4_t vs2,
+                                      _Float16 vs1, vfloat16m4_t vs2,
                                       size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, vl);
 }
@@ -424,7 +424,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1,
                                            vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -434,7 +434,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1,
                                          vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -444,7 +444,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1,
                                          vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -454,7 +454,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1,
                                          vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -464,7 +464,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1,
                                          vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -516,7 +516,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                            float16_t vs1, vfloat16mf4_t vs2,
+                                            _Float16 vs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -528,7 +528,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                          float16_t vs1, vfloat16mf2_t vs2,
+                                          _Float16 vs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -540,7 +540,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                          float16_t vs1, vfloat16m1_t vs2,
+                                          _Float16 vs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -552,7 +552,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                          float16_t vs1, vfloat16m2_t vs2,
+                                          _Float16 vs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -564,7 +564,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                          float16_t vs1, vfloat16m4_t vs2,
+                                          _Float16 vs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfwmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -624,7 +624,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                             float16_t vs1, vfloat16mf4_t vs2,
+                                             _Float16 vs1, vfloat16mf4_t vs2,
                                              size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -636,7 +636,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmsac_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                           float16_t vs1, vfloat16mf2_t vs2,
+                                           _Float16 vs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -648,7 +648,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmsac_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                           float16_t vs1, vfloat16m1_t vs2,
+                                           _Float16 vs1, vfloat16m1_t vs2,
                                            size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -660,7 +660,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmsac_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                           float16_t vs1, vfloat16m2_t vs2,
+                                           _Float16 vs1, vfloat16m2_t vs2,
                                            size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -672,7 +672,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmsac_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                           float16_t vs1, vfloat16m4_t vs2,
+                                           _Float16 vs1, vfloat16m4_t vs2,
                                            size_t vl) {
   return __riscv_vfwmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -732,7 +732,7 @@ vfloat32mf2_t test_vfwmsac_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmsac_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                           float16_t vs1, vfloat16mf4_t vs2,
+                                           _Float16 vs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -744,7 +744,7 @@ vfloat32m1_t test_vfwmsac_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmsac_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                         float16_t vs1, vfloat16mf2_t vs2,
+                                         _Float16 vs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -756,7 +756,7 @@ vfloat32m2_t test_vfwmsac_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmsac_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                         float16_t vs1, vfloat16m1_t vs2,
+                                         _Float16 vs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -768,7 +768,7 @@ vfloat32m4_t test_vfwmsac_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmsac_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                         float16_t vs1, vfloat16m2_t vs2,
+                                         _Float16 vs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -780,7 +780,7 @@ vfloat32m8_t test_vfwmsac_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmsac_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                         float16_t vs1, vfloat16m4_t vs2,
+                                         _Float16 vs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfwmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfwmul.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfwmul.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
 }
 
 vfloat32m4_t test_vfwmul_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
 }
 
 vfloat32m8_t test_vfwmul_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, vl);
 }
 
@@ -102,7 +102,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, vl);
 }
@@ -114,7 +114,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, vl);
 }
@@ -126,7 +126,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, vl);
 }
@@ -138,7 +138,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmul_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, vl);
 }
@@ -150,7 +150,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmul_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, vl);
 }
@@ -210,7 +210,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -222,7 +222,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -234,7 +234,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -246,7 +246,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmul_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -258,7 +258,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmul_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -318,7 +318,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, vl);
 }
@@ -330,7 +330,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                     vfloat16mf2_t vs2, float16_t rs1,
+                                     vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, vl);
 }
@@ -342,7 +342,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, vl);
 }
@@ -354,7 +354,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmul_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, vl);
 }
@@ -366,7 +366,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmul_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, vl);
 }
@@ -425,7 +425,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -435,7 +435,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -445,7 +445,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -455,7 +455,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
 }
 
 vfloat32m4_t test_vfwmul_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -465,7 +465,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
 }
 
 vfloat32m8_t test_vfwmul_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwmul_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -516,7 +516,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -528,7 +528,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -540,7 +540,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -552,7 +552,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmul_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -564,7 +564,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmul_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwmul_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -624,7 +624,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -636,7 +636,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -648,7 +648,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -660,7 +660,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmul_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -672,7 +672,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmul_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwmul_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -732,7 +732,7 @@ vfloat32mf2_t test_vfwmul_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwmul_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -744,7 +744,7 @@ vfloat32m1_t test_vfwmul_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwmul_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -756,7 +756,7 @@ vfloat32m2_t test_vfwmul_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwmul_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -768,7 +768,7 @@ vfloat32m4_t test_vfwmul_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwmul_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -780,7 +780,7 @@ vfloat32m8_t test_vfwmul_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwmul_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwmul_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfwnmacc.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfwnmacc.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1,
                                          vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwnmacc_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwnmacc_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1,
                                        vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwnmacc_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1,
                                        vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwnmacc_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1,
                                        vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, vl);
 }
@@ -102,7 +102,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                          float16_t vs1, vfloat16mf4_t vs2,
+                                          _Float16 vs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, vl);
 }
@@ -114,7 +114,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmacc_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                        float16_t vs1, vfloat16mf2_t vs2,
+                                        _Float16 vs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, vl);
 }
@@ -126,7 +126,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmacc_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                        float16_t vs1, vfloat16m1_t vs2,
+                                        _Float16 vs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, vl);
 }
@@ -138,7 +138,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmacc_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                        float16_t vs1, vfloat16m2_t vs2,
+                                        _Float16 vs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, vl);
 }
@@ -150,7 +150,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmacc_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                        float16_t vs1, vfloat16m4_t vs2,
+                                        _Float16 vs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmacc_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                           float16_t vs1, vfloat16mf4_t vs2,
+                                           _Float16 vs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmacc_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                         float16_t vs1, vfloat16mf2_t vs2,
+                                         _Float16 vs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -234,7 +234,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmacc_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                         float16_t vs1, vfloat16m1_t vs2,
+                                         _Float16 vs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -246,7 +246,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmacc_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                         float16_t vs1, vfloat16m2_t vs2,
+                                         _Float16 vs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -258,7 +258,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmacc_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                         float16_t vs1, vfloat16m4_t vs2,
+                                         _Float16 vs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -318,7 +318,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmacc_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                         float16_t vs1, vfloat16mf4_t vs2,
+                                         _Float16 vs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, vl);
 }
@@ -330,7 +330,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmacc_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                       float16_t vs1, vfloat16mf2_t vs2,
+                                       _Float16 vs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmacc_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                       float16_t vs1, vfloat16m1_t vs2,
+                                       _Float16 vs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmacc_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                       float16_t vs1, vfloat16m2_t vs2,
+                                       _Float16 vs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmacc_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                       float16_t vs1, vfloat16m4_t vs2,
+                                       _Float16 vs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, vl);
 }
@@ -424,7 +424,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1,
                                             vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -434,7 +434,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1,
                                           vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -444,7 +444,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1,
                                           vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -454,7 +454,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1,
                                           vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -464,7 +464,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1,
                                           vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmacc_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -516,7 +516,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                             float16_t vs1, vfloat16mf4_t vs2,
+                                             _Float16 vs1, vfloat16mf4_t vs2,
                                              size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -528,7 +528,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                           float16_t vs1, vfloat16mf2_t vs2,
+                                           _Float16 vs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -540,7 +540,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                           float16_t vs1, vfloat16m1_t vs2,
+                                           _Float16 vs1, vfloat16m1_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -552,7 +552,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                           float16_t vs1, vfloat16m2_t vs2,
+                                           _Float16 vs1, vfloat16m2_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -564,7 +564,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                           float16_t vs1, vfloat16m4_t vs2,
+                                           _Float16 vs1, vfloat16m4_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmacc_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -624,7 +624,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                              float16_t vs1, vfloat16mf4_t vs2,
+                                              _Float16 vs1, vfloat16mf4_t vs2,
                                               size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -636,7 +636,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                            float16_t vs1, vfloat16mf2_t vs2,
+                                            _Float16 vs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -648,7 +648,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                            float16_t vs1, vfloat16m1_t vs2,
+                                            _Float16 vs1, vfloat16m1_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -660,7 +660,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                            float16_t vs1, vfloat16m2_t vs2,
+                                            _Float16 vs1, vfloat16m2_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -672,7 +672,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                            float16_t vs1, vfloat16m4_t vs2,
+                                            _Float16 vs1, vfloat16m4_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmacc_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -732,7 +732,7 @@ vfloat32mf2_t test_vfwnmacc_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmacc_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                            float16_t vs1, vfloat16mf4_t vs2,
+                                            _Float16 vs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -744,7 +744,7 @@ vfloat32m1_t test_vfwnmacc_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmacc_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                          float16_t vs1, vfloat16mf2_t vs2,
+                                          _Float16 vs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -756,7 +756,7 @@ vfloat32m2_t test_vfwnmacc_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmacc_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                          float16_t vs1, vfloat16m1_t vs2,
+                                          _Float16 vs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -768,7 +768,7 @@ vfloat32m4_t test_vfwnmacc_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmacc_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                          float16_t vs1, vfloat16m2_t vs2,
+                                          _Float16 vs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -780,7 +780,7 @@ vfloat32m8_t test_vfwnmacc_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmacc_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                          float16_t vs1, vfloat16m4_t vs2,
+                                          _Float16 vs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmacc_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfwnmsac.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfwnmsac.c
@@ -10,7 +10,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tu(vfloat32mf2_t vd, _Float16 vs1,
                                          vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
@@ -20,7 +20,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwnmsac_vf_f32m1_tu(vfloat32m1_t vd, _Float16 vs1,
                                        vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
@@ -30,7 +30,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwnmsac_vf_f32m2_tu(vfloat32m2_t vd, _Float16 vs1,
                                        vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
@@ -40,7 +40,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwnmsac_vf_f32m4_tu(vfloat32m4_t vd, _Float16 vs1,
                                        vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
@@ -50,7 +50,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwnmsac_vf_f32m8_tu(vfloat32m8_t vd, _Float16 vs1,
                                        vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, vl);
 }
@@ -102,7 +102,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                          float16_t vs1, vfloat16mf4_t vs2,
+                                          _Float16 vs1, vfloat16mf4_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, vl);
 }
@@ -114,7 +114,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmsac_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                        float16_t vs1, vfloat16mf2_t vs2,
+                                        _Float16 vs1, vfloat16mf2_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, vl);
 }
@@ -126,7 +126,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmsac_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                        float16_t vs1, vfloat16m1_t vs2,
+                                        _Float16 vs1, vfloat16m1_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, vl);
 }
@@ -138,7 +138,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmsac_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                        float16_t vs1, vfloat16m2_t vs2,
+                                        _Float16 vs1, vfloat16m2_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, vl);
 }
@@ -150,7 +150,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmsac_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                        float16_t vs1, vfloat16m4_t vs2,
+                                        _Float16 vs1, vfloat16m4_t vs2,
                                         size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, vl);
 }
@@ -210,7 +210,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmsac_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                           float16_t vs1, vfloat16mf4_t vs2,
+                                           _Float16 vs1, vfloat16mf4_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -222,7 +222,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmsac_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                         float16_t vs1, vfloat16mf2_t vs2,
+                                         _Float16 vs1, vfloat16mf2_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -234,7 +234,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmsac_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                         float16_t vs1, vfloat16m1_t vs2,
+                                         _Float16 vs1, vfloat16m1_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -246,7 +246,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmsac_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                         float16_t vs1, vfloat16m2_t vs2,
+                                         _Float16 vs1, vfloat16m2_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -258,7 +258,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmsac_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                         float16_t vs1, vfloat16m4_t vs2,
+                                         _Float16 vs1, vfloat16m4_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, vl);
 }
@@ -318,7 +318,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmsac_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                         float16_t vs1, vfloat16mf4_t vs2,
+                                         _Float16 vs1, vfloat16mf4_t vs2,
                                          size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, vl);
 }
@@ -330,7 +330,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmsac_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                       float16_t vs1, vfloat16mf2_t vs2,
+                                       _Float16 vs1, vfloat16mf2_t vs2,
                                        size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, vl);
 }
@@ -342,7 +342,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmsac_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                       float16_t vs1, vfloat16m1_t vs2,
+                                       _Float16 vs1, vfloat16m1_t vs2,
                                        size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, vl);
 }
@@ -354,7 +354,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmsac_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                       float16_t vs1, vfloat16m2_t vs2,
+                                       _Float16 vs1, vfloat16m2_t vs2,
                                        size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, vl);
 }
@@ -366,7 +366,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmsac_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                       float16_t vs1, vfloat16m4_t vs2,
+                                       _Float16 vs1, vfloat16m4_t vs2,
                                        size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, vl);
 }
@@ -424,7 +424,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tu(vfloat32mf2_t vd, _Float16 vs1,
                                             vfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -434,7 +434,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tu(vfloat32m1_t vd, _Float16 vs1,
                                           vfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -444,7 +444,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tu(vfloat32m2_t vd, _Float16 vs1,
                                           vfloat16m1_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -454,7 +454,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tu(vfloat32m4_t vd, _Float16 vs1,
                                           vfloat16m2_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -464,7 +464,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tu(vfloat32m8_t vd, _Float16 vs1,
                                           vfloat16m4_t vs2, size_t vl) {
   return __riscv_vfwnmsac_tu(vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -516,7 +516,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                             float16_t vs1, vfloat16mf4_t vs2,
+                                             _Float16 vs1, vfloat16mf4_t vs2,
                                              size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -528,7 +528,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                           float16_t vs1, vfloat16mf2_t vs2,
+                                           _Float16 vs1, vfloat16mf2_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -540,7 +540,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                           float16_t vs1, vfloat16m1_t vs2,
+                                           _Float16 vs1, vfloat16m1_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -552,7 +552,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                           float16_t vs1, vfloat16m2_t vs2,
+                                           _Float16 vs1, vfloat16m2_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -564,7 +564,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                           float16_t vs1, vfloat16m4_t vs2,
+                                           _Float16 vs1, vfloat16m4_t vs2,
                                            size_t vl) {
   return __riscv_vfwnmsac_tum(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -624,7 +624,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                              float16_t vs1, vfloat16mf4_t vs2,
+                                              _Float16 vs1, vfloat16mf4_t vs2,
                                               size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -636,7 +636,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                            float16_t vs1, vfloat16mf2_t vs2,
+                                            _Float16 vs1, vfloat16mf2_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -648,7 +648,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                            float16_t vs1, vfloat16m1_t vs2,
+                                            _Float16 vs1, vfloat16m1_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -660,7 +660,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                            float16_t vs1, vfloat16m2_t vs2,
+                                            _Float16 vs1, vfloat16m2_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -672,7 +672,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                            float16_t vs1, vfloat16m4_t vs2,
+                                            _Float16 vs1, vfloat16m4_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmsac_tumu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -732,7 +732,7 @@ vfloat32mf2_t test_vfwnmsac_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwnmsac_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                            float16_t vs1, vfloat16mf4_t vs2,
+                                            _Float16 vs1, vfloat16mf4_t vs2,
                                             size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -744,7 +744,7 @@ vfloat32m1_t test_vfwnmsac_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwnmsac_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                          float16_t vs1, vfloat16mf2_t vs2,
+                                          _Float16 vs1, vfloat16mf2_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -756,7 +756,7 @@ vfloat32m2_t test_vfwnmsac_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwnmsac_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                          float16_t vs1, vfloat16m1_t vs2,
+                                          _Float16 vs1, vfloat16m1_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -768,7 +768,7 @@ vfloat32m4_t test_vfwnmsac_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwnmsac_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                          float16_t vs1, vfloat16m2_t vs2,
+                                          _Float16 vs1, vfloat16m2_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }
@@ -780,7 +780,7 @@ vfloat32m8_t test_vfwnmsac_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwnmsac_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                          float16_t vs1, vfloat16m4_t vs2,
+                                          _Float16 vs1, vfloat16m4_t vs2,
                                           size_t vl) {
   return __riscv_vfwnmsac_mu(vm, vd, vs1, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfwsub.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfwsub.c
@@ -11,7 +11,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -21,7 +21,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
-                                       float16_t rs1, size_t vl) {
+                                       _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -31,7 +31,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -41,7 +41,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -51,7 +51,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -61,7 +61,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -71,7 +71,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
 }
 
 vfloat32m4_t test_vfwsub_vf_f32m4_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -81,7 +81,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
 }
 
 vfloat32m4_t test_vfwsub_wf_f32m4_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -91,7 +91,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
 }
 
 vfloat32m8_t test_vfwsub_vf_f32m8_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, vl);
 }
 
@@ -101,7 +101,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
 }
 
 vfloat32m8_t test_vfwsub_wf_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
-                                     float16_t rs1, size_t vl) {
+                                     _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, vl);
 }
 
@@ -192,7 +192,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -204,7 +204,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                        vfloat32mf2_t vs2, float16_t rs1,
+                                        vfloat32mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -216,7 +216,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -228,7 +228,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
-                                      vfloat32m1_t vs2, float16_t rs1,
+                                      vfloat32m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -240,7 +240,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -252,7 +252,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
-                                      vfloat32m2_t vs2, float16_t rs1,
+                                      vfloat32m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -264,7 +264,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_vf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -276,7 +276,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_wf_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
-                                      vfloat32m4_t vs2, float16_t rs1,
+                                      vfloat32m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -288,7 +288,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_vf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -300,7 +300,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_wf_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
-                                      vfloat32m8_t vs2, float16_t rs1,
+                                      vfloat32m8_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, vl);
 }
@@ -408,7 +408,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                         vfloat16mf4_t vs2, float16_t rs1,
+                                         vfloat16mf4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -420,7 +420,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                         vfloat32mf2_t vs2, float16_t rs1,
+                                         vfloat32mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -432,7 +432,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -444,7 +444,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                       vfloat32m1_t vs2, float16_t rs1,
+                                       vfloat32m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -456,7 +456,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -468,7 +468,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                       vfloat32m2_t vs2, float16_t rs1,
+                                       vfloat32m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -480,7 +480,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_vf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -492,7 +492,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_wf_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                       vfloat32m4_t vs2, float16_t rs1,
+                                       vfloat32m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -504,7 +504,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_vf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -516,7 +516,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_wf_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                       vfloat32m8_t vs2, float16_t rs1,
+                                       vfloat32m8_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, vl);
 }
@@ -624,7 +624,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -636,7 +636,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                       vfloat32mf2_t vs2, float16_t rs1,
+                                       vfloat32mf2_t vs2, _Float16 rs1,
                                        size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -648,7 +648,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                     vfloat16mf2_t vs2, float16_t rs1,
+                                     vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -660,7 +660,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
-                                     vfloat32m1_t vs2, float16_t rs1,
+                                     vfloat32m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -672,7 +672,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -684,7 +684,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
-                                     vfloat32m2_t vs2, float16_t rs1,
+                                     vfloat32m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -696,7 +696,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_vf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
+                                     vfloat16m2_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -708,7 +708,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_wf_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
-                                     vfloat32m4_t vs2, float16_t rs1,
+                                     vfloat32m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -720,7 +720,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_vf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
+                                     vfloat16m4_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -732,7 +732,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_wf_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
-                                     vfloat32m8_t vs2, float16_t rs1,
+                                     vfloat32m8_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, vl);
 }
@@ -839,7 +839,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -849,7 +849,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
-                                          float16_t rs1, size_t vl) {
+                                          _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -859,7 +859,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_rm_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -869,7 +869,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -879,7 +879,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_rm_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -889,7 +889,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -899,7 +899,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
 }
 
 vfloat32m4_t test_vfwsub_vf_f32m4_rm_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -909,7 +909,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
 }
 
 vfloat32m4_t test_vfwsub_wf_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -919,7 +919,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
 }
 
 vfloat32m8_t test_vfwsub_vf_f32m8_rm_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_vf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -929,7 +929,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
 }
 
 vfloat32m8_t test_vfwsub_wf_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
-                                        float16_t rs1, size_t vl) {
+                                        _Float16 rs1, size_t vl) {
   return __riscv_vfwsub_wf_tu(vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
 
@@ -1020,7 +1020,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                           vfloat16mf4_t vs2, float16_t rs1,
+                                           vfloat16mf4_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1032,7 +1032,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                           vfloat32mf2_t vs2, float16_t rs1,
+                                           vfloat32mf2_t vs2, _Float16 rs1,
                                            size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1044,7 +1044,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                         vfloat16mf2_t vs2, float16_t rs1,
+                                         vfloat16mf2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1056,7 +1056,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
-                                         vfloat32m1_t vs2, float16_t rs1,
+                                         vfloat32m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1068,7 +1068,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                         vfloat16m1_t vs2, float16_t rs1,
+                                         vfloat16m1_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1080,7 +1080,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
-                                         vfloat32m2_t vs2, float16_t rs1,
+                                         vfloat32m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1092,7 +1092,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_vf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                         vfloat16m2_t vs2, float16_t rs1,
+                                         vfloat16m2_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1104,7 +1104,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_wf_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
-                                         vfloat32m4_t vs2, float16_t rs1,
+                                         vfloat32m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1116,7 +1116,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_vf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                         vfloat16m4_t vs2, float16_t rs1,
+                                         vfloat16m4_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_vf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1128,7 +1128,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_wf_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
-                                         vfloat32m8_t vs2, float16_t rs1,
+                                         vfloat32m8_t vs2, _Float16 rs1,
                                          size_t vl) {
   return __riscv_vfwsub_wf_tum(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1236,7 +1236,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                            vfloat16mf4_t vs2, float16_t rs1,
+                                            vfloat16mf4_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1248,7 +1248,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                            vfloat32mf2_t vs2, float16_t rs1,
+                                            vfloat32mf2_t vs2, _Float16 rs1,
                                             size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1260,7 +1260,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                          vfloat16mf2_t vs2, float16_t rs1,
+                                          vfloat16mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1272,7 +1272,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                          vfloat32m1_t vs2, float16_t rs1,
+                                          vfloat32m1_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1284,7 +1284,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                          vfloat16m1_t vs2, float16_t rs1,
+                                          vfloat16m1_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1296,7 +1296,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                          vfloat32m2_t vs2, float16_t rs1,
+                                          vfloat32m2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1308,7 +1308,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_vf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                          vfloat16m2_t vs2, float16_t rs1,
+                                          vfloat16m2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1320,7 +1320,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_wf_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                          vfloat32m4_t vs2, float16_t rs1,
+                                          vfloat32m4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1332,7 +1332,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_vf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                          vfloat16m4_t vs2, float16_t rs1,
+                                          vfloat16m4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_vf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1344,7 +1344,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_wf_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                          vfloat32m8_t vs2, float16_t rs1,
+                                          vfloat32m8_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_wf_tumu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1452,7 +1452,7 @@ vfloat32mf2_t test_vfwsub_vv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_vf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                          vfloat16mf4_t vs2, float16_t rs1,
+                                          vfloat16mf4_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1464,7 +1464,7 @@ vfloat32mf2_t test_vfwsub_wv_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
 }
 
 vfloat32mf2_t test_vfwsub_wf_f32mf2_rm_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                          vfloat32mf2_t vs2, float16_t rs1,
+                                          vfloat32mf2_t vs2, _Float16 rs1,
                                           size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1476,7 +1476,7 @@ vfloat32m1_t test_vfwsub_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_vf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1488,7 +1488,7 @@ vfloat32m1_t test_vfwsub_wv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
 }
 
 vfloat32m1_t test_vfwsub_wf_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
-                                        vfloat32m1_t vs2, float16_t rs1,
+                                        vfloat32m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1500,7 +1500,7 @@ vfloat32m2_t test_vfwsub_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_vf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                        vfloat16m1_t vs2, float16_t rs1,
+                                        vfloat16m1_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1512,7 +1512,7 @@ vfloat32m2_t test_vfwsub_wv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
 }
 
 vfloat32m2_t test_vfwsub_wf_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
-                                        vfloat32m2_t vs2, float16_t rs1,
+                                        vfloat32m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1524,7 +1524,7 @@ vfloat32m4_t test_vfwsub_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_vf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                        vfloat16m2_t vs2, float16_t rs1,
+                                        vfloat16m2_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1536,7 +1536,7 @@ vfloat32m4_t test_vfwsub_wv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
 }
 
 vfloat32m4_t test_vfwsub_wf_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
-                                        vfloat32m4_t vs2, float16_t rs1,
+                                        vfloat32m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1548,7 +1548,7 @@ vfloat32m8_t test_vfwsub_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                        vfloat16m4_t vs2, float16_t rs1,
+                                        vfloat16m4_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_vf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }
@@ -1560,7 +1560,7 @@ vfloat32m8_t test_vfwsub_wv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
 }
 
 vfloat32m8_t test_vfwsub_wf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
-                                        vfloat32m8_t vs2, float16_t rs1,
+                                        vfloat32m8_t vs2, _Float16 rs1,
                                         size_t vl) {
   return __riscv_vfwsub_wf_mu(vm, vd, vs2, rs1, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vmfeq.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vmfeq.c
@@ -12,7 +12,7 @@ vbool64_t test_vmfeq_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
 }
 
 vbool64_t test_vmfeq_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfeq_mu(vm, vd, vs2, rs1, vl);
 }
@@ -24,7 +24,7 @@ vbool32_t test_vmfeq_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
 }
 
 vbool32_t test_vmfeq_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfeq_mu(vm, vd, vs2, rs1, vl);
 }
@@ -36,7 +36,7 @@ vbool16_t test_vmfeq_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
 }
 
 vbool16_t test_vmfeq_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vmfeq_mu(vm, vd, vs2, rs1, vl);
 }
@@ -47,7 +47,7 @@ vbool8_t test_vmfeq_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
 }
 
 vbool8_t test_vmfeq_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vbool4_t test_vmfeq_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
 }
 
 vbool4_t test_vmfeq_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vbool2_t test_vmfeq_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
 }
 
 vbool2_t test_vmfeq_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfeq_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/overloaded-api-testing/vmfge.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vmfge.c
@@ -12,7 +12,7 @@ vbool64_t test_vmfge_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
 }
 
 vbool64_t test_vmfge_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfge_mu(vm, vd, vs2, rs1, vl);
 }
@@ -24,7 +24,7 @@ vbool32_t test_vmfge_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
 }
 
 vbool32_t test_vmfge_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfge_mu(vm, vd, vs2, rs1, vl);
 }
@@ -36,7 +36,7 @@ vbool16_t test_vmfge_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
 }
 
 vbool16_t test_vmfge_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vmfge_mu(vm, vd, vs2, rs1, vl);
 }
@@ -47,7 +47,7 @@ vbool8_t test_vmfge_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
 }
 
 vbool8_t test_vmfge_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfge_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vbool4_t test_vmfge_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
 }
 
 vbool4_t test_vmfge_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfge_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vbool2_t test_vmfge_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
 }
 
 vbool2_t test_vmfge_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfge_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/overloaded-api-testing/vmfgt.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vmfgt.c
@@ -12,7 +12,7 @@ vbool64_t test_vmfgt_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
 }
 
 vbool64_t test_vmfgt_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfgt_mu(vm, vd, vs2, rs1, vl);
 }
@@ -24,7 +24,7 @@ vbool32_t test_vmfgt_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
 }
 
 vbool32_t test_vmfgt_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfgt_mu(vm, vd, vs2, rs1, vl);
 }
@@ -36,7 +36,7 @@ vbool16_t test_vmfgt_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
 }
 
 vbool16_t test_vmfgt_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vmfgt_mu(vm, vd, vs2, rs1, vl);
 }
@@ -47,7 +47,7 @@ vbool8_t test_vmfgt_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
 }
 
 vbool8_t test_vmfgt_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vbool4_t test_vmfgt_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
 }
 
 vbool4_t test_vmfgt_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vbool2_t test_vmfgt_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
 }
 
 vbool2_t test_vmfgt_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfgt_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/overloaded-api-testing/vmfle.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vmfle.c
@@ -12,7 +12,7 @@ vbool64_t test_vmfle_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
 }
 
 vbool64_t test_vmfle_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfle_mu(vm, vd, vs2, rs1, vl);
 }
@@ -24,7 +24,7 @@ vbool32_t test_vmfle_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
 }
 
 vbool32_t test_vmfle_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfle_mu(vm, vd, vs2, rs1, vl);
 }
@@ -36,7 +36,7 @@ vbool16_t test_vmfle_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
 }
 
 vbool16_t test_vmfle_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vmfle_mu(vm, vd, vs2, rs1, vl);
 }
@@ -47,7 +47,7 @@ vbool8_t test_vmfle_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
 }
 
 vbool8_t test_vmfle_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfle_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vbool4_t test_vmfle_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
 }
 
 vbool4_t test_vmfle_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfle_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vbool2_t test_vmfle_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
 }
 
 vbool2_t test_vmfle_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfle_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/overloaded-api-testing/vmflt.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vmflt.c
@@ -12,7 +12,7 @@ vbool64_t test_vmflt_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
 }
 
 vbool64_t test_vmflt_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmflt_mu(vm, vd, vs2, rs1, vl);
 }
@@ -24,7 +24,7 @@ vbool32_t test_vmflt_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
 }
 
 vbool32_t test_vmflt_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmflt_mu(vm, vd, vs2, rs1, vl);
 }
@@ -36,7 +36,7 @@ vbool16_t test_vmflt_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
 }
 
 vbool16_t test_vmflt_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vmflt_mu(vm, vd, vs2, rs1, vl);
 }
@@ -47,7 +47,7 @@ vbool8_t test_vmflt_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
 }
 
 vbool8_t test_vmflt_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmflt_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vbool4_t test_vmflt_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
 }
 
 vbool4_t test_vmflt_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmflt_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vbool2_t test_vmflt_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
 }
 
 vbool2_t test_vmflt_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmflt_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/overloaded-api-testing/vmfne.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vmfne.c
@@ -12,7 +12,7 @@ vbool64_t test_vmfne_vv_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
 }
 
 vbool64_t test_vmfne_vf_f16mf4_b64_mu(vbool64_t vm, vbool64_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfne_mu(vm, vd, vs2, rs1, vl);
 }
@@ -24,7 +24,7 @@ vbool32_t test_vmfne_vv_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
 }
 
 vbool32_t test_vmfne_vf_f16mf2_b32_mu(vbool32_t vm, vbool32_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl) {
   return __riscv_vmfne_mu(vm, vd, vs2, rs1, vl);
 }
@@ -36,7 +36,7 @@ vbool16_t test_vmfne_vv_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
 }
 
 vbool16_t test_vmfne_vf_f16m1_b16_mu(vbool16_t vm, vbool16_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
+                                     vfloat16m1_t vs2, _Float16 rs1,
                                      size_t vl) {
   return __riscv_vmfne_mu(vm, vd, vs2, rs1, vl);
 }
@@ -47,7 +47,7 @@ vbool8_t test_vmfne_vv_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
 }
 
 vbool8_t test_vmfne_vf_f16m2_b8_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfne_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -57,7 +57,7 @@ vbool4_t test_vmfne_vv_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
 }
 
 vbool4_t test_vmfne_vf_f16m4_b4_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfne_mu(vm, vd, vs2, rs1, vl);
 }
 
@@ -67,7 +67,7 @@ vbool2_t test_vmfne_vv_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
 }
 
 vbool2_t test_vmfne_vf_f16m8_b2_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
-                                   float16_t rs1, size_t vl) {
+                                   _Float16 rs1, size_t vl) {
   return __riscv_vmfne_mu(vm, vd, vs2, rs1, vl);
 }
 

--- a/auto-generated/policy_funcs/overloaded_intrinsic_funcs/04_vector_floating-point_instructions.adoc
+++ b/auto-generated/policy_funcs/overloaded_intrinsic_funcs/04_vector_floating-point_instructions.adoc
@@ -9,26 +9,26 @@
 vfloat16mf4_t __riscv_vfadd_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfadd_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfadd_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfadd_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfadd_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfadd_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfadd_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m2_t __riscv_vfadd_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfadd_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfadd_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m4_t __riscv_vfadd_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfadd_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfadd_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m8_t __riscv_vfadd_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfadd_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfadd_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat32mf2_t __riscv_vfadd_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, size_t vl);
@@ -69,26 +69,26 @@ vfloat64m8_t __riscv_vfadd_tu(vfloat64m8_t vd, vfloat64m8_t vs2, float64_t rs1,
 vfloat16mf4_t __riscv_vfsub_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsub_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsub_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsub_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsub_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfsub_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfsub_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m2_t __riscv_vfsub_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfsub_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfsub_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m4_t __riscv_vfsub_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfsub_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfsub_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m8_t __riscv_vfsub_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfsub_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfsub_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat32mf2_t __riscv_vfsub_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, size_t vl);
@@ -127,16 +127,16 @@ vfloat64m8_t __riscv_vfsub_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfsub_tu(vfloat64m8_t vd, vfloat64m8_t vs2, float64_t rs1,
                               size_t vl);
 vfloat16mf4_t __riscv_vfrsub_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfrsub_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                float16_t rs1, size_t vl);
-vfloat16m1_t __riscv_vfrsub_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1,
+                                _Float16 rs1, size_t vl);
+vfloat16m1_t __riscv_vfrsub_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1,
                                size_t vl);
-vfloat16m2_t __riscv_vfrsub_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfrsub_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1,
                                size_t vl);
-vfloat16m4_t __riscv_vfrsub_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfrsub_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1,
                                size_t vl);
-vfloat16m8_t __riscv_vfrsub_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfrsub_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32mf2_t __riscv_vfrsub_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                 float32_t rs1, size_t vl);
@@ -176,28 +176,28 @@ vfloat16mf4_t __riscv_vfadd_tum(vbool64_t vm, vfloat16mf4_t vd,
                                 vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 size_t vl);
 vfloat16mf4_t __riscv_vfadd_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfadd_tum(vbool32_t vm, vfloat16mf2_t vd,
                                 vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                 size_t vl);
 vfloat16mf2_t __riscv_vfadd_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfadd_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfadd_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfadd_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfadd_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfadd_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfadd_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfadd_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfadd_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfadd_tum(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                 size_t vl);
@@ -239,28 +239,28 @@ vfloat16mf4_t __riscv_vfsub_tum(vbool64_t vm, vfloat16mf4_t vd,
                                 vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 size_t vl);
 vfloat16mf4_t __riscv_vfsub_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsub_tum(vbool32_t vm, vfloat16mf2_t vd,
                                 vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                 size_t vl);
 vfloat16mf2_t __riscv_vfsub_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsub_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsub_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsub_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsub_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsub_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsub_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsub_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsub_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsub_tum(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                 size_t vl);
@@ -299,17 +299,17 @@ vfloat64m8_t __riscv_vfsub_tum(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfsub_tum(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
                                float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfrsub_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                 vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfrsub_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                 vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfrsub_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfrsub_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfrsub_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfrsub_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrsub_tum(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfrsub_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2,
@@ -363,28 +363,28 @@ vfloat16mf4_t __riscv_vfadd_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                  size_t vl);
 vfloat16mf4_t __riscv_vfadd_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                 vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfadd_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfadd_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                 vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfadd_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                 vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfadd_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfadd_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                 vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfadd_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfadd_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                 vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfadd_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfadd_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                 vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfadd_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfadd_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                  size_t vl);
@@ -426,28 +426,28 @@ vfloat16mf4_t __riscv_vfsub_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                  size_t vl);
 vfloat16mf4_t __riscv_vfsub_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                 vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsub_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfsub_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                 vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsub_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                 vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsub_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsub_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                 vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsub_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsub_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                 vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsub_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsub_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                 vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsub_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsub_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                  size_t vl);
@@ -486,17 +486,17 @@ vfloat64m8_t __riscv_vfsub_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfsub_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
                                 float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfrsub_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                  vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfrsub_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                  vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfrsub_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                 vfloat16m1_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfrsub_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfrsub_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfrsub_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrsub_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfrsub_tumu(vbool32_t vm, vfloat32m1_t vd,
@@ -549,27 +549,27 @@ vfloat64m8_t __riscv_vfneg_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs,
 vfloat16mf4_t __riscv_vfadd_mu(vbool64_t vm, vfloat16mf4_t vd,
                                vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfadd_mu(vbool64_t vm, vfloat16mf4_t vd,
-                               vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                               vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfadd_mu(vbool32_t vm, vfloat16mf2_t vd,
                                vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfadd_mu(vbool32_t vm, vfloat16mf2_t vd,
-                               vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                               vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfadd_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfadd_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfadd_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfadd_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfadd_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfadd_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfadd_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfadd_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfadd_mu(vbool64_t vm, vfloat32mf2_t vd,
                                vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfadd_mu(vbool64_t vm, vfloat32mf2_t vd,
@@ -609,27 +609,27 @@ vfloat64m8_t __riscv_vfadd_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfsub_mu(vbool64_t vm, vfloat16mf4_t vd,
                                vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsub_mu(vbool64_t vm, vfloat16mf4_t vd,
-                               vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                               vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsub_mu(vbool32_t vm, vfloat16mf2_t vd,
                                vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsub_mu(vbool32_t vm, vfloat16mf2_t vd,
-                               vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                               vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsub_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsub_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsub_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsub_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsub_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsub_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsub_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsub_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsub_mu(vbool64_t vm, vfloat32mf2_t vd,
                                vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsub_mu(vbool64_t vm, vfloat32mf2_t vd,
@@ -667,17 +667,17 @@ vfloat64m8_t __riscv_vfsub_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfsub_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
                               float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfrsub_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfrsub_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfrsub_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfrsub_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfrsub_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfrsub_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrsub_mu(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfrsub_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2,
@@ -729,26 +729,26 @@ vfloat64m8_t __riscv_vfneg_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs,
 vfloat16mf4_t __riscv_vfadd_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                vfloat16mf4_t vs1, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfadd_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfadd_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfadd_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfadd_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfadd_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfadd_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1,
                               unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfadd_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfadd_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfadd_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1,
                               unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfadd_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfadd_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfadd_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1,
                               unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfadd_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfadd_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfadd_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1,
                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfadd_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, unsigned int frm, size_t vl);
@@ -789,26 +789,26 @@ vfloat64m8_t __riscv_vfadd_tu(vfloat64m8_t vd, vfloat64m8_t vs2, float64_t rs1,
 vfloat16mf4_t __riscv_vfsub_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                vfloat16mf4_t vs1, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfsub_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfsub_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfsub_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfsub_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfsub_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfsub_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1,
                               unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfsub_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfsub_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfsub_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1,
                               unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfsub_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfsub_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfsub_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1,
                               unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfsub_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfsub_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfsub_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1,
                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfsub_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, unsigned int frm, size_t vl);
@@ -847,16 +847,16 @@ vfloat64m8_t __riscv_vfsub_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfsub_tu(vfloat64m8_t vd, vfloat64m8_t vs2, float64_t rs1,
                               unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfrsub_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfrsub_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfrsub_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1,
+                                _Float16 rs1, unsigned int frm, size_t vl);
+vfloat16m1_t __riscv_vfrsub_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfrsub_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfrsub_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfrsub_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfrsub_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfrsub_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfrsub_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrsub_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                 float32_t rs1, unsigned int frm, size_t vl);
@@ -881,30 +881,30 @@ vfloat16mf4_t __riscv_vfadd_tum(vbool64_t vm, vfloat16mf4_t vd,
                                 vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfadd_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                vfloat16mf4_t vs2, float16_t rs1,
+                                vfloat16mf4_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfadd_tum(vbool32_t vm, vfloat16mf2_t vd,
                                 vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                 unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfadd_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                vfloat16mf2_t vs2, float16_t rs1,
+                                vfloat16mf2_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfadd_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                vfloat16m1_t vs1, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfadd_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfadd_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                vfloat16m2_t vs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfadd_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfadd_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                vfloat16m4_t vs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfadd_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfadd_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                vfloat16m8_t vs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfadd_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfadd_tum(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                 unsigned int frm, size_t vl);
@@ -947,30 +947,30 @@ vfloat16mf4_t __riscv_vfsub_tum(vbool64_t vm, vfloat16mf4_t vd,
                                 vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfsub_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                vfloat16mf4_t vs2, float16_t rs1,
+                                vfloat16mf4_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfsub_tum(vbool32_t vm, vfloat16mf2_t vd,
                                 vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                 unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfsub_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                vfloat16mf2_t vs2, float16_t rs1,
+                                vfloat16mf2_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfsub_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                vfloat16m1_t vs1, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfsub_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfsub_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                vfloat16m2_t vs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfsub_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfsub_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                vfloat16m4_t vs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfsub_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfsub_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                vfloat16m8_t vs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfsub_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfsub_tum(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                 unsigned int frm, size_t vl);
@@ -1010,19 +1010,19 @@ vfloat64m8_t __riscv_vfsub_tum(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfsub_tum(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
                                float64_t rs1, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfrsub_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                 vfloat16mf4_t vs2, float16_t rs1,
+                                 vfloat16mf4_t vs2, _Float16 rs1,
                                  unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfrsub_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                 vfloat16mf2_t vs2, float16_t rs1,
+                                 vfloat16mf2_t vs2, _Float16 rs1,
                                  unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfrsub_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfrsub_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfrsub_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfrsub_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrsub_tum(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs2, float32_t rs1,
                                  unsigned int frm, size_t vl);
@@ -1047,30 +1047,30 @@ vfloat16mf4_t __riscv_vfadd_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                  unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfadd_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                 vfloat16mf4_t vs2, float16_t rs1,
+                                 vfloat16mf4_t vs2, _Float16 rs1,
                                  unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfadd_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                  unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfadd_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                 vfloat16mf2_t vs2, float16_t rs1,
+                                 vfloat16mf2_t vs2, _Float16 rs1,
                                  unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfadd_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                 vfloat16m1_t vs1, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfadd_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfadd_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                 vfloat16m2_t vs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfadd_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfadd_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                 vfloat16m4_t vs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfadd_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfadd_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                 vfloat16m8_t vs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfadd_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfadd_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                  unsigned int frm, size_t vl);
@@ -1113,30 +1113,30 @@ vfloat16mf4_t __riscv_vfsub_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                  unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfsub_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                 vfloat16mf4_t vs2, float16_t rs1,
+                                 vfloat16mf4_t vs2, _Float16 rs1,
                                  unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfsub_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                  unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfsub_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                 vfloat16mf2_t vs2, float16_t rs1,
+                                 vfloat16mf2_t vs2, _Float16 rs1,
                                  unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfsub_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                 vfloat16m1_t vs1, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfsub_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfsub_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                 vfloat16m2_t vs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfsub_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfsub_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                 vfloat16m4_t vs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfsub_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfsub_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                 vfloat16m8_t vs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfsub_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfsub_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                  unsigned int frm, size_t vl);
@@ -1176,20 +1176,20 @@ vfloat64m8_t __riscv_vfsub_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfsub_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
                                 float64_t rs1, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfrsub_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                  vfloat16mf4_t vs2, float16_t rs1,
+                                  vfloat16mf4_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfrsub_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                  vfloat16mf2_t vs2, float16_t rs1,
+                                  vfloat16mf2_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfrsub_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                 vfloat16m1_t vs2, float16_t rs1,
+                                 vfloat16m1_t vs2, _Float16 rs1,
                                  unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfrsub_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                 float16_t rs1, unsigned int frm, size_t vl);
+                                 _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfrsub_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                 float16_t rs1, unsigned int frm, size_t vl);
+                                 _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfrsub_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                 float16_t rs1, unsigned int frm, size_t vl);
+                                 _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrsub_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs2, float32_t rs1,
                                   unsigned int frm, size_t vl);
@@ -1219,30 +1219,30 @@ vfloat16mf4_t __riscv_vfadd_mu(vbool64_t vm, vfloat16mf4_t vd,
                                vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfadd_mu(vbool64_t vm, vfloat16mf4_t vd,
-                               vfloat16mf4_t vs2, float16_t rs1,
+                               vfloat16mf4_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfadd_mu(vbool32_t vm, vfloat16mf2_t vd,
                                vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfadd_mu(vbool32_t vm, vfloat16mf2_t vd,
-                               vfloat16mf2_t vs2, float16_t rs1,
+                               vfloat16mf2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfadd_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfadd_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                              float16_t rs1, unsigned int frm, size_t vl);
+                              _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfadd_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfadd_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                              float16_t rs1, unsigned int frm, size_t vl);
+                              _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfadd_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfadd_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                              float16_t rs1, unsigned int frm, size_t vl);
+                              _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfadd_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfadd_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                              float16_t rs1, unsigned int frm, size_t vl);
+                              _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfadd_mu(vbool64_t vm, vfloat32mf2_t vd,
                                vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                unsigned int frm, size_t vl);
@@ -1285,30 +1285,30 @@ vfloat16mf4_t __riscv_vfsub_mu(vbool64_t vm, vfloat16mf4_t vd,
                                vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfsub_mu(vbool64_t vm, vfloat16mf4_t vd,
-                               vfloat16mf4_t vs2, float16_t rs1,
+                               vfloat16mf4_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfsub_mu(vbool32_t vm, vfloat16mf2_t vd,
                                vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfsub_mu(vbool32_t vm, vfloat16mf2_t vd,
-                               vfloat16mf2_t vs2, float16_t rs1,
+                               vfloat16mf2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfsub_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfsub_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                              float16_t rs1, unsigned int frm, size_t vl);
+                              _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfsub_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfsub_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                              float16_t rs1, unsigned int frm, size_t vl);
+                              _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfsub_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfsub_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                              float16_t rs1, unsigned int frm, size_t vl);
+                              _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfsub_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfsub_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                              float16_t rs1, unsigned int frm, size_t vl);
+                              _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfsub_mu(vbool64_t vm, vfloat32mf2_t vd,
                                vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                unsigned int frm, size_t vl);
@@ -1348,19 +1348,19 @@ vfloat64m8_t __riscv_vfsub_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfsub_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
                               float64_t rs1, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfrsub_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                vfloat16mf4_t vs2, float16_t rs1,
+                                vfloat16mf4_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfrsub_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                vfloat16mf2_t vs2, float16_t rs1,
+                                vfloat16mf2_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfrsub_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfrsub_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfrsub_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfrsub_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrsub_mu(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs2, float32_t rs1,
                                 unsigned int frm, size_t vl);
@@ -1390,43 +1390,43 @@ vfloat64m8_t __riscv_vfrsub_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat32mf2_t __riscv_vfwadd_vv_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
                                    vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                   float16_t rs1, size_t vl);
+                                   _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                    vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
-                                   float16_t rs1, size_t vl);
+                                   _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
                                   vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                  float16_t rs1, size_t vl);
+                                  _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
                                   vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
-                                  float16_t rs1, size_t vl);
+                                  _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
                                   vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                  float16_t rs1, size_t vl);
+                                  _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
                                   vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
-                                  float16_t rs1, size_t vl);
+                                  _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
                                   vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                  float16_t rs1, size_t vl);
+                                  _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
                                   vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
-                                  float16_t rs1, size_t vl);
+                                  _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
                                   vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                  float16_t rs1, size_t vl);
+                                  _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
                                   vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
-                                  float16_t rs1, size_t vl);
+                                  _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_tu(vfloat64m1_t vd, vfloat32mf2_t vs2,
                                   vfloat32mf2_t vs1, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vf_tu(vfloat64m1_t vd, vfloat32mf2_t vs2,
@@ -1462,43 +1462,43 @@ vfloat64m8_t __riscv_vfwadd_wf_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat32mf2_t __riscv_vfwsub_vv_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
                                    vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                   float16_t rs1, size_t vl);
+                                   _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                    vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
-                                   float16_t rs1, size_t vl);
+                                   _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
                                   vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                  float16_t rs1, size_t vl);
+                                  _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
                                   vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
-                                  float16_t rs1, size_t vl);
+                                  _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
                                   vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                  float16_t rs1, size_t vl);
+                                  _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
                                   vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
-                                  float16_t rs1, size_t vl);
+                                  _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
                                   vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                  float16_t rs1, size_t vl);
+                                  _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
                                   vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
-                                  float16_t rs1, size_t vl);
+                                  _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
                                   vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                  float16_t rs1, size_t vl);
+                                  _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
                                   vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
-                                  float16_t rs1, size_t vl);
+                                  _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_tu(vfloat64m1_t vd, vfloat32mf2_t vs2,
                                   vfloat32mf2_t vs1, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vf_tu(vfloat64m1_t vd, vfloat32mf2_t vs2,
@@ -1536,54 +1536,52 @@ vfloat32mf2_t __riscv_vfwadd_vv_tum(vbool64_t vm, vfloat32mf2_t vd,
                                     vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                     size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                    vfloat16mf4_t vs2, float16_t rs1,
-                                    size_t vl);
+                                    vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_tum(vbool64_t vm, vfloat32mf2_t vd,
                                     vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                     size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                    vfloat32mf2_t vs2, float16_t rs1,
-                                    size_t vl);
+                                    vfloat32mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_tum(vbool32_t vm, vfloat32m1_t vd,
                                    vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                    size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_tum(vbool32_t vm, vfloat32m1_t vd,
-                                   vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                   vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_tum(vbool32_t vm, vfloat32m1_t vd,
                                    vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                    size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_tum(vbool32_t vm, vfloat32m1_t vd,
-                                   vfloat32m1_t vs2, float16_t rs1, size_t vl);
+                                   vfloat32m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_tum(vbool16_t vm, vfloat32m2_t vd,
                                    vfloat16m1_t vs2, vfloat16m1_t vs1,
                                    size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_tum(vbool16_t vm, vfloat32m2_t vd,
-                                   vfloat16m1_t vs2, float16_t rs1, size_t vl);
+                                   vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_tum(vbool16_t vm, vfloat32m2_t vd,
                                    vfloat32m2_t vs2, vfloat16m1_t vs1,
                                    size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_tum(vbool16_t vm, vfloat32m2_t vd,
-                                   vfloat32m2_t vs2, float16_t rs1, size_t vl);
+                                   vfloat32m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_tum(vbool8_t vm, vfloat32m4_t vd,
                                    vfloat16m2_t vs2, vfloat16m2_t vs1,
                                    size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_tum(vbool8_t vm, vfloat32m4_t vd,
-                                   vfloat16m2_t vs2, float16_t rs1, size_t vl);
+                                   vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_tum(vbool8_t vm, vfloat32m4_t vd,
                                    vfloat32m4_t vs2, vfloat16m2_t vs1,
                                    size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_tum(vbool8_t vm, vfloat32m4_t vd,
-                                   vfloat32m4_t vs2, float16_t rs1, size_t vl);
+                                   vfloat32m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_tum(vbool4_t vm, vfloat32m8_t vd,
                                    vfloat16m4_t vs2, vfloat16m4_t vs1,
                                    size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_tum(vbool4_t vm, vfloat32m8_t vd,
-                                   vfloat16m4_t vs2, float16_t rs1, size_t vl);
+                                   vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_tum(vbool4_t vm, vfloat32m8_t vd,
                                    vfloat32m8_t vs2, vfloat16m4_t vs1,
                                    size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_tum(vbool4_t vm, vfloat32m8_t vd,
-                                   vfloat32m8_t vs2, float16_t rs1, size_t vl);
+                                   vfloat32m8_t vs2, _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_tum(vbool64_t vm, vfloat64m1_t vd,
                                    vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                    size_t vl);
@@ -1628,54 +1626,52 @@ vfloat32mf2_t __riscv_vfwsub_vv_tum(vbool64_t vm, vfloat32mf2_t vd,
                                     vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                     size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                    vfloat16mf4_t vs2, float16_t rs1,
-                                    size_t vl);
+                                    vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_tum(vbool64_t vm, vfloat32mf2_t vd,
                                     vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                     size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                    vfloat32mf2_t vs2, float16_t rs1,
-                                    size_t vl);
+                                    vfloat32mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_tum(vbool32_t vm, vfloat32m1_t vd,
                                    vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                    size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_tum(vbool32_t vm, vfloat32m1_t vd,
-                                   vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                   vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_tum(vbool32_t vm, vfloat32m1_t vd,
                                    vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                    size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_tum(vbool32_t vm, vfloat32m1_t vd,
-                                   vfloat32m1_t vs2, float16_t rs1, size_t vl);
+                                   vfloat32m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_tum(vbool16_t vm, vfloat32m2_t vd,
                                    vfloat16m1_t vs2, vfloat16m1_t vs1,
                                    size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_tum(vbool16_t vm, vfloat32m2_t vd,
-                                   vfloat16m1_t vs2, float16_t rs1, size_t vl);
+                                   vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_tum(vbool16_t vm, vfloat32m2_t vd,
                                    vfloat32m2_t vs2, vfloat16m1_t vs1,
                                    size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_tum(vbool16_t vm, vfloat32m2_t vd,
-                                   vfloat32m2_t vs2, float16_t rs1, size_t vl);
+                                   vfloat32m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_tum(vbool8_t vm, vfloat32m4_t vd,
                                    vfloat16m2_t vs2, vfloat16m2_t vs1,
                                    size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_tum(vbool8_t vm, vfloat32m4_t vd,
-                                   vfloat16m2_t vs2, float16_t rs1, size_t vl);
+                                   vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_tum(vbool8_t vm, vfloat32m4_t vd,
                                    vfloat32m4_t vs2, vfloat16m2_t vs1,
                                    size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_tum(vbool8_t vm, vfloat32m4_t vd,
-                                   vfloat32m4_t vs2, float16_t rs1, size_t vl);
+                                   vfloat32m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_tum(vbool4_t vm, vfloat32m8_t vd,
                                    vfloat16m4_t vs2, vfloat16m4_t vs1,
                                    size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_tum(vbool4_t vm, vfloat32m8_t vd,
-                                   vfloat16m4_t vs2, float16_t rs1, size_t vl);
+                                   vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_tum(vbool4_t vm, vfloat32m8_t vd,
                                    vfloat32m8_t vs2, vfloat16m4_t vs1,
                                    size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_tum(vbool4_t vm, vfloat32m8_t vd,
-                                   vfloat32m8_t vs2, float16_t rs1, size_t vl);
+                                   vfloat32m8_t vs2, _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_tum(vbool64_t vm, vfloat64m1_t vd,
                                    vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                    size_t vl);
@@ -1721,55 +1717,54 @@ vfloat32mf2_t __riscv_vfwadd_vv_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                      vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                      size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                     vfloat16mf4_t vs2, float16_t rs1,
+                                     vfloat16mf4_t vs2, _Float16 rs1,
                                      size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                      vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                      size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                     vfloat32mf2_t vs2, float16_t rs1,
+                                     vfloat32mf2_t vs2, _Float16 rs1,
                                      size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_tumu(vbool32_t vm, vfloat32m1_t vd,
                                     vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                     size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                    vfloat16mf2_t vs2, float16_t rs1,
-                                    size_t vl);
+                                    vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_tumu(vbool32_t vm, vfloat32m1_t vd,
                                     vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                     size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                    vfloat32m1_t vs2, float16_t rs1, size_t vl);
+                                    vfloat32m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_tumu(vbool16_t vm, vfloat32m2_t vd,
                                     vfloat16m1_t vs2, vfloat16m1_t vs1,
                                     size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                    vfloat16m1_t vs2, float16_t rs1, size_t vl);
+                                    vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_tumu(vbool16_t vm, vfloat32m2_t vd,
                                     vfloat32m2_t vs2, vfloat16m1_t vs1,
                                     size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                    vfloat32m2_t vs2, float16_t rs1, size_t vl);
+                                    vfloat32m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_tumu(vbool8_t vm, vfloat32m4_t vd,
                                     vfloat16m2_t vs2, vfloat16m2_t vs1,
                                     size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                    vfloat16m2_t vs2, float16_t rs1, size_t vl);
+                                    vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_tumu(vbool8_t vm, vfloat32m4_t vd,
                                     vfloat32m4_t vs2, vfloat16m2_t vs1,
                                     size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                    vfloat32m4_t vs2, float16_t rs1, size_t vl);
+                                    vfloat32m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_tumu(vbool4_t vm, vfloat32m8_t vd,
                                     vfloat16m4_t vs2, vfloat16m4_t vs1,
                                     size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                    vfloat16m4_t vs2, float16_t rs1, size_t vl);
+                                    vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_tumu(vbool4_t vm, vfloat32m8_t vd,
                                     vfloat32m8_t vs2, vfloat16m4_t vs1,
                                     size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                    vfloat32m8_t vs2, float16_t rs1, size_t vl);
+                                    vfloat32m8_t vs2, _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_tumu(vbool64_t vm, vfloat64m1_t vd,
                                     vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                     size_t vl);
@@ -1815,55 +1810,54 @@ vfloat32mf2_t __riscv_vfwsub_vv_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                      vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                      size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                     vfloat16mf4_t vs2, float16_t rs1,
+                                     vfloat16mf4_t vs2, _Float16 rs1,
                                      size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                      vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                      size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                     vfloat32mf2_t vs2, float16_t rs1,
+                                     vfloat32mf2_t vs2, _Float16 rs1,
                                      size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_tumu(vbool32_t vm, vfloat32m1_t vd,
                                     vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                     size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                    vfloat16mf2_t vs2, float16_t rs1,
-                                    size_t vl);
+                                    vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_tumu(vbool32_t vm, vfloat32m1_t vd,
                                     vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                     size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                    vfloat32m1_t vs2, float16_t rs1, size_t vl);
+                                    vfloat32m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_tumu(vbool16_t vm, vfloat32m2_t vd,
                                     vfloat16m1_t vs2, vfloat16m1_t vs1,
                                     size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                    vfloat16m1_t vs2, float16_t rs1, size_t vl);
+                                    vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_tumu(vbool16_t vm, vfloat32m2_t vd,
                                     vfloat32m2_t vs2, vfloat16m1_t vs1,
                                     size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                    vfloat32m2_t vs2, float16_t rs1, size_t vl);
+                                    vfloat32m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_tumu(vbool8_t vm, vfloat32m4_t vd,
                                     vfloat16m2_t vs2, vfloat16m2_t vs1,
                                     size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                    vfloat16m2_t vs2, float16_t rs1, size_t vl);
+                                    vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_tumu(vbool8_t vm, vfloat32m4_t vd,
                                     vfloat32m4_t vs2, vfloat16m2_t vs1,
                                     size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                    vfloat32m4_t vs2, float16_t rs1, size_t vl);
+                                    vfloat32m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_tumu(vbool4_t vm, vfloat32m8_t vd,
                                     vfloat16m4_t vs2, vfloat16m4_t vs1,
                                     size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                    vfloat16m4_t vs2, float16_t rs1, size_t vl);
+                                    vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_tumu(vbool4_t vm, vfloat32m8_t vd,
                                     vfloat32m8_t vs2, vfloat16m4_t vs1,
                                     size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                    vfloat32m8_t vs2, float16_t rs1, size_t vl);
+                                    vfloat32m8_t vs2, _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_tumu(vbool64_t vm, vfloat64m1_t vd,
                                     vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                     size_t vl);
@@ -1910,52 +1904,52 @@ vfloat32mf2_t __riscv_vfwadd_vv_mu(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                    size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                   vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                   vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_mu(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                    size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                   vfloat32mf2_t vs2, float16_t rs1, size_t vl);
+                                   vfloat32mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_mu(vbool32_t vm, vfloat32m1_t vd,
                                   vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                   size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_mu(vbool32_t vm, vfloat32m1_t vd,
-                                  vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_mu(vbool32_t vm, vfloat32m1_t vd,
                                   vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                   size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_mu(vbool32_t vm, vfloat32m1_t vd,
-                                  vfloat32m1_t vs2, float16_t rs1, size_t vl);
+                                  vfloat32m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_mu(vbool16_t vm, vfloat32m2_t vd,
                                   vfloat16m1_t vs2, vfloat16m1_t vs1,
                                   size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_mu(vbool16_t vm, vfloat32m2_t vd,
-                                  vfloat16m1_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_mu(vbool16_t vm, vfloat32m2_t vd,
                                   vfloat32m2_t vs2, vfloat16m1_t vs1,
                                   size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_mu(vbool16_t vm, vfloat32m2_t vd,
-                                  vfloat32m2_t vs2, float16_t rs1, size_t vl);
+                                  vfloat32m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_mu(vbool8_t vm, vfloat32m4_t vd,
                                   vfloat16m2_t vs2, vfloat16m2_t vs1,
                                   size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_mu(vbool8_t vm, vfloat32m4_t vd,
-                                  vfloat16m2_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_mu(vbool8_t vm, vfloat32m4_t vd,
                                   vfloat32m4_t vs2, vfloat16m2_t vs1,
                                   size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_mu(vbool8_t vm, vfloat32m4_t vd,
-                                  vfloat32m4_t vs2, float16_t rs1, size_t vl);
+                                  vfloat32m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_mu(vbool4_t vm, vfloat32m8_t vd,
                                   vfloat16m4_t vs2, vfloat16m4_t vs1,
                                   size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_mu(vbool4_t vm, vfloat32m8_t vd,
-                                  vfloat16m4_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_mu(vbool4_t vm, vfloat32m8_t vd,
                                   vfloat32m8_t vs2, vfloat16m4_t vs1,
                                   size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_mu(vbool4_t vm, vfloat32m8_t vd,
-                                  vfloat32m8_t vs2, float16_t rs1, size_t vl);
+                                  vfloat32m8_t vs2, _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_mu(vbool64_t vm, vfloat64m1_t vd,
                                   vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                   size_t vl);
@@ -2000,52 +1994,52 @@ vfloat32mf2_t __riscv_vfwsub_vv_mu(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                    size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                   vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                   vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_mu(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                    size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                   vfloat32mf2_t vs2, float16_t rs1, size_t vl);
+                                   vfloat32mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_mu(vbool32_t vm, vfloat32m1_t vd,
                                   vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                   size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_mu(vbool32_t vm, vfloat32m1_t vd,
-                                  vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_mu(vbool32_t vm, vfloat32m1_t vd,
                                   vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                   size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_mu(vbool32_t vm, vfloat32m1_t vd,
-                                  vfloat32m1_t vs2, float16_t rs1, size_t vl);
+                                  vfloat32m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_mu(vbool16_t vm, vfloat32m2_t vd,
                                   vfloat16m1_t vs2, vfloat16m1_t vs1,
                                   size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_mu(vbool16_t vm, vfloat32m2_t vd,
-                                  vfloat16m1_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_mu(vbool16_t vm, vfloat32m2_t vd,
                                   vfloat32m2_t vs2, vfloat16m1_t vs1,
                                   size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_mu(vbool16_t vm, vfloat32m2_t vd,
-                                  vfloat32m2_t vs2, float16_t rs1, size_t vl);
+                                  vfloat32m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_mu(vbool8_t vm, vfloat32m4_t vd,
                                   vfloat16m2_t vs2, vfloat16m2_t vs1,
                                   size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_mu(vbool8_t vm, vfloat32m4_t vd,
-                                  vfloat16m2_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_mu(vbool8_t vm, vfloat32m4_t vd,
                                   vfloat32m4_t vs2, vfloat16m2_t vs1,
                                   size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_mu(vbool8_t vm, vfloat32m4_t vd,
-                                  vfloat32m4_t vs2, float16_t rs1, size_t vl);
+                                  vfloat32m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_mu(vbool4_t vm, vfloat32m8_t vd,
                                   vfloat16m4_t vs2, vfloat16m4_t vs1,
                                   size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_mu(vbool4_t vm, vfloat32m8_t vd,
-                                  vfloat16m4_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_mu(vbool4_t vm, vfloat32m8_t vd,
                                   vfloat32m8_t vs2, vfloat16m4_t vs1,
                                   size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_mu(vbool4_t vm, vfloat32m8_t vd,
-                                  vfloat32m8_t vs2, float16_t rs1, size_t vl);
+                                  vfloat32m8_t vs2, _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_mu(vbool64_t vm, vfloat64m1_t vd,
                                   vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                   size_t vl);
@@ -2090,52 +2084,52 @@ vfloat32mf2_t __riscv_vfwadd_vv_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
                                    vfloat16mf4_t vs1, unsigned int frm,
                                    size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                   float16_t rs1, unsigned int frm, size_t vl);
+                                   _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                    vfloat16mf4_t vs1, unsigned int frm,
                                    size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
-                                   float16_t rs1, unsigned int frm, size_t vl);
+                                   _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
                                   vfloat16mf2_t vs1, unsigned int frm,
                                   size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                  float16_t rs1, unsigned int frm, size_t vl);
+                                  _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
                                   vfloat16mf2_t vs1, unsigned int frm,
                                   size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
-                                  float16_t rs1, unsigned int frm, size_t vl);
+                                  _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
                                   vfloat16m1_t vs1, unsigned int frm,
                                   size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                  float16_t rs1, unsigned int frm, size_t vl);
+                                  _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
                                   vfloat16m1_t vs1, unsigned int frm,
                                   size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
-                                  float16_t rs1, unsigned int frm, size_t vl);
+                                  _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
                                   vfloat16m2_t vs1, unsigned int frm,
                                   size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                  float16_t rs1, unsigned int frm, size_t vl);
+                                  _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
                                   vfloat16m2_t vs1, unsigned int frm,
                                   size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
-                                  float16_t rs1, unsigned int frm, size_t vl);
+                                  _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
                                   vfloat16m4_t vs1, unsigned int frm,
                                   size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                  float16_t rs1, unsigned int frm, size_t vl);
+                                  _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
                                   vfloat16m4_t vs1, unsigned int frm,
                                   size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
-                                  float16_t rs1, unsigned int frm, size_t vl);
+                                  _Float16 rs1, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_tu(vfloat64m1_t vd, vfloat32mf2_t vs2,
                                   vfloat32mf2_t vs1, unsigned int frm,
                                   size_t vl);
@@ -2180,52 +2174,52 @@ vfloat32mf2_t __riscv_vfwsub_vv_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
                                    vfloat16mf4_t vs1, unsigned int frm,
                                    size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                   float16_t rs1, unsigned int frm, size_t vl);
+                                   _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                    vfloat16mf4_t vs1, unsigned int frm,
                                    size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
-                                   float16_t rs1, unsigned int frm, size_t vl);
+                                   _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
                                   vfloat16mf2_t vs1, unsigned int frm,
                                   size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                                  float16_t rs1, unsigned int frm, size_t vl);
+                                  _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
                                   vfloat16mf2_t vs1, unsigned int frm,
                                   size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
-                                  float16_t rs1, unsigned int frm, size_t vl);
+                                  _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
                                   vfloat16m1_t vs1, unsigned int frm,
                                   size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
-                                  float16_t rs1, unsigned int frm, size_t vl);
+                                  _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
                                   vfloat16m1_t vs1, unsigned int frm,
                                   size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_tu(vfloat32m2_t vd, vfloat32m2_t vs2,
-                                  float16_t rs1, unsigned int frm, size_t vl);
+                                  _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
                                   vfloat16m2_t vs1, unsigned int frm,
                                   size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
-                                  float16_t rs1, unsigned int frm, size_t vl);
+                                  _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
                                   vfloat16m2_t vs1, unsigned int frm,
                                   size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_tu(vfloat32m4_t vd, vfloat32m4_t vs2,
-                                  float16_t rs1, unsigned int frm, size_t vl);
+                                  _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
                                   vfloat16m4_t vs1, unsigned int frm,
                                   size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
-                                  float16_t rs1, unsigned int frm, size_t vl);
+                                  _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
                                   vfloat16m4_t vs1, unsigned int frm,
                                   size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
-                                  float16_t rs1, unsigned int frm, size_t vl);
+                                  _Float16 rs1, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_tu(vfloat64m1_t vd, vfloat32mf2_t vs2,
                                   vfloat32mf2_t vs1, unsigned int frm,
                                   size_t vl);
@@ -2271,61 +2265,61 @@ vfloat32mf2_t __riscv_vfwadd_vv_tum(vbool64_t vm, vfloat32mf2_t vd,
                                     vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                    vfloat16mf4_t vs2, float16_t rs1,
+                                    vfloat16mf4_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_tum(vbool64_t vm, vfloat32mf2_t vd,
                                     vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                    vfloat32mf2_t vs2, float16_t rs1,
+                                    vfloat32mf2_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_tum(vbool32_t vm, vfloat32m1_t vd,
                                    vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_tum(vbool32_t vm, vfloat32m1_t vd,
-                                   vfloat16mf2_t vs2, float16_t rs1,
+                                   vfloat16mf2_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_tum(vbool32_t vm, vfloat32m1_t vd,
                                    vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_tum(vbool32_t vm, vfloat32m1_t vd,
-                                   vfloat32m1_t vs2, float16_t rs1,
+                                   vfloat32m1_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_tum(vbool16_t vm, vfloat32m2_t vd,
                                    vfloat16m1_t vs2, vfloat16m1_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_tum(vbool16_t vm, vfloat32m2_t vd,
-                                   vfloat16m1_t vs2, float16_t rs1,
+                                   vfloat16m1_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_tum(vbool16_t vm, vfloat32m2_t vd,
                                    vfloat32m2_t vs2, vfloat16m1_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_tum(vbool16_t vm, vfloat32m2_t vd,
-                                   vfloat32m2_t vs2, float16_t rs1,
+                                   vfloat32m2_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_tum(vbool8_t vm, vfloat32m4_t vd,
                                    vfloat16m2_t vs2, vfloat16m2_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_tum(vbool8_t vm, vfloat32m4_t vd,
-                                   vfloat16m2_t vs2, float16_t rs1,
+                                   vfloat16m2_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_tum(vbool8_t vm, vfloat32m4_t vd,
                                    vfloat32m4_t vs2, vfloat16m2_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_tum(vbool8_t vm, vfloat32m4_t vd,
-                                   vfloat32m4_t vs2, float16_t rs1,
+                                   vfloat32m4_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_tum(vbool4_t vm, vfloat32m8_t vd,
                                    vfloat16m4_t vs2, vfloat16m4_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_tum(vbool4_t vm, vfloat32m8_t vd,
-                                   vfloat16m4_t vs2, float16_t rs1,
+                                   vfloat16m4_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_tum(vbool4_t vm, vfloat32m8_t vd,
                                    vfloat32m8_t vs2, vfloat16m4_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_tum(vbool4_t vm, vfloat32m8_t vd,
-                                   vfloat32m8_t vs2, float16_t rs1,
+                                   vfloat32m8_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_tum(vbool64_t vm, vfloat64m1_t vd,
                                    vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -2379,61 +2373,61 @@ vfloat32mf2_t __riscv_vfwsub_vv_tum(vbool64_t vm, vfloat32mf2_t vd,
                                     vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                    vfloat16mf4_t vs2, float16_t rs1,
+                                    vfloat16mf4_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_tum(vbool64_t vm, vfloat32mf2_t vd,
                                     vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                    vfloat32mf2_t vs2, float16_t rs1,
+                                    vfloat32mf2_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_tum(vbool32_t vm, vfloat32m1_t vd,
                                    vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_tum(vbool32_t vm, vfloat32m1_t vd,
-                                   vfloat16mf2_t vs2, float16_t rs1,
+                                   vfloat16mf2_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_tum(vbool32_t vm, vfloat32m1_t vd,
                                    vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_tum(vbool32_t vm, vfloat32m1_t vd,
-                                   vfloat32m1_t vs2, float16_t rs1,
+                                   vfloat32m1_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_tum(vbool16_t vm, vfloat32m2_t vd,
                                    vfloat16m1_t vs2, vfloat16m1_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_tum(vbool16_t vm, vfloat32m2_t vd,
-                                   vfloat16m1_t vs2, float16_t rs1,
+                                   vfloat16m1_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_tum(vbool16_t vm, vfloat32m2_t vd,
                                    vfloat32m2_t vs2, vfloat16m1_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_tum(vbool16_t vm, vfloat32m2_t vd,
-                                   vfloat32m2_t vs2, float16_t rs1,
+                                   vfloat32m2_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_tum(vbool8_t vm, vfloat32m4_t vd,
                                    vfloat16m2_t vs2, vfloat16m2_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_tum(vbool8_t vm, vfloat32m4_t vd,
-                                   vfloat16m2_t vs2, float16_t rs1,
+                                   vfloat16m2_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_tum(vbool8_t vm, vfloat32m4_t vd,
                                    vfloat32m4_t vs2, vfloat16m2_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_tum(vbool8_t vm, vfloat32m4_t vd,
-                                   vfloat32m4_t vs2, float16_t rs1,
+                                   vfloat32m4_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_tum(vbool4_t vm, vfloat32m8_t vd,
                                    vfloat16m4_t vs2, vfloat16m4_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_tum(vbool4_t vm, vfloat32m8_t vd,
-                                   vfloat16m4_t vs2, float16_t rs1,
+                                   vfloat16m4_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_tum(vbool4_t vm, vfloat32m8_t vd,
                                    vfloat32m8_t vs2, vfloat16m4_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_tum(vbool4_t vm, vfloat32m8_t vd,
-                                   vfloat32m8_t vs2, float16_t rs1,
+                                   vfloat32m8_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_tum(vbool64_t vm, vfloat64m1_t vd,
                                    vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -2488,61 +2482,61 @@ vfloat32mf2_t __riscv_vfwadd_vv_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                      vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                      unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                     vfloat16mf4_t vs2, float16_t rs1,
+                                     vfloat16mf4_t vs2, _Float16 rs1,
                                      unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                      vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                      unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                     vfloat32mf2_t vs2, float16_t rs1,
+                                     vfloat32mf2_t vs2, _Float16 rs1,
                                      unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_tumu(vbool32_t vm, vfloat32m1_t vd,
                                     vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                    vfloat16mf2_t vs2, float16_t rs1,
+                                    vfloat16mf2_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_tumu(vbool32_t vm, vfloat32m1_t vd,
                                     vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                    vfloat32m1_t vs2, float16_t rs1,
+                                    vfloat32m1_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_tumu(vbool16_t vm, vfloat32m2_t vd,
                                     vfloat16m1_t vs2, vfloat16m1_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                    vfloat16m1_t vs2, float16_t rs1,
+                                    vfloat16m1_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_tumu(vbool16_t vm, vfloat32m2_t vd,
                                     vfloat32m2_t vs2, vfloat16m1_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                    vfloat32m2_t vs2, float16_t rs1,
+                                    vfloat32m2_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_tumu(vbool8_t vm, vfloat32m4_t vd,
                                     vfloat16m2_t vs2, vfloat16m2_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                    vfloat16m2_t vs2, float16_t rs1,
+                                    vfloat16m2_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_tumu(vbool8_t vm, vfloat32m4_t vd,
                                     vfloat32m4_t vs2, vfloat16m2_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                    vfloat32m4_t vs2, float16_t rs1,
+                                    vfloat32m4_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_tumu(vbool4_t vm, vfloat32m8_t vd,
                                     vfloat16m4_t vs2, vfloat16m4_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                    vfloat16m4_t vs2, float16_t rs1,
+                                    vfloat16m4_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_tumu(vbool4_t vm, vfloat32m8_t vd,
                                     vfloat32m8_t vs2, vfloat16m4_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                    vfloat32m8_t vs2, float16_t rs1,
+                                    vfloat32m8_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_tumu(vbool64_t vm, vfloat64m1_t vd,
                                     vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -2596,61 +2590,61 @@ vfloat32mf2_t __riscv_vfwsub_vv_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                      vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                      unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                     vfloat16mf4_t vs2, float16_t rs1,
+                                     vfloat16mf4_t vs2, _Float16 rs1,
                                      unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                      vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                      unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                     vfloat32mf2_t vs2, float16_t rs1,
+                                     vfloat32mf2_t vs2, _Float16 rs1,
                                      unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_tumu(vbool32_t vm, vfloat32m1_t vd,
                                     vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                    vfloat16mf2_t vs2, float16_t rs1,
+                                    vfloat16mf2_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_tumu(vbool32_t vm, vfloat32m1_t vd,
                                     vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                    vfloat32m1_t vs2, float16_t rs1,
+                                    vfloat32m1_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_tumu(vbool16_t vm, vfloat32m2_t vd,
                                     vfloat16m1_t vs2, vfloat16m1_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                    vfloat16m1_t vs2, float16_t rs1,
+                                    vfloat16m1_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_tumu(vbool16_t vm, vfloat32m2_t vd,
                                     vfloat32m2_t vs2, vfloat16m1_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                    vfloat32m2_t vs2, float16_t rs1,
+                                    vfloat32m2_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_tumu(vbool8_t vm, vfloat32m4_t vd,
                                     vfloat16m2_t vs2, vfloat16m2_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                    vfloat16m2_t vs2, float16_t rs1,
+                                    vfloat16m2_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_tumu(vbool8_t vm, vfloat32m4_t vd,
                                     vfloat32m4_t vs2, vfloat16m2_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_tumu(vbool8_t vm, vfloat32m4_t vd,
-                                    vfloat32m4_t vs2, float16_t rs1,
+                                    vfloat32m4_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_tumu(vbool4_t vm, vfloat32m8_t vd,
                                     vfloat16m4_t vs2, vfloat16m4_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                    vfloat16m4_t vs2, float16_t rs1,
+                                    vfloat16m4_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_tumu(vbool4_t vm, vfloat32m8_t vd,
                                     vfloat32m8_t vs2, vfloat16m4_t vs1,
                                     unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_tumu(vbool4_t vm, vfloat32m8_t vd,
-                                    vfloat32m8_t vs2, float16_t rs1,
+                                    vfloat32m8_t vs2, _Float16 rs1,
                                     unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_tumu(vbool64_t vm, vfloat64m1_t vd,
                                     vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -2705,61 +2699,61 @@ vfloat32mf2_t __riscv_vfwadd_vv_mu(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_vf_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                   vfloat16mf4_t vs2, float16_t rs1,
+                                   vfloat16mf4_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wv_mu(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwadd_wf_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                   vfloat32mf2_t vs2, float16_t rs1,
+                                   vfloat32mf2_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vv_mu(vbool32_t vm, vfloat32m1_t vd,
                                   vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                   unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_vf_mu(vbool32_t vm, vfloat32m1_t vd,
-                                  vfloat16mf2_t vs2, float16_t rs1,
+                                  vfloat16mf2_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wv_mu(vbool32_t vm, vfloat32m1_t vd,
                                   vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                   unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwadd_wf_mu(vbool32_t vm, vfloat32m1_t vd,
-                                  vfloat32m1_t vs2, float16_t rs1,
+                                  vfloat32m1_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vv_mu(vbool16_t vm, vfloat32m2_t vd,
                                   vfloat16m1_t vs2, vfloat16m1_t vs1,
                                   unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_vf_mu(vbool16_t vm, vfloat32m2_t vd,
-                                  vfloat16m1_t vs2, float16_t rs1,
+                                  vfloat16m1_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wv_mu(vbool16_t vm, vfloat32m2_t vd,
                                   vfloat32m2_t vs2, vfloat16m1_t vs1,
                                   unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwadd_wf_mu(vbool16_t vm, vfloat32m2_t vd,
-                                  vfloat32m2_t vs2, float16_t rs1,
+                                  vfloat32m2_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vv_mu(vbool8_t vm, vfloat32m4_t vd,
                                   vfloat16m2_t vs2, vfloat16m2_t vs1,
                                   unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_vf_mu(vbool8_t vm, vfloat32m4_t vd,
-                                  vfloat16m2_t vs2, float16_t rs1,
+                                  vfloat16m2_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wv_mu(vbool8_t vm, vfloat32m4_t vd,
                                   vfloat32m4_t vs2, vfloat16m2_t vs1,
                                   unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwadd_wf_mu(vbool8_t vm, vfloat32m4_t vd,
-                                  vfloat32m4_t vs2, float16_t rs1,
+                                  vfloat32m4_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vv_mu(vbool4_t vm, vfloat32m8_t vd,
                                   vfloat16m4_t vs2, vfloat16m4_t vs1,
                                   unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_vf_mu(vbool4_t vm, vfloat32m8_t vd,
-                                  vfloat16m4_t vs2, float16_t rs1,
+                                  vfloat16m4_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wv_mu(vbool4_t vm, vfloat32m8_t vd,
                                   vfloat32m8_t vs2, vfloat16m4_t vs1,
                                   unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwadd_wf_mu(vbool4_t vm, vfloat32m8_t vd,
-                                  vfloat32m8_t vs2, float16_t rs1,
+                                  vfloat32m8_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwadd_vv_mu(vbool64_t vm, vfloat64m1_t vd,
                                   vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -2813,61 +2807,61 @@ vfloat32mf2_t __riscv_vfwsub_vv_mu(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_vf_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                   vfloat16mf4_t vs2, float16_t rs1,
+                                   vfloat16mf4_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wv_mu(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat32mf2_t vs2, vfloat16mf4_t vs1,
                                    unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwsub_wf_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                   vfloat32mf2_t vs2, float16_t rs1,
+                                   vfloat32mf2_t vs2, _Float16 rs1,
                                    unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vv_mu(vbool32_t vm, vfloat32m1_t vd,
                                   vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                   unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_vf_mu(vbool32_t vm, vfloat32m1_t vd,
-                                  vfloat16mf2_t vs2, float16_t rs1,
+                                  vfloat16mf2_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wv_mu(vbool32_t vm, vfloat32m1_t vd,
                                   vfloat32m1_t vs2, vfloat16mf2_t vs1,
                                   unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwsub_wf_mu(vbool32_t vm, vfloat32m1_t vd,
-                                  vfloat32m1_t vs2, float16_t rs1,
+                                  vfloat32m1_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vv_mu(vbool16_t vm, vfloat32m2_t vd,
                                   vfloat16m1_t vs2, vfloat16m1_t vs1,
                                   unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_vf_mu(vbool16_t vm, vfloat32m2_t vd,
-                                  vfloat16m1_t vs2, float16_t rs1,
+                                  vfloat16m1_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wv_mu(vbool16_t vm, vfloat32m2_t vd,
                                   vfloat32m2_t vs2, vfloat16m1_t vs1,
                                   unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwsub_wf_mu(vbool16_t vm, vfloat32m2_t vd,
-                                  vfloat32m2_t vs2, float16_t rs1,
+                                  vfloat32m2_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vv_mu(vbool8_t vm, vfloat32m4_t vd,
                                   vfloat16m2_t vs2, vfloat16m2_t vs1,
                                   unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_vf_mu(vbool8_t vm, vfloat32m4_t vd,
-                                  vfloat16m2_t vs2, float16_t rs1,
+                                  vfloat16m2_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wv_mu(vbool8_t vm, vfloat32m4_t vd,
                                   vfloat32m4_t vs2, vfloat16m2_t vs1,
                                   unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwsub_wf_mu(vbool8_t vm, vfloat32m4_t vd,
-                                  vfloat32m4_t vs2, float16_t rs1,
+                                  vfloat32m4_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vv_mu(vbool4_t vm, vfloat32m8_t vd,
                                   vfloat16m4_t vs2, vfloat16m4_t vs1,
                                   unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_vf_mu(vbool4_t vm, vfloat32m8_t vd,
-                                  vfloat16m4_t vs2, float16_t rs1,
+                                  vfloat16m4_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wv_mu(vbool4_t vm, vfloat32m8_t vd,
                                   vfloat32m8_t vs2, vfloat16m4_t vs1,
                                   unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwsub_wf_mu(vbool4_t vm, vfloat32m8_t vd,
-                                  vfloat32m8_t vs2, float16_t rs1,
+                                  vfloat32m8_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwsub_vv_mu(vbool64_t vm, vfloat64m1_t vd,
                                   vfloat32mf2_t vs2, vfloat32mf2_t vs1,
@@ -2927,26 +2921,26 @@ vfloat64m8_t __riscv_vfwsub_wf_mu(vbool8_t vm, vfloat64m8_t vd,
 vfloat16mf4_t __riscv_vfmul_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfmul_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmul_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfmul_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmul_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfmul_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfmul_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m2_t __riscv_vfmul_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfmul_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfmul_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m4_t __riscv_vfmul_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfmul_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfmul_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m8_t __riscv_vfmul_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfmul_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfmul_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat32mf2_t __riscv_vfmul_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, size_t vl);
@@ -2987,26 +2981,26 @@ vfloat64m8_t __riscv_vfmul_tu(vfloat64m8_t vd, vfloat64m8_t vs2, float64_t rs1,
 vfloat16mf4_t __riscv_vfdiv_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfdiv_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfdiv_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfdiv_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfdiv_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m2_t __riscv_vfdiv_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfdiv_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfdiv_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m4_t __riscv_vfdiv_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfdiv_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfdiv_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m8_t __riscv_vfdiv_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfdiv_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfdiv_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat32mf2_t __riscv_vfdiv_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, size_t vl);
@@ -3045,16 +3039,16 @@ vfloat64m8_t __riscv_vfdiv_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfdiv_tu(vfloat64m8_t vd, vfloat64m8_t vs2, float64_t rs1,
                               size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                float16_t rs1, size_t vl);
-vfloat16m1_t __riscv_vfrdiv_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1,
+                                _Float16 rs1, size_t vl);
+vfloat16m1_t __riscv_vfrdiv_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1,
                                size_t vl);
-vfloat16m2_t __riscv_vfrdiv_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfrdiv_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1,
                                size_t vl);
-vfloat16m4_t __riscv_vfrdiv_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfrdiv_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1,
                                size_t vl);
-vfloat16m8_t __riscv_vfrdiv_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfrdiv_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                 float32_t rs1, size_t vl);
@@ -3079,28 +3073,28 @@ vfloat16mf4_t __riscv_vfmul_tum(vbool64_t vm, vfloat16mf4_t vd,
                                 vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 size_t vl);
 vfloat16mf4_t __riscv_vfmul_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmul_tum(vbool32_t vm, vfloat16mf2_t vd,
                                 vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                 size_t vl);
 vfloat16mf2_t __riscv_vfmul_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmul_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfmul_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmul_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfmul_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmul_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfmul_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmul_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfmul_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmul_tum(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                 size_t vl);
@@ -3142,28 +3136,28 @@ vfloat16mf4_t __riscv_vfdiv_tum(vbool64_t vm, vfloat16mf4_t vd,
                                 vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 size_t vl);
 vfloat16mf4_t __riscv_vfdiv_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_tum(vbool32_t vm, vfloat16mf2_t vd,
                                 vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                 size_t vl);
 vfloat16mf2_t __riscv_vfdiv_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfdiv_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfdiv_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfdiv_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfdiv_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfdiv_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfdiv_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfdiv_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfdiv_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_tum(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                 size_t vl);
@@ -3202,17 +3196,17 @@ vfloat64m8_t __riscv_vfdiv_tum(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfdiv_tum(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
                                float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                 vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                 vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfrdiv_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfrdiv_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfrdiv_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfrdiv_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_tum(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfrdiv_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2,
@@ -3236,28 +3230,28 @@ vfloat16mf4_t __riscv_vfmul_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                  size_t vl);
 vfloat16mf4_t __riscv_vfmul_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                 vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmul_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfmul_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                 vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmul_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                 vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfmul_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmul_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                 vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfmul_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmul_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                 vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfmul_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmul_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                 vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfmul_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmul_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                  size_t vl);
@@ -3299,28 +3293,28 @@ vfloat16mf4_t __riscv_vfdiv_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                  size_t vl);
 vfloat16mf4_t __riscv_vfdiv_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                 vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfdiv_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                 vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfdiv_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                 vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfdiv_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfdiv_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                 vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfdiv_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfdiv_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                 vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfdiv_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfdiv_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                 vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfdiv_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                  size_t vl);
@@ -3359,17 +3353,17 @@ vfloat64m8_t __riscv_vfdiv_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfdiv_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
                                 float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                  vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                  vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfrdiv_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                 vfloat16m1_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfrdiv_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfrdiv_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfrdiv_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfrdiv_tumu(vbool32_t vm, vfloat32m1_t vd,
@@ -3392,27 +3386,27 @@ vfloat64m8_t __riscv_vfrdiv_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfmul_mu(vbool64_t vm, vfloat16mf4_t vd,
                                vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfmul_mu(vbool64_t vm, vfloat16mf4_t vd,
-                               vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                               vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmul_mu(vbool32_t vm, vfloat16mf2_t vd,
                                vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfmul_mu(vbool32_t vm, vfloat16mf2_t vd,
-                               vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                               vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmul_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfmul_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmul_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfmul_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmul_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfmul_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmul_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfmul_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmul_mu(vbool64_t vm, vfloat32mf2_t vd,
                                vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmul_mu(vbool64_t vm, vfloat32mf2_t vd,
@@ -3452,27 +3446,27 @@ vfloat64m8_t __riscv_vfmul_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfdiv_mu(vbool64_t vm, vfloat16mf4_t vd,
                                vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfdiv_mu(vbool64_t vm, vfloat16mf4_t vd,
-                               vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                               vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_mu(vbool32_t vm, vfloat16mf2_t vd,
                                vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_mu(vbool32_t vm, vfloat16mf2_t vd,
-                               vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                               vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfdiv_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfdiv_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfdiv_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfdiv_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfdiv_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfdiv_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfdiv_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfdiv_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_mu(vbool64_t vm, vfloat32mf2_t vd,
                                vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_mu(vbool64_t vm, vfloat32mf2_t vd,
@@ -3510,17 +3504,17 @@ vfloat64m8_t __riscv_vfdiv_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfdiv_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
                               float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfrdiv_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfrdiv_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfrdiv_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfrdiv_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_mu(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs2, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfrdiv_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m1_t vs2,
@@ -3542,26 +3536,26 @@ vfloat64m8_t __riscv_vfrdiv_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfmul_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                vfloat16mf4_t vs1, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmul_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmul_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmul_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmul_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmul_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfmul_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1,
                               unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmul_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmul_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfmul_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1,
                               unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmul_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmul_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfmul_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1,
                               unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmul_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmul_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfmul_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1,
                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmul_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, unsigned int frm, size_t vl);
@@ -3602,26 +3596,26 @@ vfloat64m8_t __riscv_vfmul_tu(vfloat64m8_t vd, vfloat64m8_t vs2, float64_t rs1,
 vfloat16mf4_t __riscv_vfdiv_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                vfloat16mf4_t vs1, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfdiv_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfdiv_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfdiv_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfdiv_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1,
                               unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfdiv_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfdiv_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfdiv_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1,
                               unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfdiv_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfdiv_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfdiv_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1,
                               unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfdiv_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfdiv_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfdiv_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1,
                               unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, unsigned int frm, size_t vl);
@@ -3660,16 +3654,16 @@ vfloat64m8_t __riscv_vfdiv_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfdiv_tu(vfloat64m8_t vd, vfloat64m8_t vs2, float64_t rs1,
                               unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfrdiv_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1,
+                                _Float16 rs1, unsigned int frm, size_t vl);
+vfloat16m1_t __riscv_vfrdiv_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfrdiv_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfrdiv_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfrdiv_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfrdiv_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfrdiv_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfrdiv_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                 float32_t rs1, unsigned int frm, size_t vl);
@@ -3694,30 +3688,30 @@ vfloat16mf4_t __riscv_vfmul_tum(vbool64_t vm, vfloat16mf4_t vd,
                                 vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmul_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                vfloat16mf4_t vs2, float16_t rs1,
+                                vfloat16mf4_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmul_tum(vbool32_t vm, vfloat16mf2_t vd,
                                 vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                 unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmul_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                vfloat16mf2_t vs2, float16_t rs1,
+                                vfloat16mf2_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmul_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                vfloat16m1_t vs1, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmul_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmul_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                vfloat16m2_t vs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmul_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmul_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                vfloat16m4_t vs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmul_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmul_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                vfloat16m8_t vs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmul_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmul_tum(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                 unsigned int frm, size_t vl);
@@ -3760,30 +3754,30 @@ vfloat16mf4_t __riscv_vfdiv_tum(vbool64_t vm, vfloat16mf4_t vd,
                                 vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfdiv_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                vfloat16mf4_t vs2, float16_t rs1,
+                                vfloat16mf4_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_tum(vbool32_t vm, vfloat16mf2_t vd,
                                 vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                 unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                vfloat16mf2_t vs2, float16_t rs1,
+                                vfloat16mf2_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfdiv_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                vfloat16m1_t vs1, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfdiv_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfdiv_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                vfloat16m2_t vs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfdiv_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfdiv_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                vfloat16m4_t vs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfdiv_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfdiv_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                vfloat16m8_t vs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfdiv_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_tum(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                 unsigned int frm, size_t vl);
@@ -3823,19 +3817,19 @@ vfloat64m8_t __riscv_vfdiv_tum(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfdiv_tum(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
                                float64_t rs1, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                 vfloat16mf4_t vs2, float16_t rs1,
+                                 vfloat16mf4_t vs2, _Float16 rs1,
                                  unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                 vfloat16mf2_t vs2, float16_t rs1,
+                                 vfloat16mf2_t vs2, _Float16 rs1,
                                  unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfrdiv_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfrdiv_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfrdiv_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfrdiv_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_tum(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs2, float32_t rs1,
                                  unsigned int frm, size_t vl);
@@ -3860,30 +3854,30 @@ vfloat16mf4_t __riscv_vfmul_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                  unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmul_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                 vfloat16mf4_t vs2, float16_t rs1,
+                                 vfloat16mf4_t vs2, _Float16 rs1,
                                  unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmul_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                  unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmul_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                 vfloat16mf2_t vs2, float16_t rs1,
+                                 vfloat16mf2_t vs2, _Float16 rs1,
                                  unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmul_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                 vfloat16m1_t vs1, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmul_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmul_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                 vfloat16m2_t vs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmul_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmul_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                 vfloat16m4_t vs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmul_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmul_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                 vfloat16m8_t vs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmul_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmul_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                  unsigned int frm, size_t vl);
@@ -3926,30 +3920,30 @@ vfloat16mf4_t __riscv_vfdiv_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                  unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfdiv_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                 vfloat16mf4_t vs2, float16_t rs1,
+                                 vfloat16mf4_t vs2, _Float16 rs1,
                                  unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                  unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                 vfloat16mf2_t vs2, float16_t rs1,
+                                 vfloat16mf2_t vs2, _Float16 rs1,
                                  unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfdiv_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                 vfloat16m1_t vs1, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfdiv_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfdiv_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                 vfloat16m2_t vs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfdiv_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfdiv_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                 vfloat16m4_t vs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfdiv_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfdiv_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                 vfloat16m8_t vs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfdiv_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                  unsigned int frm, size_t vl);
@@ -3989,20 +3983,20 @@ vfloat64m8_t __riscv_vfdiv_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfdiv_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
                                 float64_t rs1, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                  vfloat16mf4_t vs2, float16_t rs1,
+                                  vfloat16mf4_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                  vfloat16mf2_t vs2, float16_t rs1,
+                                  vfloat16mf2_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfrdiv_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                 vfloat16m1_t vs2, float16_t rs1,
+                                 vfloat16m1_t vs2, _Float16 rs1,
                                  unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfrdiv_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                 float16_t rs1, unsigned int frm, size_t vl);
+                                 _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfrdiv_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                 float16_t rs1, unsigned int frm, size_t vl);
+                                 _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfrdiv_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                 float16_t rs1, unsigned int frm, size_t vl);
+                                 _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs2, float32_t rs1,
                                   unsigned int frm, size_t vl);
@@ -4032,30 +4026,30 @@ vfloat16mf4_t __riscv_vfmul_mu(vbool64_t vm, vfloat16mf4_t vd,
                                vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmul_mu(vbool64_t vm, vfloat16mf4_t vd,
-                               vfloat16mf4_t vs2, float16_t rs1,
+                               vfloat16mf4_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmul_mu(vbool32_t vm, vfloat16mf2_t vd,
                                vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmul_mu(vbool32_t vm, vfloat16mf2_t vd,
-                               vfloat16mf2_t vs2, float16_t rs1,
+                               vfloat16mf2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmul_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmul_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                              float16_t rs1, unsigned int frm, size_t vl);
+                              _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmul_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmul_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                              float16_t rs1, unsigned int frm, size_t vl);
+                              _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmul_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmul_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                              float16_t rs1, unsigned int frm, size_t vl);
+                              _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmul_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmul_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                              float16_t rs1, unsigned int frm, size_t vl);
+                              _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmul_mu(vbool64_t vm, vfloat32mf2_t vd,
                                vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                unsigned int frm, size_t vl);
@@ -4098,30 +4092,30 @@ vfloat16mf4_t __riscv_vfdiv_mu(vbool64_t vm, vfloat16mf4_t vd,
                                vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfdiv_mu(vbool64_t vm, vfloat16mf4_t vd,
-                               vfloat16mf4_t vs2, float16_t rs1,
+                               vfloat16mf4_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_mu(vbool32_t vm, vfloat16mf2_t vd,
                                vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfdiv_mu(vbool32_t vm, vfloat16mf2_t vd,
-                               vfloat16mf2_t vs2, float16_t rs1,
+                               vfloat16mf2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfdiv_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfdiv_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                              float16_t rs1, unsigned int frm, size_t vl);
+                              _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfdiv_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfdiv_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                              float16_t rs1, unsigned int frm, size_t vl);
+                              _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfdiv_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfdiv_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                              float16_t rs1, unsigned int frm, size_t vl);
+                              _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfdiv_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfdiv_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                              float16_t rs1, unsigned int frm, size_t vl);
+                              _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfdiv_mu(vbool64_t vm, vfloat32mf2_t vd,
                                vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                unsigned int frm, size_t vl);
@@ -4161,19 +4155,19 @@ vfloat64m8_t __riscv_vfdiv_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat64m8_t __riscv_vfdiv_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
                               float64_t rs1, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfrdiv_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                vfloat16mf4_t vs2, float16_t rs1,
+                                vfloat16mf4_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfrdiv_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                vfloat16mf2_t vs2, float16_t rs1,
+                                vfloat16mf2_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfrdiv_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfrdiv_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfrdiv_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfrdiv_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfrdiv_mu(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs2, float32_t rs1,
                                 unsigned int frm, size_t vl);
@@ -4203,22 +4197,22 @@ vfloat64m8_t __riscv_vfrdiv_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat32mf2_t __riscv_vfwmul_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
                                 vfloat16mf4_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfwmul_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwmul_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, size_t vl);
-vfloat32m1_t __riscv_vfwmul_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                               float16_t rs1, size_t vl);
+vfloat32m1_t __riscv_vfwmul_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1,
+                               size_t vl);
 vfloat32m2_t __riscv_vfwmul_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
                                vfloat16m1_t vs1, size_t vl);
-vfloat32m2_t __riscv_vfwmul_tu(vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwmul_tu(vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m4_t __riscv_vfwmul_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
                                vfloat16m2_t vs1, size_t vl);
-vfloat32m4_t __riscv_vfwmul_tu(vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwmul_tu(vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32m8_t __riscv_vfwmul_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
                                vfloat16m4_t vs1, size_t vl);
-vfloat32m8_t __riscv_vfwmul_tu(vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwmul_tu(vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat64m1_t __riscv_vfwmul_tu(vfloat64m1_t vd, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, size_t vl);
@@ -4241,24 +4235,24 @@ vfloat32mf2_t __riscv_vfwmul_tum(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                  size_t vl);
 vfloat32mf2_t __riscv_vfwmul_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                 vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwmul_tum(vbool32_t vm, vfloat32m1_t vd,
                                 vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                 size_t vl);
 vfloat32m1_t __riscv_vfwmul_tum(vbool32_t vm, vfloat32m1_t vd,
-                                vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwmul_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2,
                                 vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwmul_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwmul_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2,
                                 vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwmul_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwmul_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2,
                                 vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwmul_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwmul_tum(vbool64_t vm, vfloat64m1_t vd,
                                 vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                 size_t vl);
@@ -4281,24 +4275,24 @@ vfloat32mf2_t __riscv_vfwmul_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                   size_t vl);
 vfloat32mf2_t __riscv_vfwmul_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                  vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwmul_tumu(vbool32_t vm, vfloat32m1_t vd,
                                  vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                  size_t vl);
 vfloat32m1_t __riscv_vfwmul_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                 vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwmul_tumu(vbool16_t vm, vfloat32m2_t vd,
                                  vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwmul_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                 vfloat16m1_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwmul_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2,
                                  vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwmul_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwmul_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2,
                                  vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwmul_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwmul_tumu(vbool64_t vm, vfloat64m1_t vd,
                                  vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                  size_t vl);
@@ -4321,23 +4315,23 @@ vfloat32mf2_t __riscv_vfwmul_mu(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 size_t vl);
 vfloat32mf2_t __riscv_vfwmul_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat32m1_t __riscv_vfwmul_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, size_t vl);
 vfloat32m1_t __riscv_vfwmul_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat32m2_t __riscv_vfwmul_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2,
                                vfloat16m1_t vs1, size_t vl);
 vfloat32m2_t __riscv_vfwmul_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat32m4_t __riscv_vfwmul_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2,
                                vfloat16m2_t vs1, size_t vl);
 vfloat32m4_t __riscv_vfwmul_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat32m8_t __riscv_vfwmul_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2,
                                vfloat16m4_t vs1, size_t vl);
 vfloat32m8_t __riscv_vfwmul_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat64m1_t __riscv_vfwmul_mu(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, size_t vl);
 vfloat64m1_t __riscv_vfwmul_mu(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs2,
@@ -4357,22 +4351,22 @@ vfloat64m8_t __riscv_vfwmul_mu(vbool8_t vm, vfloat64m8_t vd, vfloat32m4_t vs2,
 vfloat32mf2_t __riscv_vfwmul_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
                                 vfloat16mf4_t vs1, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmul_tu(vfloat32mf2_t vd, vfloat16mf4_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmul_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmul_tu(vfloat32m1_t vd, vfloat16mf2_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+vfloat32m1_t __riscv_vfwmul_tu(vfloat32m1_t vd, vfloat16mf2_t vs2, _Float16 rs1,
+                               unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmul_tu(vfloat32m2_t vd, vfloat16m1_t vs2,
                                vfloat16m1_t vs1, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmul_tu(vfloat32m2_t vd, vfloat16m1_t vs2, float16_t rs1,
+vfloat32m2_t __riscv_vfwmul_tu(vfloat32m2_t vd, vfloat16m1_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmul_tu(vfloat32m4_t vd, vfloat16m2_t vs2,
                                vfloat16m2_t vs1, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmul_tu(vfloat32m4_t vd, vfloat16m2_t vs2, float16_t rs1,
+vfloat32m4_t __riscv_vfwmul_tu(vfloat32m4_t vd, vfloat16m2_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmul_tu(vfloat32m8_t vd, vfloat16m4_t vs2,
                                vfloat16m4_t vs1, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmul_tu(vfloat32m8_t vd, vfloat16m4_t vs2, float16_t rs1,
+vfloat32m8_t __riscv_vfwmul_tu(vfloat32m8_t vd, vfloat16m4_t vs2, _Float16 rs1,
                                unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmul_tu(vfloat64m1_t vd, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, unsigned int frm, size_t vl);
@@ -4395,26 +4389,26 @@ vfloat32mf2_t __riscv_vfwmul_tum(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                  unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmul_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                 vfloat16mf4_t vs2, float16_t rs1,
+                                 vfloat16mf4_t vs2, _Float16 rs1,
                                  unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmul_tum(vbool32_t vm, vfloat32m1_t vd,
                                 vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                 unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmul_tum(vbool32_t vm, vfloat32m1_t vd,
-                                vfloat16mf2_t vs2, float16_t rs1,
+                                vfloat16mf2_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmul_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2,
                                 vfloat16m1_t vs1, unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmul_tum(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmul_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2,
                                 vfloat16m2_t vs1, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmul_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmul_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2,
                                 vfloat16m4_t vs1, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmul_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, unsigned int frm, size_t vl);
+                                _Float16 rs1, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmul_tum(vbool64_t vm, vfloat64m1_t vd,
                                 vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                 unsigned int frm, size_t vl);
@@ -4438,28 +4432,28 @@ vfloat32mf2_t __riscv_vfwmul_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                   unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmul_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                  vfloat16mf4_t vs2, float16_t rs1,
+                                  vfloat16mf4_t vs2, _Float16 rs1,
                                   unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmul_tumu(vbool32_t vm, vfloat32m1_t vd,
                                  vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                  unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmul_tumu(vbool32_t vm, vfloat32m1_t vd,
-                                 vfloat16mf2_t vs2, float16_t rs1,
+                                 vfloat16mf2_t vs2, _Float16 rs1,
                                  unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmul_tumu(vbool16_t vm, vfloat32m2_t vd,
                                  vfloat16m1_t vs2, vfloat16m1_t vs1,
                                  unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmul_tumu(vbool16_t vm, vfloat32m2_t vd,
-                                 vfloat16m1_t vs2, float16_t rs1,
+                                 vfloat16m1_t vs2, _Float16 rs1,
                                  unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmul_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2,
                                  vfloat16m2_t vs1, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmul_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2,
-                                 float16_t rs1, unsigned int frm, size_t vl);
+                                 _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmul_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2,
                                  vfloat16m4_t vs1, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmul_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2,
-                                 float16_t rs1, unsigned int frm, size_t vl);
+                                 _Float16 rs1, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmul_tumu(vbool64_t vm, vfloat64m1_t vd,
                                  vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                  unsigned int frm, size_t vl);
@@ -4487,24 +4481,24 @@ vfloat32mf2_t __riscv_vfwmul_mu(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwmul_mu(vbool64_t vm, vfloat32mf2_t vd,
-                                vfloat16mf4_t vs2, float16_t rs1,
+                                vfloat16mf4_t vs2, _Float16 rs1,
                                 unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmul_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwmul_mu(vbool32_t vm, vfloat32m1_t vd, vfloat16mf2_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmul_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2,
                                vfloat16m1_t vs1, unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmul_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmul_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2,
                                vfloat16m2_t vs1, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmul_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmul_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2,
                                vfloat16m4_t vs1, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmul_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs2,
-                               float16_t rs1, unsigned int frm, size_t vl);
+                               _Float16 rs1, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmul_mu(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmul_mu(vbool64_t vm, vfloat64m1_t vd, vfloat32mf2_t vs2,
@@ -4530,27 +4524,27 @@ vfloat64m8_t __riscv_vfwmul_mu(vbool8_t vm, vfloat64m8_t vd, vfloat32m4_t vs2,
 ----
 vfloat16mf4_t __riscv_vfmacc_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                 vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmacc_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmacc_tu(vfloat16mf4_t vd, _Float16 rs1,
                                 vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmacc_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                 vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmacc_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmacc_tu(vfloat16mf2_t vd, _Float16 rs1,
                                 vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmacc_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmacc_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmacc_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                                size_t vl);
 vfloat16m2_t __riscv_vfmacc_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmacc_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmacc_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                                size_t vl);
 vfloat16m4_t __riscv_vfmacc_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmacc_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmacc_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                                size_t vl);
 vfloat16m8_t __riscv_vfmacc_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmacc_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmacc_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                                size_t vl);
 vfloat32mf2_t __riscv_vfmacc_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                 vfloat32mf2_t vs2, size_t vl);
@@ -4590,28 +4584,28 @@ vfloat64m8_t __riscv_vfmacc_tu(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                                size_t vl);
 vfloat16mf4_t __riscv_vfnmacc_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                  vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmacc_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmacc_tu(vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                  vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmacc_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmacc_tu(vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmacc_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmacc_tu(vfloat16m1_t vd, float16_t rs1,
-                                vfloat16m1_t vs2, size_t vl);
+vfloat16m1_t __riscv_vfnmacc_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
+                                size_t vl);
 vfloat16m2_t __riscv_vfnmacc_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmacc_tu(vfloat16m2_t vd, float16_t rs1,
-                                vfloat16m2_t vs2, size_t vl);
+vfloat16m2_t __riscv_vfnmacc_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
+                                size_t vl);
 vfloat16m4_t __riscv_vfnmacc_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmacc_tu(vfloat16m4_t vd, float16_t rs1,
-                                vfloat16m4_t vs2, size_t vl);
+vfloat16m4_t __riscv_vfnmacc_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
+                                size_t vl);
 vfloat16m8_t __riscv_vfnmacc_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmacc_tu(vfloat16m8_t vd, float16_t rs1,
-                                vfloat16m8_t vs2, size_t vl);
+vfloat16m8_t __riscv_vfnmacc_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
+                                size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                  vfloat32mf2_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_tu(vfloat32mf2_t vd, float32_t rs1,
@@ -4650,27 +4644,27 @@ vfloat64m8_t __riscv_vfnmacc_tu(vfloat64m8_t vd, float64_t rs1,
                                 vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmsac_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                 vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmsac_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsac_tu(vfloat16mf4_t vd, _Float16 rs1,
                                 vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsac_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                 vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmsac_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsac_tu(vfloat16mf2_t vd, _Float16 rs1,
                                 vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmsac_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmsac_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmsac_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                                size_t vl);
 vfloat16m2_t __riscv_vfmsac_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmsac_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmsac_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                                size_t vl);
 vfloat16m4_t __riscv_vfmsac_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmsac_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmsac_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                                size_t vl);
 vfloat16m8_t __riscv_vfmsac_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmsac_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmsac_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                                size_t vl);
 vfloat32mf2_t __riscv_vfmsac_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                 vfloat32mf2_t vs2, size_t vl);
@@ -4710,28 +4704,28 @@ vfloat64m8_t __riscv_vfmsac_tu(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                                size_t vl);
 vfloat16mf4_t __riscv_vfnmsac_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                  vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmsac_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsac_tu(vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                  vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmsac_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsac_tu(vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmsac_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsac_tu(vfloat16m1_t vd, float16_t rs1,
-                                vfloat16m1_t vs2, size_t vl);
+vfloat16m1_t __riscv_vfnmsac_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
+                                size_t vl);
 vfloat16m2_t __riscv_vfnmsac_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsac_tu(vfloat16m2_t vd, float16_t rs1,
-                                vfloat16m2_t vs2, size_t vl);
+vfloat16m2_t __riscv_vfnmsac_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
+                                size_t vl);
 vfloat16m4_t __riscv_vfnmsac_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsac_tu(vfloat16m4_t vd, float16_t rs1,
-                                vfloat16m4_t vs2, size_t vl);
+vfloat16m4_t __riscv_vfnmsac_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
+                                size_t vl);
 vfloat16m8_t __riscv_vfnmsac_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsac_tu(vfloat16m8_t vd, float16_t rs1,
-                                vfloat16m8_t vs2, size_t vl);
+vfloat16m8_t __riscv_vfnmsac_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
+                                size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                  vfloat32mf2_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_tu(vfloat32mf2_t vd, float32_t rs1,
@@ -4770,27 +4764,27 @@ vfloat64m8_t __riscv_vfnmsac_tu(vfloat64m8_t vd, float64_t rs1,
                                 vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmadd_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                 vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmadd_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmadd_tu(vfloat16mf4_t vd, _Float16 rs1,
                                 vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmadd_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                 vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmadd_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmadd_tu(vfloat16mf2_t vd, _Float16 rs1,
                                 vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmadd_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmadd_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmadd_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                                size_t vl);
 vfloat16m2_t __riscv_vfmadd_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmadd_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmadd_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                                size_t vl);
 vfloat16m4_t __riscv_vfmadd_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmadd_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmadd_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                                size_t vl);
 vfloat16m8_t __riscv_vfmadd_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmadd_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmadd_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                                size_t vl);
 vfloat32mf2_t __riscv_vfmadd_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                 vfloat32mf2_t vs2, size_t vl);
@@ -4830,28 +4824,28 @@ vfloat64m8_t __riscv_vfmadd_tu(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                                size_t vl);
 vfloat16mf4_t __riscv_vfnmadd_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                  vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmadd_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmadd_tu(vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                  vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmadd_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmadd_tu(vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmadd_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmadd_tu(vfloat16m1_t vd, float16_t rs1,
-                                vfloat16m1_t vs2, size_t vl);
+vfloat16m1_t __riscv_vfnmadd_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
+                                size_t vl);
 vfloat16m2_t __riscv_vfnmadd_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmadd_tu(vfloat16m2_t vd, float16_t rs1,
-                                vfloat16m2_t vs2, size_t vl);
+vfloat16m2_t __riscv_vfnmadd_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
+                                size_t vl);
 vfloat16m4_t __riscv_vfnmadd_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmadd_tu(vfloat16m4_t vd, float16_t rs1,
-                                vfloat16m4_t vs2, size_t vl);
+vfloat16m4_t __riscv_vfnmadd_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
+                                size_t vl);
 vfloat16m8_t __riscv_vfnmadd_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmadd_tu(vfloat16m8_t vd, float16_t rs1,
-                                vfloat16m8_t vs2, size_t vl);
+vfloat16m8_t __riscv_vfnmadd_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
+                                size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                  vfloat32mf2_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_tu(vfloat32mf2_t vd, float32_t rs1,
@@ -4890,27 +4884,27 @@ vfloat64m8_t __riscv_vfnmadd_tu(vfloat64m8_t vd, float64_t rs1,
                                 vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmsub_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                 vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfmsub_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsub_tu(vfloat16mf4_t vd, _Float16 rs1,
                                 vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsub_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                 vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfmsub_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsub_tu(vfloat16mf2_t vd, _Float16 rs1,
                                 vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmsub_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmsub_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmsub_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                                size_t vl);
 vfloat16m2_t __riscv_vfmsub_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmsub_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmsub_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                                size_t vl);
 vfloat16m4_t __riscv_vfmsub_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmsub_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmsub_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                                size_t vl);
 vfloat16m8_t __riscv_vfmsub_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmsub_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmsub_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                                size_t vl);
 vfloat32mf2_t __riscv_vfmsub_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                 vfloat32mf2_t vs2, size_t vl);
@@ -4950,28 +4944,28 @@ vfloat64m8_t __riscv_vfmsub_tu(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
                                size_t vl);
 vfloat16mf4_t __riscv_vfnmsub_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                  vfloat16mf4_t vs2, size_t vl);
-vfloat16mf4_t __riscv_vfnmsub_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsub_tu(vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                  vfloat16mf2_t vs2, size_t vl);
-vfloat16mf2_t __riscv_vfnmsub_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsub_tu(vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmsub_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsub_tu(vfloat16m1_t vd, float16_t rs1,
-                                vfloat16m1_t vs2, size_t vl);
+vfloat16m1_t __riscv_vfnmsub_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
+                                size_t vl);
 vfloat16m2_t __riscv_vfnmsub_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsub_tu(vfloat16m2_t vd, float16_t rs1,
-                                vfloat16m2_t vs2, size_t vl);
+vfloat16m2_t __riscv_vfnmsub_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
+                                size_t vl);
 vfloat16m4_t __riscv_vfnmsub_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsub_tu(vfloat16m4_t vd, float16_t rs1,
-                                vfloat16m4_t vs2, size_t vl);
+vfloat16m4_t __riscv_vfnmsub_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
+                                size_t vl);
 vfloat16m8_t __riscv_vfnmsub_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsub_tu(vfloat16m8_t vd, float16_t rs1,
-                                vfloat16m8_t vs2, size_t vl);
+vfloat16m8_t __riscv_vfnmsub_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
+                                size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                  vfloat32mf2_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_tu(vfloat32mf2_t vd, float32_t rs1,
@@ -5012,28 +5006,28 @@ vfloat64m8_t __riscv_vfnmsub_tu(vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmacc_tum(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  size_t vl);
-vfloat16mf4_t __riscv_vfmacc_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmacc_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmacc_tum(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  size_t vl);
-vfloat16mf2_t __riscv_vfmacc_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmacc_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmacc_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmacc_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmacc_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                 vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmacc_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmacc_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmacc_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                 vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmacc_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmacc_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmacc_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                 vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmacc_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmacc_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmacc_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                 vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmacc_tum(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5075,28 +5069,28 @@ vfloat64m8_t __riscv_vfmacc_tum(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmacc_tum(vbool64_t vm, vfloat16mf4_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   size_t vl);
-vfloat16mf4_t __riscv_vfnmacc_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmacc_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                   vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_tum(vbool32_t vm, vfloat16mf2_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   size_t vl);
-vfloat16mf2_t __riscv_vfnmacc_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmacc_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                   vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmacc_tum(vbool16_t vm, vfloat16m1_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmacc_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmacc_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                  vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmacc_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmacc_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmacc_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                  vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmacc_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmacc_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmacc_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                  vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmacc_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                  vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmacc_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmacc_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                  vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_tum(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5138,28 +5132,28 @@ vfloat64m8_t __riscv_vfnmacc_tum(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmsac_tum(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  size_t vl);
-vfloat16mf4_t __riscv_vfmsac_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsac_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsac_tum(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  size_t vl);
-vfloat16mf2_t __riscv_vfmsac_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsac_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmsac_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmsac_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsac_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                 vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmsac_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmsac_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsac_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                 vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmsac_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmsac_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsac_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                 vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmsac_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmsac_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsac_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                 vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmsac_tum(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5201,28 +5195,28 @@ vfloat64m8_t __riscv_vfmsac_tum(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmsac_tum(vbool64_t vm, vfloat16mf4_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   size_t vl);
-vfloat16mf4_t __riscv_vfnmsac_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsac_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                   vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_tum(vbool32_t vm, vfloat16mf2_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   size_t vl);
-vfloat16mf2_t __riscv_vfnmsac_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsac_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                   vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmsac_tum(vbool16_t vm, vfloat16m1_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsac_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsac_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                  vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmsac_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsac_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsac_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                  vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmsac_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsac_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsac_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                  vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmsac_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                  vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsac_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsac_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                  vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_tum(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5264,28 +5258,28 @@ vfloat64m8_t __riscv_vfnmsac_tum(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmadd_tum(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  size_t vl);
-vfloat16mf4_t __riscv_vfmadd_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmadd_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmadd_tum(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  size_t vl);
-vfloat16mf2_t __riscv_vfmadd_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmadd_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmadd_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmadd_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmadd_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                 vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmadd_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmadd_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmadd_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                 vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmadd_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmadd_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmadd_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                 vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmadd_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmadd_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmadd_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                 vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmadd_tum(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5327,28 +5321,28 @@ vfloat64m8_t __riscv_vfmadd_tum(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmadd_tum(vbool64_t vm, vfloat16mf4_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   size_t vl);
-vfloat16mf4_t __riscv_vfnmadd_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmadd_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                   vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_tum(vbool32_t vm, vfloat16mf2_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   size_t vl);
-vfloat16mf2_t __riscv_vfnmadd_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmadd_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                   vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmadd_tum(vbool16_t vm, vfloat16m1_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmadd_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmadd_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                  vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmadd_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmadd_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmadd_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                  vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmadd_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmadd_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmadd_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                  vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmadd_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                  vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmadd_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmadd_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                  vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_tum(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5390,28 +5384,28 @@ vfloat64m8_t __riscv_vfnmadd_tum(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmsub_tum(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  size_t vl);
-vfloat16mf4_t __riscv_vfmsub_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsub_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsub_tum(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  size_t vl);
-vfloat16mf2_t __riscv_vfmsub_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsub_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmsub_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmsub_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsub_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                 vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmsub_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmsub_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsub_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                 vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmsub_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmsub_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsub_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                 vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmsub_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmsub_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsub_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                 vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmsub_tum(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5453,28 +5447,28 @@ vfloat64m8_t __riscv_vfmsub_tum(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmsub_tum(vbool64_t vm, vfloat16mf4_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   size_t vl);
-vfloat16mf4_t __riscv_vfnmsub_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsub_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                   vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_tum(vbool32_t vm, vfloat16mf2_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   size_t vl);
-vfloat16mf2_t __riscv_vfnmsub_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsub_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                   vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmsub_tum(vbool16_t vm, vfloat16m1_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsub_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsub_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                  vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmsub_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsub_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsub_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                  vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmsub_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsub_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsub_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                  vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmsub_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                  vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsub_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsub_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                  vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_tum(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5517,28 +5511,28 @@ vfloat64m8_t __riscv_vfnmsub_tum(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmacc_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   size_t vl);
-vfloat16mf4_t __riscv_vfmacc_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmacc_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                   vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmacc_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   size_t vl);
-vfloat16mf2_t __riscv_vfmacc_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmacc_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                   vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmacc_tumu(vbool16_t vm, vfloat16m1_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmacc_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmacc_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                  vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmacc_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmacc_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmacc_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                  vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmacc_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmacc_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmacc_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                  vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmacc_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                  vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmacc_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmacc_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                  vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmacc_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5580,32 +5574,32 @@ vfloat64m8_t __riscv_vfmacc_tumu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmacc_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                    vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                    size_t vl);
-vfloat16mf4_t __riscv_vfnmacc_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                   float16_t rs1, vfloat16mf4_t vs2, size_t vl);
+vfloat16mf4_t __riscv_vfnmacc_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
+                                   vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                    vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                    size_t vl);
-vfloat16mf2_t __riscv_vfnmacc_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                   float16_t rs1, vfloat16mf2_t vs2, size_t vl);
+vfloat16mf2_t __riscv_vfnmacc_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
+                                   vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmacc_tumu(vbool16_t vm, vfloat16m1_t vd,
                                   vfloat16m1_t vs1, vfloat16m1_t vs2,
                                   size_t vl);
-vfloat16m1_t __riscv_vfnmacc_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmacc_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                   vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmacc_tumu(vbool8_t vm, vfloat16m2_t vd,
                                   vfloat16m2_t vs1, vfloat16m2_t vs2,
                                   size_t vl);
-vfloat16m2_t __riscv_vfnmacc_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmacc_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                   vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmacc_tumu(vbool4_t vm, vfloat16m4_t vd,
                                   vfloat16m4_t vs1, vfloat16m4_t vs2,
                                   size_t vl);
-vfloat16m4_t __riscv_vfnmacc_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmacc_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                   vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmacc_tumu(vbool2_t vm, vfloat16m8_t vd,
                                   vfloat16m8_t vs1, vfloat16m8_t vs2,
                                   size_t vl);
-vfloat16m8_t __riscv_vfnmacc_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmacc_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                   vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5655,28 +5649,28 @@ vfloat64m8_t __riscv_vfnmacc_tumu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmsac_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   size_t vl);
-vfloat16mf4_t __riscv_vfmsac_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsac_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                   vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsac_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   size_t vl);
-vfloat16mf2_t __riscv_vfmsac_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsac_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                   vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmsac_tumu(vbool16_t vm, vfloat16m1_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmsac_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsac_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                  vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmsac_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmsac_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsac_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                  vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmsac_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmsac_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsac_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                  vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmsac_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                  vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmsac_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsac_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                  vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmsac_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5718,32 +5712,32 @@ vfloat64m8_t __riscv_vfmsac_tumu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmsac_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                    vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                    size_t vl);
-vfloat16mf4_t __riscv_vfnmsac_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                   float16_t rs1, vfloat16mf4_t vs2, size_t vl);
+vfloat16mf4_t __riscv_vfnmsac_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
+                                   vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                    vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                    size_t vl);
-vfloat16mf2_t __riscv_vfnmsac_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                   float16_t rs1, vfloat16mf2_t vs2, size_t vl);
+vfloat16mf2_t __riscv_vfnmsac_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
+                                   vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmsac_tumu(vbool16_t vm, vfloat16m1_t vd,
                                   vfloat16m1_t vs1, vfloat16m1_t vs2,
                                   size_t vl);
-vfloat16m1_t __riscv_vfnmsac_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsac_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                   vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmsac_tumu(vbool8_t vm, vfloat16m2_t vd,
                                   vfloat16m2_t vs1, vfloat16m2_t vs2,
                                   size_t vl);
-vfloat16m2_t __riscv_vfnmsac_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsac_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                   vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmsac_tumu(vbool4_t vm, vfloat16m4_t vd,
                                   vfloat16m4_t vs1, vfloat16m4_t vs2,
                                   size_t vl);
-vfloat16m4_t __riscv_vfnmsac_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsac_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                   vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmsac_tumu(vbool2_t vm, vfloat16m8_t vd,
                                   vfloat16m8_t vs1, vfloat16m8_t vs2,
                                   size_t vl);
-vfloat16m8_t __riscv_vfnmsac_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsac_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                   vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5793,28 +5787,28 @@ vfloat64m8_t __riscv_vfnmsac_tumu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmadd_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   size_t vl);
-vfloat16mf4_t __riscv_vfmadd_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmadd_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                   vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmadd_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   size_t vl);
-vfloat16mf2_t __riscv_vfmadd_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmadd_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                   vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmadd_tumu(vbool16_t vm, vfloat16m1_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmadd_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmadd_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                  vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmadd_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmadd_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmadd_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                  vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmadd_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmadd_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmadd_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                  vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmadd_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                  vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmadd_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmadd_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                  vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmadd_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5856,32 +5850,32 @@ vfloat64m8_t __riscv_vfmadd_tumu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmadd_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                    vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                    size_t vl);
-vfloat16mf4_t __riscv_vfnmadd_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                   float16_t rs1, vfloat16mf4_t vs2, size_t vl);
+vfloat16mf4_t __riscv_vfnmadd_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
+                                   vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                    vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                    size_t vl);
-vfloat16mf2_t __riscv_vfnmadd_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                   float16_t rs1, vfloat16mf2_t vs2, size_t vl);
+vfloat16mf2_t __riscv_vfnmadd_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
+                                   vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmadd_tumu(vbool16_t vm, vfloat16m1_t vd,
                                   vfloat16m1_t vs1, vfloat16m1_t vs2,
                                   size_t vl);
-vfloat16m1_t __riscv_vfnmadd_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmadd_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                   vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmadd_tumu(vbool8_t vm, vfloat16m2_t vd,
                                   vfloat16m2_t vs1, vfloat16m2_t vs2,
                                   size_t vl);
-vfloat16m2_t __riscv_vfnmadd_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmadd_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                   vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmadd_tumu(vbool4_t vm, vfloat16m4_t vd,
                                   vfloat16m4_t vs1, vfloat16m4_t vs2,
                                   size_t vl);
-vfloat16m4_t __riscv_vfnmadd_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmadd_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                   vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmadd_tumu(vbool2_t vm, vfloat16m8_t vd,
                                   vfloat16m8_t vs1, vfloat16m8_t vs2,
                                   size_t vl);
-vfloat16m8_t __riscv_vfnmadd_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmadd_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                   vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5931,28 +5925,28 @@ vfloat64m8_t __riscv_vfnmadd_tumu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmsub_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   size_t vl);
-vfloat16mf4_t __riscv_vfmsub_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsub_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                   vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsub_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   size_t vl);
-vfloat16mf2_t __riscv_vfmsub_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsub_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                   vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmsub_tumu(vbool16_t vm, vfloat16m1_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmsub_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsub_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                  vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmsub_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmsub_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsub_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                  vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmsub_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmsub_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsub_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                  vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmsub_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                  vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmsub_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsub_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                  vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmsub_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -5994,32 +5988,32 @@ vfloat64m8_t __riscv_vfmsub_tumu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmsub_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                    vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                    size_t vl);
-vfloat16mf4_t __riscv_vfnmsub_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                   float16_t rs1, vfloat16mf4_t vs2, size_t vl);
+vfloat16mf4_t __riscv_vfnmsub_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
+                                   vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                    vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                    size_t vl);
-vfloat16mf2_t __riscv_vfnmsub_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                   float16_t rs1, vfloat16mf2_t vs2, size_t vl);
+vfloat16mf2_t __riscv_vfnmsub_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
+                                   vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmsub_tumu(vbool16_t vm, vfloat16m1_t vd,
                                   vfloat16m1_t vs1, vfloat16m1_t vs2,
                                   size_t vl);
-vfloat16m1_t __riscv_vfnmsub_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsub_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                   vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmsub_tumu(vbool8_t vm, vfloat16m2_t vd,
                                   vfloat16m2_t vs1, vfloat16m2_t vs2,
                                   size_t vl);
-vfloat16m2_t __riscv_vfnmsub_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsub_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                   vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmsub_tumu(vbool4_t vm, vfloat16m4_t vd,
                                   vfloat16m4_t vs1, vfloat16m4_t vs2,
                                   size_t vl);
-vfloat16m4_t __riscv_vfnmsub_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsub_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                   vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmsub_tumu(vbool2_t vm, vfloat16m8_t vd,
                                   vfloat16m8_t vs1, vfloat16m8_t vs2,
                                   size_t vl);
-vfloat16m8_t __riscv_vfnmsub_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsub_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                   vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -6070,28 +6064,28 @@ vfloat64m8_t __riscv_vfnmsub_tumu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmacc_mu(vbool64_t vm, vfloat16mf4_t vd,
                                 vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                 size_t vl);
-vfloat16mf4_t __riscv_vfmacc_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmacc_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                 vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmacc_mu(vbool32_t vm, vfloat16mf2_t vd,
                                 vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                 size_t vl);
-vfloat16mf2_t __riscv_vfmacc_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmacc_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                 vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmacc_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmacc_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmacc_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmacc_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmacc_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmacc_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmacc_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmacc_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmacc_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmacc_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmacc_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmacc_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmacc_mu(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -6133,28 +6127,28 @@ vfloat64m8_t __riscv_vfmacc_mu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmacc_mu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  size_t vl);
-vfloat16mf4_t __riscv_vfnmacc_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmacc_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_mu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  size_t vl);
-vfloat16mf2_t __riscv_vfnmacc_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmacc_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmacc_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmacc_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmacc_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                 vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmacc_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmacc_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmacc_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                 vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmacc_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmacc_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmacc_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                 vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmacc_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmacc_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmacc_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                 vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_mu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -6196,28 +6190,28 @@ vfloat64m8_t __riscv_vfnmacc_mu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmsac_mu(vbool64_t vm, vfloat16mf4_t vd,
                                 vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                 size_t vl);
-vfloat16mf4_t __riscv_vfmsac_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsac_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                 vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsac_mu(vbool32_t vm, vfloat16mf2_t vd,
                                 vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                 size_t vl);
-vfloat16mf2_t __riscv_vfmsac_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsac_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                 vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmsac_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmsac_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsac_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmsac_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmsac_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsac_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmsac_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmsac_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsac_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmsac_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmsac_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsac_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmsac_mu(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -6259,28 +6253,28 @@ vfloat64m8_t __riscv_vfmsac_mu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmsac_mu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  size_t vl);
-vfloat16mf4_t __riscv_vfnmsac_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsac_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_mu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  size_t vl);
-vfloat16mf2_t __riscv_vfnmsac_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsac_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmsac_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsac_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsac_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                 vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmsac_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsac_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsac_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                 vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmsac_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsac_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsac_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                 vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmsac_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsac_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsac_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                 vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_mu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -6322,28 +6316,28 @@ vfloat64m8_t __riscv_vfnmsac_mu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmadd_mu(vbool64_t vm, vfloat16mf4_t vd,
                                 vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                 size_t vl);
-vfloat16mf4_t __riscv_vfmadd_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmadd_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                 vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmadd_mu(vbool32_t vm, vfloat16mf2_t vd,
                                 vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                 size_t vl);
-vfloat16mf2_t __riscv_vfmadd_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmadd_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                 vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmadd_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmadd_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmadd_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmadd_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmadd_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmadd_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmadd_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmadd_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmadd_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmadd_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmadd_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmadd_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmadd_mu(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -6385,28 +6379,28 @@ vfloat64m8_t __riscv_vfmadd_mu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmadd_mu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  size_t vl);
-vfloat16mf4_t __riscv_vfnmadd_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmadd_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_mu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  size_t vl);
-vfloat16mf2_t __riscv_vfnmadd_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmadd_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmadd_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmadd_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmadd_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                 vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmadd_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmadd_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmadd_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                 vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmadd_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmadd_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmadd_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                 vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmadd_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmadd_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmadd_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                 vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_mu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -6448,28 +6442,28 @@ vfloat64m8_t __riscv_vfnmadd_mu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmsub_mu(vbool64_t vm, vfloat16mf4_t vd,
                                 vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                 size_t vl);
-vfloat16mf4_t __riscv_vfmsub_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsub_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                 vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfmsub_mu(vbool32_t vm, vfloat16mf2_t vd,
                                 vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                 size_t vl);
-vfloat16mf2_t __riscv_vfmsub_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsub_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                 vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfmsub_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfmsub_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsub_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfmsub_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfmsub_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsub_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfmsub_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfmsub_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsub_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfmsub_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfmsub_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsub_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfmsub_mu(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -6511,28 +6505,28 @@ vfloat64m8_t __riscv_vfmsub_mu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmsub_mu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  size_t vl);
-vfloat16mf4_t __riscv_vfnmsub_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsub_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_mu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  size_t vl);
-vfloat16mf2_t __riscv_vfnmsub_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsub_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, size_t vl);
 vfloat16m1_t __riscv_vfnmsub_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, size_t vl);
-vfloat16m1_t __riscv_vfnmsub_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsub_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                 vfloat16m1_t vs2, size_t vl);
 vfloat16m2_t __riscv_vfnmsub_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, size_t vl);
-vfloat16m2_t __riscv_vfnmsub_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsub_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                 vfloat16m2_t vs2, size_t vl);
 vfloat16m4_t __riscv_vfnmsub_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, size_t vl);
-vfloat16m4_t __riscv_vfnmsub_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsub_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                 vfloat16m4_t vs2, size_t vl);
 vfloat16m8_t __riscv_vfnmsub_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, size_t vl);
-vfloat16m8_t __riscv_vfnmsub_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsub_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                 vfloat16m8_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_mu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -6573,27 +6567,27 @@ vfloat64m8_t __riscv_vfnmsub_mu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
                                 vfloat64m8_t vs2, size_t vl);
 vfloat16mf4_t __riscv_vfmacc_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                 vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmacc_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmacc_tu(vfloat16mf4_t vd, _Float16 rs1,
                                 vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmacc_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                 vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmacc_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmacc_tu(vfloat16mf2_t vd, _Float16 rs1,
                                 vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmacc_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmacc_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmacc_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                                unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmacc_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmacc_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmacc_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                                unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmacc_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmacc_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmacc_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                                unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmacc_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmacc_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmacc_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmacc_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                 vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -6634,31 +6628,31 @@ vfloat64m8_t __riscv_vfmacc_tu(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfnmacc_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
-vfloat16mf4_t __riscv_vfnmacc_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmacc_tu(vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
-vfloat16mf2_t __riscv_vfnmacc_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmacc_tu(vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16m1_t __riscv_vfnmacc_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmacc_tu(vfloat16m1_t vd, float16_t rs1,
-                                vfloat16m1_t vs2, unsigned int frm, size_t vl);
+vfloat16m1_t __riscv_vfnmacc_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmacc_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmacc_tu(vfloat16m2_t vd, float16_t rs1,
-                                vfloat16m2_t vs2, unsigned int frm, size_t vl);
+vfloat16m2_t __riscv_vfnmacc_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmacc_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmacc_tu(vfloat16m4_t vd, float16_t rs1,
-                                vfloat16m4_t vs2, unsigned int frm, size_t vl);
+vfloat16m4_t __riscv_vfnmacc_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmacc_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmacc_tu(vfloat16m8_t vd, float16_t rs1,
-                                vfloat16m8_t vs2, unsigned int frm, size_t vl);
+vfloat16m8_t __riscv_vfnmacc_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                  vfloat32mf2_t vs2, unsigned int frm,
                                  size_t vl);
@@ -6699,27 +6693,27 @@ vfloat64m8_t __riscv_vfnmacc_tu(vfloat64m8_t vd, float64_t rs1,
                                 vfloat64m8_t vs2, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmsac_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                 vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmsac_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsac_tu(vfloat16mf4_t vd, _Float16 rs1,
                                 vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsac_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                 vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmsac_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsac_tu(vfloat16mf2_t vd, _Float16 rs1,
                                 vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsac_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmsac_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmsac_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                                unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsac_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmsac_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmsac_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                                unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsac_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmsac_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmsac_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                                unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsac_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmsac_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmsac_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsac_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                 vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -6760,31 +6754,31 @@ vfloat64m8_t __riscv_vfmsac_tu(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfnmsac_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
-vfloat16mf4_t __riscv_vfnmsac_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsac_tu(vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
-vfloat16mf2_t __riscv_vfnmsac_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsac_tu(vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16m1_t __riscv_vfnmsac_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmsac_tu(vfloat16m1_t vd, float16_t rs1,
-                                vfloat16m1_t vs2, unsigned int frm, size_t vl);
+vfloat16m1_t __riscv_vfnmsac_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsac_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmsac_tu(vfloat16m2_t vd, float16_t rs1,
-                                vfloat16m2_t vs2, unsigned int frm, size_t vl);
+vfloat16m2_t __riscv_vfnmsac_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsac_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmsac_tu(vfloat16m4_t vd, float16_t rs1,
-                                vfloat16m4_t vs2, unsigned int frm, size_t vl);
+vfloat16m4_t __riscv_vfnmsac_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsac_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmsac_tu(vfloat16m8_t vd, float16_t rs1,
-                                vfloat16m8_t vs2, unsigned int frm, size_t vl);
+vfloat16m8_t __riscv_vfnmsac_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                  vfloat32mf2_t vs2, unsigned int frm,
                                  size_t vl);
@@ -6825,27 +6819,27 @@ vfloat64m8_t __riscv_vfnmsac_tu(vfloat64m8_t vd, float64_t rs1,
                                 vfloat64m8_t vs2, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmadd_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                 vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmadd_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmadd_tu(vfloat16mf4_t vd, _Float16 rs1,
                                 vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmadd_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                 vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmadd_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmadd_tu(vfloat16mf2_t vd, _Float16 rs1,
                                 vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmadd_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmadd_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmadd_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                                unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmadd_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmadd_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmadd_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                                unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmadd_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmadd_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmadd_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                                unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmadd_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmadd_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmadd_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmadd_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                 vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -6886,31 +6880,31 @@ vfloat64m8_t __riscv_vfmadd_tu(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfnmadd_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
-vfloat16mf4_t __riscv_vfnmadd_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmadd_tu(vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
-vfloat16mf2_t __riscv_vfnmadd_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmadd_tu(vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16m1_t __riscv_vfnmadd_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmadd_tu(vfloat16m1_t vd, float16_t rs1,
-                                vfloat16m1_t vs2, unsigned int frm, size_t vl);
+vfloat16m1_t __riscv_vfnmadd_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmadd_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmadd_tu(vfloat16m2_t vd, float16_t rs1,
-                                vfloat16m2_t vs2, unsigned int frm, size_t vl);
+vfloat16m2_t __riscv_vfnmadd_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmadd_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmadd_tu(vfloat16m4_t vd, float16_t rs1,
-                                vfloat16m4_t vs2, unsigned int frm, size_t vl);
+vfloat16m4_t __riscv_vfnmadd_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmadd_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmadd_tu(vfloat16m8_t vd, float16_t rs1,
-                                vfloat16m8_t vs2, unsigned int frm, size_t vl);
+vfloat16m8_t __riscv_vfnmadd_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                  vfloat32mf2_t vs2, unsigned int frm,
                                  size_t vl);
@@ -6951,27 +6945,27 @@ vfloat64m8_t __riscv_vfnmadd_tu(vfloat64m8_t vd, float64_t rs1,
                                 vfloat64m8_t vs2, unsigned int frm, size_t vl);
 vfloat16mf4_t __riscv_vfmsub_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                 vfloat16mf4_t vs2, unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmsub_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsub_tu(vfloat16mf4_t vd, _Float16 rs1,
                                 vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsub_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                 vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmsub_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsub_tu(vfloat16mf2_t vd, _Float16 rs1,
                                 vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsub_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmsub_tu(vfloat16m1_t vd, float16_t rs1, vfloat16m1_t vs2,
+vfloat16m1_t __riscv_vfmsub_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
                                unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsub_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmsub_tu(vfloat16m2_t vd, float16_t rs1, vfloat16m2_t vs2,
+vfloat16m2_t __riscv_vfmsub_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
                                unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsub_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmsub_tu(vfloat16m4_t vd, float16_t rs1, vfloat16m4_t vs2,
+vfloat16m4_t __riscv_vfmsub_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
                                unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsub_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmsub_tu(vfloat16m8_t vd, float16_t rs1, vfloat16m8_t vs2,
+vfloat16m8_t __riscv_vfmsub_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsub_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                 vfloat32mf2_t vs2, unsigned int frm, size_t vl);
@@ -7012,31 +7006,31 @@ vfloat64m8_t __riscv_vfmsub_tu(vfloat64m8_t vd, float64_t rs1, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfnmsub_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
-vfloat16mf4_t __riscv_vfnmsub_tu(vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsub_tu(vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
-vfloat16mf2_t __riscv_vfnmsub_tu(vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsub_tu(vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16m1_t __riscv_vfnmsub_tu(vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmsub_tu(vfloat16m1_t vd, float16_t rs1,
-                                vfloat16m1_t vs2, unsigned int frm, size_t vl);
+vfloat16m1_t __riscv_vfnmsub_tu(vfloat16m1_t vd, _Float16 rs1, vfloat16m1_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsub_tu(vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmsub_tu(vfloat16m2_t vd, float16_t rs1,
-                                vfloat16m2_t vs2, unsigned int frm, size_t vl);
+vfloat16m2_t __riscv_vfnmsub_tu(vfloat16m2_t vd, _Float16 rs1, vfloat16m2_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsub_tu(vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmsub_tu(vfloat16m4_t vd, float16_t rs1,
-                                vfloat16m4_t vs2, unsigned int frm, size_t vl);
+vfloat16m4_t __riscv_vfnmsub_tu(vfloat16m4_t vd, _Float16 rs1, vfloat16m4_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsub_tu(vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmsub_tu(vfloat16m8_t vd, float16_t rs1,
-                                vfloat16m8_t vs2, unsigned int frm, size_t vl);
+vfloat16m8_t __riscv_vfnmsub_tu(vfloat16m8_t vd, _Float16 rs1, vfloat16m8_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1,
                                  vfloat32mf2_t vs2, unsigned int frm,
                                  size_t vl);
@@ -7079,30 +7073,30 @@ vfloat64m8_t __riscv_vfnmsub_tu(vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmacc_tum(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmacc_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmacc_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfmacc_tum(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmacc_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmacc_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16m1_t __riscv_vfmacc_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmacc_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmacc_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmacc_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmacc_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmacc_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmacc_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmacc_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmacc_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmacc_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmacc_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmacc_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmacc_tum(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -7145,31 +7139,31 @@ vfloat64m8_t __riscv_vfmacc_tum(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmacc_tum(vbool64_t vm, vfloat16mf4_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmacc_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmacc_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                   vfloat16mf4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_tum(vbool32_t vm, vfloat16mf2_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmacc_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmacc_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                   vfloat16mf2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m1_t __riscv_vfnmacc_tum(vbool16_t vm, vfloat16m1_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmacc_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmacc_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                  vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmacc_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmacc_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmacc_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmacc_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmacc_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmacc_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmacc_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                  vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmacc_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmacc_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                  vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_tum(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -7217,30 +7211,30 @@ vfloat64m8_t __riscv_vfnmacc_tum(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmsac_tum(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmsac_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsac_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfmsac_tum(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmsac_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsac_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16m1_t __riscv_vfmsac_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmsac_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsac_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsac_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmsac_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsac_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsac_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmsac_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsac_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsac_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmsac_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsac_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsac_tum(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -7283,31 +7277,31 @@ vfloat64m8_t __riscv_vfmsac_tum(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmsac_tum(vbool64_t vm, vfloat16mf4_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmsac_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsac_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                   vfloat16mf4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_tum(vbool32_t vm, vfloat16mf2_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmsac_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsac_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                   vfloat16mf2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m1_t __riscv_vfnmsac_tum(vbool16_t vm, vfloat16m1_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmsac_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsac_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                  vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsac_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmsac_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsac_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsac_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmsac_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsac_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsac_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                  vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmsac_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsac_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                  vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_tum(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -7355,30 +7349,30 @@ vfloat64m8_t __riscv_vfnmsac_tum(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmadd_tum(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmadd_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmadd_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfmadd_tum(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmadd_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmadd_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16m1_t __riscv_vfmadd_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmadd_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmadd_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmadd_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmadd_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmadd_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmadd_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmadd_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmadd_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmadd_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmadd_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmadd_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmadd_tum(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -7421,31 +7415,31 @@ vfloat64m8_t __riscv_vfmadd_tum(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmadd_tum(vbool64_t vm, vfloat16mf4_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmadd_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmadd_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                   vfloat16mf4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_tum(vbool32_t vm, vfloat16mf2_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmadd_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmadd_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                   vfloat16mf2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m1_t __riscv_vfnmadd_tum(vbool16_t vm, vfloat16m1_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmadd_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmadd_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                  vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmadd_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmadd_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmadd_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmadd_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmadd_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmadd_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmadd_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                  vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmadd_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmadd_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                  vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_tum(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -7493,30 +7487,30 @@ vfloat64m8_t __riscv_vfnmadd_tum(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmsub_tum(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmsub_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsub_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfmsub_tum(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmsub_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsub_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16m1_t __riscv_vfmsub_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmsub_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsub_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsub_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmsub_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsub_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsub_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmsub_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsub_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsub_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmsub_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsub_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsub_tum(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -7559,31 +7553,31 @@ vfloat64m8_t __riscv_vfmsub_tum(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmsub_tum(vbool64_t vm, vfloat16mf4_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmsub_tum(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsub_tum(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                   vfloat16mf4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_tum(vbool32_t vm, vfloat16mf2_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmsub_tum(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsub_tum(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                   vfloat16mf2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m1_t __riscv_vfnmsub_tum(vbool16_t vm, vfloat16m1_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmsub_tum(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsub_tum(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                  vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsub_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmsub_tum(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsub_tum(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsub_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmsub_tum(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsub_tum(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsub_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                  vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmsub_tum(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsub_tum(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                  vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_tum(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -7632,31 +7626,31 @@ vfloat64m8_t __riscv_vfnmsub_tum(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmacc_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmacc_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmacc_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                   vfloat16mf4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16mf2_t __riscv_vfmacc_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmacc_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmacc_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                   vfloat16mf2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m1_t __riscv_vfmacc_tumu(vbool16_t vm, vfloat16m1_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmacc_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmacc_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                  vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmacc_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmacc_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmacc_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmacc_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmacc_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmacc_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmacc_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                  vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmacc_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmacc_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                  vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmacc_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -7704,37 +7698,37 @@ vfloat64m8_t __riscv_vfmacc_tumu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmacc_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                    vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmacc_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                   float16_t rs1, vfloat16mf4_t vs2,
-                                   unsigned int frm, size_t vl);
+vfloat16mf4_t __riscv_vfnmacc_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
+                                   vfloat16mf4_t vs2, unsigned int frm,
+                                   size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                    vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmacc_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                   float16_t rs1, vfloat16mf2_t vs2,
-                                   unsigned int frm, size_t vl);
+vfloat16mf2_t __riscv_vfnmacc_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
+                                   vfloat16mf2_t vs2, unsigned int frm,
+                                   size_t vl);
 vfloat16m1_t __riscv_vfnmacc_tumu(vbool16_t vm, vfloat16m1_t vd,
                                   vfloat16m1_t vs1, vfloat16m1_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmacc_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmacc_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                   vfloat16m1_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m2_t __riscv_vfnmacc_tumu(vbool8_t vm, vfloat16m2_t vd,
                                   vfloat16m2_t vs1, vfloat16m2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmacc_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmacc_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                   vfloat16m2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m4_t __riscv_vfnmacc_tumu(vbool4_t vm, vfloat16m4_t vd,
                                   vfloat16m4_t vs1, vfloat16m4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmacc_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmacc_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                   vfloat16m4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m8_t __riscv_vfnmacc_tumu(vbool2_t vm, vfloat16m8_t vd,
                                   vfloat16m8_t vs1, vfloat16m8_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmacc_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmacc_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                   vfloat16m8_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_tumu(vbool64_t vm, vfloat32mf2_t vd,
@@ -7794,31 +7788,31 @@ vfloat64m8_t __riscv_vfnmacc_tumu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmsac_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmsac_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsac_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                   vfloat16mf4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16mf2_t __riscv_vfmsac_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmsac_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsac_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                   vfloat16mf2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m1_t __riscv_vfmsac_tumu(vbool16_t vm, vfloat16m1_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmsac_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsac_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                  vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsac_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmsac_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsac_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsac_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmsac_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsac_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsac_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                  vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmsac_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsac_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                  vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsac_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -7866,37 +7860,37 @@ vfloat64m8_t __riscv_vfmsac_tumu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmsac_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                    vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmsac_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                   float16_t rs1, vfloat16mf4_t vs2,
-                                   unsigned int frm, size_t vl);
+vfloat16mf4_t __riscv_vfnmsac_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
+                                   vfloat16mf4_t vs2, unsigned int frm,
+                                   size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                    vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmsac_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                   float16_t rs1, vfloat16mf2_t vs2,
-                                   unsigned int frm, size_t vl);
+vfloat16mf2_t __riscv_vfnmsac_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
+                                   vfloat16mf2_t vs2, unsigned int frm,
+                                   size_t vl);
 vfloat16m1_t __riscv_vfnmsac_tumu(vbool16_t vm, vfloat16m1_t vd,
                                   vfloat16m1_t vs1, vfloat16m1_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmsac_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsac_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                   vfloat16m1_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m2_t __riscv_vfnmsac_tumu(vbool8_t vm, vfloat16m2_t vd,
                                   vfloat16m2_t vs1, vfloat16m2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmsac_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsac_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                   vfloat16m2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m4_t __riscv_vfnmsac_tumu(vbool4_t vm, vfloat16m4_t vd,
                                   vfloat16m4_t vs1, vfloat16m4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmsac_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsac_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                   vfloat16m4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m8_t __riscv_vfnmsac_tumu(vbool2_t vm, vfloat16m8_t vd,
                                   vfloat16m8_t vs1, vfloat16m8_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmsac_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsac_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                   vfloat16m8_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_tumu(vbool64_t vm, vfloat32mf2_t vd,
@@ -7956,31 +7950,31 @@ vfloat64m8_t __riscv_vfnmsac_tumu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmadd_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmadd_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmadd_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                   vfloat16mf4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16mf2_t __riscv_vfmadd_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmadd_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmadd_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                   vfloat16mf2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m1_t __riscv_vfmadd_tumu(vbool16_t vm, vfloat16m1_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmadd_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmadd_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                  vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmadd_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmadd_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmadd_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmadd_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmadd_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmadd_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmadd_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                  vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmadd_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmadd_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                  vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmadd_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -8028,37 +8022,37 @@ vfloat64m8_t __riscv_vfmadd_tumu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmadd_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                    vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmadd_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                   float16_t rs1, vfloat16mf4_t vs2,
-                                   unsigned int frm, size_t vl);
+vfloat16mf4_t __riscv_vfnmadd_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
+                                   vfloat16mf4_t vs2, unsigned int frm,
+                                   size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                    vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmadd_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                   float16_t rs1, vfloat16mf2_t vs2,
-                                   unsigned int frm, size_t vl);
+vfloat16mf2_t __riscv_vfnmadd_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
+                                   vfloat16mf2_t vs2, unsigned int frm,
+                                   size_t vl);
 vfloat16m1_t __riscv_vfnmadd_tumu(vbool16_t vm, vfloat16m1_t vd,
                                   vfloat16m1_t vs1, vfloat16m1_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmadd_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmadd_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                   vfloat16m1_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m2_t __riscv_vfnmadd_tumu(vbool8_t vm, vfloat16m2_t vd,
                                   vfloat16m2_t vs1, vfloat16m2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmadd_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmadd_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                   vfloat16m2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m4_t __riscv_vfnmadd_tumu(vbool4_t vm, vfloat16m4_t vd,
                                   vfloat16m4_t vs1, vfloat16m4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmadd_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmadd_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                   vfloat16m4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m8_t __riscv_vfnmadd_tumu(vbool2_t vm, vfloat16m8_t vd,
                                   vfloat16m8_t vs1, vfloat16m8_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmadd_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmadd_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                   vfloat16m8_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_tumu(vbool64_t vm, vfloat32mf2_t vd,
@@ -8118,31 +8112,31 @@ vfloat64m8_t __riscv_vfnmadd_tumu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmsub_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmsub_tumu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsub_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                   vfloat16mf4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16mf2_t __riscv_vfmsub_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmsub_tumu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsub_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                   vfloat16mf2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m1_t __riscv_vfmsub_tumu(vbool16_t vm, vfloat16m1_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmsub_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsub_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                  vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsub_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmsub_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsub_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsub_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmsub_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsub_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsub_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                  vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmsub_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsub_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                  vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsub_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -8190,37 +8184,37 @@ vfloat64m8_t __riscv_vfmsub_tumu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmsub_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                    vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmsub_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                   float16_t rs1, vfloat16mf4_t vs2,
-                                   unsigned int frm, size_t vl);
+vfloat16mf4_t __riscv_vfnmsub_tumu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
+                                   vfloat16mf4_t vs2, unsigned int frm,
+                                   size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                    vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmsub_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                   float16_t rs1, vfloat16mf2_t vs2,
-                                   unsigned int frm, size_t vl);
+vfloat16mf2_t __riscv_vfnmsub_tumu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
+                                   vfloat16mf2_t vs2, unsigned int frm,
+                                   size_t vl);
 vfloat16m1_t __riscv_vfnmsub_tumu(vbool16_t vm, vfloat16m1_t vd,
                                   vfloat16m1_t vs1, vfloat16m1_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmsub_tumu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsub_tumu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                   vfloat16m1_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m2_t __riscv_vfnmsub_tumu(vbool8_t vm, vfloat16m2_t vd,
                                   vfloat16m2_t vs1, vfloat16m2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmsub_tumu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsub_tumu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                   vfloat16m2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m4_t __riscv_vfnmsub_tumu(vbool4_t vm, vfloat16m4_t vd,
                                   vfloat16m4_t vs1, vfloat16m4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmsub_tumu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsub_tumu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                   vfloat16m4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat16m8_t __riscv_vfnmsub_tumu(vbool2_t vm, vfloat16m8_t vd,
                                   vfloat16m8_t vs1, vfloat16m8_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmsub_tumu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsub_tumu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                   vfloat16m8_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_tumu(vbool64_t vm, vfloat32mf2_t vd,
@@ -8281,28 +8275,28 @@ vfloat64m8_t __riscv_vfnmsub_tumu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmacc_mu(vbool64_t vm, vfloat16mf4_t vd,
                                 vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                 unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmacc_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmacc_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                 vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmacc_mu(vbool32_t vm, vfloat16mf2_t vd,
                                 vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                 unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmacc_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmacc_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                 vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmacc_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmacc_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmacc_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmacc_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmacc_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmacc_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmacc_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmacc_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmacc_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmacc_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmacc_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmacc_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmacc_mu(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -8344,30 +8338,30 @@ vfloat64m8_t __riscv_vfmacc_mu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmacc_mu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmacc_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmacc_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfnmacc_mu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmacc_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmacc_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16m1_t __riscv_vfnmacc_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmacc_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmacc_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmacc_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmacc_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmacc_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmacc_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmacc_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmacc_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmacc_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmacc_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmacc_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmacc_mu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -8410,28 +8404,28 @@ vfloat64m8_t __riscv_vfnmacc_mu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmsac_mu(vbool64_t vm, vfloat16mf4_t vd,
                                 vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                 unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmsac_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsac_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                 vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsac_mu(vbool32_t vm, vfloat16mf2_t vd,
                                 vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                 unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmsac_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsac_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                 vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsac_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmsac_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsac_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsac_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmsac_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsac_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsac_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmsac_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsac_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsac_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmsac_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsac_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsac_mu(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -8473,30 +8467,30 @@ vfloat64m8_t __riscv_vfmsac_mu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmsac_mu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmsac_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsac_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfnmsac_mu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmsac_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsac_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16m1_t __riscv_vfnmsac_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmsac_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsac_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsac_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmsac_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsac_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsac_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmsac_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsac_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsac_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmsac_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsac_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsac_mu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -8539,28 +8533,28 @@ vfloat64m8_t __riscv_vfnmsac_mu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmadd_mu(vbool64_t vm, vfloat16mf4_t vd,
                                 vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                 unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmadd_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmadd_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                 vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmadd_mu(vbool32_t vm, vfloat16mf2_t vd,
                                 vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                 unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmadd_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmadd_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                 vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmadd_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmadd_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmadd_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmadd_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmadd_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmadd_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmadd_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmadd_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmadd_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmadd_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmadd_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmadd_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmadd_mu(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -8602,30 +8596,30 @@ vfloat64m8_t __riscv_vfmadd_mu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmadd_mu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmadd_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmadd_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfnmadd_mu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmadd_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmadd_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16m1_t __riscv_vfnmadd_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmadd_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmadd_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmadd_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmadd_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmadd_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmadd_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmadd_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmadd_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmadd_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmadd_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmadd_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmadd_mu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -8668,28 +8662,28 @@ vfloat64m8_t __riscv_vfnmadd_mu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfmsub_mu(vbool64_t vm, vfloat16mf4_t vd,
                                 vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                 unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfmsub_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfmsub_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                 vfloat16mf4_t vs2, unsigned int frm, size_t vl);
 vfloat16mf2_t __riscv_vfmsub_mu(vbool32_t vm, vfloat16mf2_t vd,
                                 vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                 unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfmsub_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfmsub_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                 vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat16m1_t __riscv_vfmsub_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfmsub_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfmsub_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfmsub_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfmsub_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfmsub_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfmsub_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfmsub_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfmsub_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfmsub_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfmsub_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfmsub_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfmsub_mu(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -8731,30 +8725,30 @@ vfloat64m8_t __riscv_vfmsub_mu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 vfloat16mf4_t __riscv_vfnmsub_mu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16mf4_t __riscv_vfnmsub_mu(vbool64_t vm, vfloat16mf4_t vd, float16_t rs1,
+vfloat16mf4_t __riscv_vfnmsub_mu(vbool64_t vm, vfloat16mf4_t vd, _Float16 rs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfnmsub_mu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat16mf2_t __riscv_vfnmsub_mu(vbool32_t vm, vfloat16mf2_t vd, float16_t rs1,
+vfloat16mf2_t __riscv_vfnmsub_mu(vbool32_t vm, vfloat16mf2_t vd, _Float16 rs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat16m1_t __riscv_vfnmsub_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat16m1_t __riscv_vfnmsub_mu(vbool16_t vm, vfloat16m1_t vd, float16_t rs1,
+vfloat16m1_t __riscv_vfnmsub_mu(vbool16_t vm, vfloat16m1_t vd, _Float16 rs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat16m2_t __riscv_vfnmsub_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat16m2_t __riscv_vfnmsub_mu(vbool8_t vm, vfloat16m2_t vd, float16_t rs1,
+vfloat16m2_t __riscv_vfnmsub_mu(vbool8_t vm, vfloat16m2_t vd, _Float16 rs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat16m4_t __riscv_vfnmsub_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat16m4_t __riscv_vfnmsub_mu(vbool4_t vm, vfloat16m4_t vd, float16_t rs1,
+vfloat16m4_t __riscv_vfnmsub_mu(vbool4_t vm, vfloat16m4_t vd, _Float16 rs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat16m8_t __riscv_vfnmsub_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
-vfloat16m8_t __riscv_vfnmsub_mu(vbool2_t vm, vfloat16m8_t vd, float16_t rs1,
+vfloat16m8_t __riscv_vfnmsub_mu(vbool2_t vm, vfloat16m8_t vd, _Float16 rs1,
                                 vfloat16m8_t vs2, unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfnmsub_mu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -8803,24 +8797,24 @@ vfloat64m8_t __riscv_vfnmsub_mu(vbool8_t vm, vfloat64m8_t vd, float64_t rs1,
 ----
 vfloat32mf2_t __riscv_vfwmacc_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                  vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwmacc_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmacc_tu(vfloat32mf2_t vd, _Float16 vs1,
                                  vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwmacc_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                 vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwmacc_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmacc_tu(vfloat32m1_t vd, _Float16 vs1,
                                 vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwmacc_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmacc_tu(vfloat32m2_t vd, float16_t vs1,
-                                vfloat16m1_t vs2, size_t vl);
+vfloat32m2_t __riscv_vfwmacc_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
+                                size_t vl);
 vfloat32m4_t __riscv_vfwmacc_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmacc_tu(vfloat32m4_t vd, float16_t vs1,
-                                vfloat16m2_t vs2, size_t vl);
+vfloat32m4_t __riscv_vfwmacc_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
+                                size_t vl);
 vfloat32m8_t __riscv_vfwmacc_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmacc_tu(vfloat32m8_t vd, float16_t vs1,
-                                vfloat16m4_t vs2, size_t vl);
+vfloat32m8_t __riscv_vfwmacc_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
+                                size_t vl);
 vfloat64m1_t __riscv_vfwmacc_tu(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                 vfloat32mf2_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwmacc_tu(vfloat64m1_t vd, float32_t vs1,
@@ -8839,23 +8833,23 @@ vfloat64m8_t __riscv_vfwmacc_tu(vfloat64m8_t vd, float32_t vs1,
                                 vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                   vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmacc_tu(vfloat32mf2_t vd, _Float16 vs1,
                                   vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                  vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwnmacc_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmacc_tu(vfloat32m1_t vd, _Float16 vs1,
                                  vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
                                  vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwnmacc_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmacc_tu(vfloat32m2_t vd, _Float16 vs1,
                                  vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwnmacc_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmacc_tu(vfloat32m4_t vd, _Float16 vs1,
                                  vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwnmacc_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmacc_tu(vfloat32m8_t vd, _Float16 vs1,
                                  vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_tu(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                  vfloat32mf2_t vs2, size_t vl);
@@ -8875,24 +8869,24 @@ vfloat64m8_t __riscv_vfwnmacc_tu(vfloat64m8_t vd, float32_t vs1,
                                  vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwmsac_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                  vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwmsac_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmsac_tu(vfloat32mf2_t vd, _Float16 vs1,
                                  vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwmsac_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                 vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwmsac_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmsac_tu(vfloat32m1_t vd, _Float16 vs1,
                                 vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwmsac_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmsac_tu(vfloat32m2_t vd, float16_t vs1,
-                                vfloat16m1_t vs2, size_t vl);
+vfloat32m2_t __riscv_vfwmsac_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
+                                size_t vl);
 vfloat32m4_t __riscv_vfwmsac_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmsac_tu(vfloat32m4_t vd, float16_t vs1,
-                                vfloat16m2_t vs2, size_t vl);
+vfloat32m4_t __riscv_vfwmsac_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
+                                size_t vl);
 vfloat32m8_t __riscv_vfwmsac_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmsac_tu(vfloat32m8_t vd, float16_t vs1,
-                                vfloat16m4_t vs2, size_t vl);
+vfloat32m8_t __riscv_vfwmsac_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
+                                size_t vl);
 vfloat64m1_t __riscv_vfwmsac_tu(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                 vfloat32mf2_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwmsac_tu(vfloat64m1_t vd, float32_t vs1,
@@ -8911,23 +8905,23 @@ vfloat64m8_t __riscv_vfwmsac_tu(vfloat64m8_t vd, float32_t vs1,
                                 vfloat32m4_t vs2, size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                   vfloat16mf4_t vs2, size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmsac_tu(vfloat32mf2_t vd, _Float16 vs1,
                                   vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                  vfloat16mf2_t vs2, size_t vl);
-vfloat32m1_t __riscv_vfwnmsac_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmsac_tu(vfloat32m1_t vd, _Float16 vs1,
                                  vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
                                  vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwnmsac_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmsac_tu(vfloat32m2_t vd, _Float16 vs1,
                                  vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwnmsac_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmsac_tu(vfloat32m4_t vd, _Float16 vs1,
                                  vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwnmsac_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmsac_tu(vfloat32m8_t vd, _Float16 vs1,
                                  vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_tu(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                  vfloat32mf2_t vs2, size_t vl);
@@ -8949,24 +8943,24 @@ vfloat64m8_t __riscv_vfwnmsac_tu(vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwmacc_tum(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   size_t vl);
-vfloat32mf2_t __riscv_vfwmacc_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmacc_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                   vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwmacc_tum(vbool32_t vm, vfloat32m1_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  size_t vl);
-vfloat32m1_t __riscv_vfwmacc_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmacc_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                  vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwmacc_tum(vbool16_t vm, vfloat32m2_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmacc_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmacc_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                  vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwmacc_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmacc_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmacc_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                  vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwmacc_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmacc_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmacc_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                  vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwmacc_tum(vbool64_t vm, vfloat64m1_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -8988,27 +8982,27 @@ vfloat64m8_t __riscv_vfwmacc_tum(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwnmacc_tum(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                    size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                   float16_t vs1, vfloat16mf4_t vs2, size_t vl);
+vfloat32mf2_t __riscv_vfwnmacc_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
+                                   vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_tum(vbool32_t vm, vfloat32m1_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   size_t vl);
-vfloat32m1_t __riscv_vfwnmacc_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmacc_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                   vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_tum(vbool16_t vm, vfloat32m2_t vd,
                                   vfloat16m1_t vs1, vfloat16m1_t vs2,
                                   size_t vl);
-vfloat32m2_t __riscv_vfwnmacc_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmacc_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                   vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_tum(vbool8_t vm, vfloat32m4_t vd,
                                   vfloat16m2_t vs1, vfloat16m2_t vs2,
                                   size_t vl);
-vfloat32m4_t __riscv_vfwnmacc_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmacc_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                   vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_tum(vbool4_t vm, vfloat32m8_t vd,
                                   vfloat16m4_t vs1, vfloat16m4_t vs2,
                                   size_t vl);
-vfloat32m8_t __riscv_vfwnmacc_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmacc_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                   vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_tum(vbool64_t vm, vfloat64m1_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -9033,24 +9027,24 @@ vfloat64m8_t __riscv_vfwnmacc_tum(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwmsac_tum(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   size_t vl);
-vfloat32mf2_t __riscv_vfwmsac_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmsac_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                   vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwmsac_tum(vbool32_t vm, vfloat32m1_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  size_t vl);
-vfloat32m1_t __riscv_vfwmsac_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmsac_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                  vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwmsac_tum(vbool16_t vm, vfloat32m2_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmsac_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmsac_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                  vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwmsac_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmsac_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmsac_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                  vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwmsac_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmsac_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmsac_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                  vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwmsac_tum(vbool64_t vm, vfloat64m1_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -9072,27 +9066,27 @@ vfloat64m8_t __riscv_vfwmsac_tum(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwnmsac_tum(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                    size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                   float16_t vs1, vfloat16mf4_t vs2, size_t vl);
+vfloat32mf2_t __riscv_vfwnmsac_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
+                                   vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_tum(vbool32_t vm, vfloat32m1_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   size_t vl);
-vfloat32m1_t __riscv_vfwnmsac_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmsac_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                   vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_tum(vbool16_t vm, vfloat32m2_t vd,
                                   vfloat16m1_t vs1, vfloat16m1_t vs2,
                                   size_t vl);
-vfloat32m2_t __riscv_vfwnmsac_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmsac_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                   vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_tum(vbool8_t vm, vfloat32m4_t vd,
                                   vfloat16m2_t vs1, vfloat16m2_t vs2,
                                   size_t vl);
-vfloat32m4_t __riscv_vfwnmsac_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmsac_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                   vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_tum(vbool4_t vm, vfloat32m8_t vd,
                                   vfloat16m4_t vs1, vfloat16m4_t vs2,
                                   size_t vl);
-vfloat32m8_t __riscv_vfwnmsac_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmsac_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                   vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_tum(vbool64_t vm, vfloat64m1_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -9118,27 +9112,27 @@ vfloat64m8_t __riscv_vfwnmsac_tum(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwmacc_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                    size_t vl);
-vfloat32mf2_t __riscv_vfwmacc_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                   float16_t vs1, vfloat16mf4_t vs2, size_t vl);
+vfloat32mf2_t __riscv_vfwmacc_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
+                                   vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwmacc_tumu(vbool32_t vm, vfloat32m1_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   size_t vl);
-vfloat32m1_t __riscv_vfwmacc_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmacc_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                   vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwmacc_tumu(vbool16_t vm, vfloat32m2_t vd,
                                   vfloat16m1_t vs1, vfloat16m1_t vs2,
                                   size_t vl);
-vfloat32m2_t __riscv_vfwmacc_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmacc_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                   vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwmacc_tumu(vbool8_t vm, vfloat32m4_t vd,
                                   vfloat16m2_t vs1, vfloat16m2_t vs2,
                                   size_t vl);
-vfloat32m4_t __riscv_vfwmacc_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmacc_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                   vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwmacc_tumu(vbool4_t vm, vfloat32m8_t vd,
                                   vfloat16m4_t vs1, vfloat16m4_t vs2,
                                   size_t vl);
-vfloat32m8_t __riscv_vfwmacc_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmacc_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                   vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwmacc_tumu(vbool64_t vm, vfloat64m1_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -9164,27 +9158,26 @@ vfloat32mf2_t __riscv_vfwnmacc_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                     vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                     size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                    float16_t vs1, vfloat16mf4_t vs2,
-                                    size_t vl);
+                                    _Float16 vs1, vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_tumu(vbool32_t vm, vfloat32m1_t vd,
                                    vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                    size_t vl);
-vfloat32m1_t __riscv_vfwnmacc_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmacc_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                    vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_tumu(vbool16_t vm, vfloat32m2_t vd,
                                    vfloat16m1_t vs1, vfloat16m1_t vs2,
                                    size_t vl);
-vfloat32m2_t __riscv_vfwnmacc_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmacc_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                    vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_tumu(vbool8_t vm, vfloat32m4_t vd,
                                    vfloat16m2_t vs1, vfloat16m2_t vs2,
                                    size_t vl);
-vfloat32m4_t __riscv_vfwnmacc_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmacc_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                    vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_tumu(vbool4_t vm, vfloat32m8_t vd,
                                    vfloat16m4_t vs1, vfloat16m4_t vs2,
                                    size_t vl);
-vfloat32m8_t __riscv_vfwnmacc_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmacc_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                    vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_tumu(vbool64_t vm, vfloat64m1_t vd,
                                    vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -9209,27 +9202,27 @@ vfloat64m8_t __riscv_vfwnmacc_tumu(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwmsac_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                    size_t vl);
-vfloat32mf2_t __riscv_vfwmsac_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                   float16_t vs1, vfloat16mf4_t vs2, size_t vl);
+vfloat32mf2_t __riscv_vfwmsac_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
+                                   vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwmsac_tumu(vbool32_t vm, vfloat32m1_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   size_t vl);
-vfloat32m1_t __riscv_vfwmsac_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmsac_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                   vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwmsac_tumu(vbool16_t vm, vfloat32m2_t vd,
                                   vfloat16m1_t vs1, vfloat16m1_t vs2,
                                   size_t vl);
-vfloat32m2_t __riscv_vfwmsac_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmsac_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                   vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwmsac_tumu(vbool8_t vm, vfloat32m4_t vd,
                                   vfloat16m2_t vs1, vfloat16m2_t vs2,
                                   size_t vl);
-vfloat32m4_t __riscv_vfwmsac_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmsac_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                   vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwmsac_tumu(vbool4_t vm, vfloat32m8_t vd,
                                   vfloat16m4_t vs1, vfloat16m4_t vs2,
                                   size_t vl);
-vfloat32m8_t __riscv_vfwmsac_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmsac_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                   vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwmsac_tumu(vbool64_t vm, vfloat64m1_t vd,
                                   vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -9255,27 +9248,26 @@ vfloat32mf2_t __riscv_vfwnmsac_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                     vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                     size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                    float16_t vs1, vfloat16mf4_t vs2,
-                                    size_t vl);
+                                    _Float16 vs1, vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_tumu(vbool32_t vm, vfloat32m1_t vd,
                                    vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                    size_t vl);
-vfloat32m1_t __riscv_vfwnmsac_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmsac_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                    vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_tumu(vbool16_t vm, vfloat32m2_t vd,
                                    vfloat16m1_t vs1, vfloat16m1_t vs2,
                                    size_t vl);
-vfloat32m2_t __riscv_vfwnmsac_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmsac_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                    vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_tumu(vbool8_t vm, vfloat32m4_t vd,
                                    vfloat16m2_t vs1, vfloat16m2_t vs2,
                                    size_t vl);
-vfloat32m4_t __riscv_vfwnmsac_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmsac_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                    vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_tumu(vbool4_t vm, vfloat32m8_t vd,
                                    vfloat16m4_t vs1, vfloat16m4_t vs2,
                                    size_t vl);
-vfloat32m8_t __riscv_vfwnmsac_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmsac_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                    vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_tumu(vbool64_t vm, vfloat64m1_t vd,
                                    vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -9301,24 +9293,24 @@ vfloat64m8_t __riscv_vfwnmsac_tumu(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwmacc_mu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  size_t vl);
-vfloat32mf2_t __riscv_vfwmacc_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmacc_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                  vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwmacc_mu(vbool32_t vm, vfloat32m1_t vd,
                                 vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                 size_t vl);
-vfloat32m1_t __riscv_vfwmacc_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmacc_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                 vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwmacc_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmacc_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmacc_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                 vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwmacc_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmacc_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmacc_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                 vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwmacc_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmacc_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmacc_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                 vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwmacc_mu(vbool64_t vm, vfloat64m1_t vd,
                                 vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -9340,24 +9332,24 @@ vfloat64m8_t __riscv_vfwmacc_mu(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwnmacc_mu(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmacc_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                   vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_mu(vbool32_t vm, vfloat32m1_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  size_t vl);
-vfloat32m1_t __riscv_vfwnmacc_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmacc_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                  vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_mu(vbool16_t vm, vfloat32m2_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwnmacc_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmacc_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                  vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwnmacc_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmacc_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                  vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwnmacc_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmacc_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                  vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_mu(vbool64_t vm, vfloat64m1_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -9379,24 +9371,24 @@ vfloat64m8_t __riscv_vfwnmacc_mu(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwmsac_mu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  size_t vl);
-vfloat32mf2_t __riscv_vfwmsac_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmsac_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                  vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwmsac_mu(vbool32_t vm, vfloat32m1_t vd,
                                 vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                 size_t vl);
-vfloat32m1_t __riscv_vfwmsac_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmsac_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                 vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwmsac_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwmsac_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmsac_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                 vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwmsac_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwmsac_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmsac_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                 vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwmsac_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwmsac_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmsac_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                 vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwmsac_mu(vbool64_t vm, vfloat64m1_t vd,
                                 vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -9418,24 +9410,24 @@ vfloat64m8_t __riscv_vfwmsac_mu(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwnmsac_mu(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmsac_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                   vfloat16mf4_t vs2, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_mu(vbool32_t vm, vfloat32m1_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  size_t vl);
-vfloat32m1_t __riscv_vfwnmsac_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmsac_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                  vfloat16mf2_t vs2, size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_mu(vbool16_t vm, vfloat32m2_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2, size_t vl);
-vfloat32m2_t __riscv_vfwnmsac_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmsac_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                  vfloat16m1_t vs2, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, size_t vl);
-vfloat32m4_t __riscv_vfwnmsac_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmsac_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                  vfloat16m2_t vs2, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, size_t vl);
-vfloat32m8_t __riscv_vfwnmsac_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmsac_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                  vfloat16m4_t vs2, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_mu(vbool64_t vm, vfloat64m1_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -9457,25 +9449,25 @@ vfloat64m8_t __riscv_vfwnmsac_mu(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwmacc_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
-vfloat32mf2_t __riscv_vfwmacc_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmacc_tu(vfloat32mf2_t vd, _Float16 vs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat32m1_t __riscv_vfwmacc_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                 vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmacc_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmacc_tu(vfloat32m1_t vd, _Float16 vs1,
                                 vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmacc_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmacc_tu(vfloat32m2_t vd, float16_t vs1,
-                                vfloat16m1_t vs2, unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfwmacc_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmacc_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmacc_tu(vfloat32m4_t vd, float16_t vs1,
-                                vfloat16m2_t vs2, unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfwmacc_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmacc_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmacc_tu(vfloat32m8_t vd, float16_t vs1,
-                                vfloat16m4_t vs2, unsigned int frm, size_t vl);
+vfloat32m8_t __riscv_vfwmacc_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmacc_tu(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                 vfloat32mf2_t vs2, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmacc_tu(vfloat64m1_t vd, float32_t vs1,
@@ -9495,26 +9487,26 @@ vfloat64m8_t __riscv_vfwmacc_tu(vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwnmacc_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                   vfloat16mf4_t vs2, unsigned int frm,
                                   size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmacc_tu(vfloat32mf2_t vd, _Float16 vs1,
                                   vfloat16mf4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
-vfloat32m1_t __riscv_vfwnmacc_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmacc_tu(vfloat32m1_t vd, _Float16 vs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
                                  vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwnmacc_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmacc_tu(vfloat32m2_t vd, _Float16 vs1,
                                  vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwnmacc_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmacc_tu(vfloat32m4_t vd, _Float16 vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwnmacc_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmacc_tu(vfloat32m8_t vd, _Float16 vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_tu(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                  vfloat32mf2_t vs2, unsigned int frm,
@@ -9537,25 +9529,25 @@ vfloat64m8_t __riscv_vfwnmacc_tu(vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwmsac_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
-vfloat32mf2_t __riscv_vfwmsac_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmsac_tu(vfloat32mf2_t vd, _Float16 vs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat32m1_t __riscv_vfwmsac_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                 vfloat16mf2_t vs2, unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmsac_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmsac_tu(vfloat32m1_t vd, _Float16 vs1,
                                 vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmsac_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmsac_tu(vfloat32m2_t vd, float16_t vs1,
-                                vfloat16m1_t vs2, unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfwmsac_tu(vfloat32m2_t vd, _Float16 vs1, vfloat16m1_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmsac_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmsac_tu(vfloat32m4_t vd, float16_t vs1,
-                                vfloat16m2_t vs2, unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfwmsac_tu(vfloat32m4_t vd, _Float16 vs1, vfloat16m2_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmsac_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmsac_tu(vfloat32m8_t vd, float16_t vs1,
-                                vfloat16m4_t vs2, unsigned int frm, size_t vl);
+vfloat32m8_t __riscv_vfwmsac_tu(vfloat32m8_t vd, _Float16 vs1, vfloat16m4_t vs2,
+                                unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmsac_tu(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                 vfloat32mf2_t vs2, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmsac_tu(vfloat64m1_t vd, float32_t vs1,
@@ -9575,26 +9567,26 @@ vfloat64m8_t __riscv_vfwmsac_tu(vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwnmsac_tu(vfloat32mf2_t vd, vfloat16mf4_t vs1,
                                   vfloat16mf4_t vs2, unsigned int frm,
                                   size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac_tu(vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmsac_tu(vfloat32mf2_t vd, _Float16 vs1,
                                   vfloat16mf4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_tu(vfloat32m1_t vd, vfloat16mf2_t vs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
-vfloat32m1_t __riscv_vfwnmsac_tu(vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmsac_tu(vfloat32m1_t vd, _Float16 vs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_tu(vfloat32m2_t vd, vfloat16m1_t vs1,
                                  vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwnmsac_tu(vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmsac_tu(vfloat32m2_t vd, _Float16 vs1,
                                  vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_tu(vfloat32m4_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwnmsac_tu(vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmsac_tu(vfloat32m4_t vd, _Float16 vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_tu(vfloat32m8_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwnmsac_tu(vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmsac_tu(vfloat32m8_t vd, _Float16 vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_tu(vfloat64m1_t vd, vfloat32mf2_t vs1,
                                  vfloat32mf2_t vs2, unsigned int frm,
@@ -9618,27 +9610,27 @@ vfloat64m8_t __riscv_vfwnmsac_tu(vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwmacc_tum(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmacc_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmacc_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                   vfloat16mf4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32m1_t __riscv_vfwmacc_tum(vbool32_t vm, vfloat32m1_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmacc_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmacc_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat32m2_t __riscv_vfwmacc_tum(vbool16_t vm, vfloat32m2_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmacc_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmacc_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                  vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmacc_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmacc_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmacc_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmacc_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmacc_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmacc_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmacc_tum(vbool64_t vm, vfloat64m1_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -9663,31 +9655,31 @@ vfloat64m8_t __riscv_vfwmacc_tum(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwnmacc_tum(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                   float16_t vs1, vfloat16mf4_t vs2,
-                                   unsigned int frm, size_t vl);
+vfloat32mf2_t __riscv_vfwnmacc_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
+                                   vfloat16mf4_t vs2, unsigned int frm,
+                                   size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_tum(vbool32_t vm, vfloat32m1_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwnmacc_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmacc_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                   vfloat16mf2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_tum(vbool16_t vm, vfloat32m2_t vd,
                                   vfloat16m1_t vs1, vfloat16m1_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwnmacc_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmacc_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                   vfloat16m1_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_tum(vbool8_t vm, vfloat32m4_t vd,
                                   vfloat16m2_t vs1, vfloat16m2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwnmacc_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmacc_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                   vfloat16m2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_tum(vbool4_t vm, vfloat32m8_t vd,
                                   vfloat16m4_t vs1, vfloat16m4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwnmacc_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmacc_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                   vfloat16m4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_tum(vbool64_t vm, vfloat64m1_t vd,
@@ -9717,27 +9709,27 @@ vfloat64m8_t __riscv_vfwnmacc_tum(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwmsac_tum(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmsac_tum(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmsac_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                   vfloat16mf4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32m1_t __riscv_vfwmsac_tum(vbool32_t vm, vfloat32m1_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmsac_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmsac_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat32m2_t __riscv_vfwmsac_tum(vbool16_t vm, vfloat32m2_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmsac_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmsac_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                  vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmsac_tum(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmsac_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmsac_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmsac_tum(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmsac_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmsac_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmsac_tum(vbool64_t vm, vfloat64m1_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -9762,31 +9754,31 @@ vfloat64m8_t __riscv_vfwmsac_tum(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwnmsac_tum(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac_tum(vbool64_t vm, vfloat32mf2_t vd,
-                                   float16_t vs1, vfloat16mf4_t vs2,
-                                   unsigned int frm, size_t vl);
+vfloat32mf2_t __riscv_vfwnmsac_tum(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
+                                   vfloat16mf4_t vs2, unsigned int frm,
+                                   size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_tum(vbool32_t vm, vfloat32m1_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwnmsac_tum(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmsac_tum(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                   vfloat16mf2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_tum(vbool16_t vm, vfloat32m2_t vd,
                                   vfloat16m1_t vs1, vfloat16m1_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwnmsac_tum(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmsac_tum(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                   vfloat16m1_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_tum(vbool8_t vm, vfloat32m4_t vd,
                                   vfloat16m2_t vs1, vfloat16m2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwnmsac_tum(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmsac_tum(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                   vfloat16m2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_tum(vbool4_t vm, vfloat32m8_t vd,
                                   vfloat16m4_t vs1, vfloat16m4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwnmsac_tum(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmsac_tum(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                   vfloat16m4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_tum(vbool64_t vm, vfloat64m1_t vd,
@@ -9817,31 +9809,31 @@ vfloat64m8_t __riscv_vfwnmsac_tum(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwmacc_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmacc_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                   float16_t vs1, vfloat16mf4_t vs2,
-                                   unsigned int frm, size_t vl);
+vfloat32mf2_t __riscv_vfwmacc_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
+                                   vfloat16mf4_t vs2, unsigned int frm,
+                                   size_t vl);
 vfloat32m1_t __riscv_vfwmacc_tumu(vbool32_t vm, vfloat32m1_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmacc_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmacc_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                   vfloat16mf2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32m2_t __riscv_vfwmacc_tumu(vbool16_t vm, vfloat32m2_t vd,
                                   vfloat16m1_t vs1, vfloat16m1_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmacc_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmacc_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                   vfloat16m1_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32m4_t __riscv_vfwmacc_tumu(vbool8_t vm, vfloat32m4_t vd,
                                   vfloat16m2_t vs1, vfloat16m2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmacc_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmacc_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                   vfloat16m2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32m8_t __riscv_vfwmacc_tumu(vbool4_t vm, vfloat32m8_t vd,
                                   vfloat16m4_t vs1, vfloat16m4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmacc_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmacc_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                   vfloat16m4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat64m1_t __riscv_vfwmacc_tumu(vbool64_t vm, vfloat64m1_t vd,
@@ -9872,30 +9864,30 @@ vfloat32mf2_t __riscv_vfwnmacc_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                     vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                     unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwnmacc_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                    float16_t vs1, vfloat16mf4_t vs2,
+                                    _Float16 vs1, vfloat16mf4_t vs2,
                                     unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_tumu(vbool32_t vm, vfloat32m1_t vd,
                                    vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwnmacc_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmacc_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                    vfloat16mf2_t vs2, unsigned int frm,
                                    size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_tumu(vbool16_t vm, vfloat32m2_t vd,
                                    vfloat16m1_t vs1, vfloat16m1_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwnmacc_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmacc_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                    vfloat16m1_t vs2, unsigned int frm,
                                    size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_tumu(vbool8_t vm, vfloat32m4_t vd,
                                    vfloat16m2_t vs1, vfloat16m2_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwnmacc_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmacc_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                    vfloat16m2_t vs2, unsigned int frm,
                                    size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_tumu(vbool4_t vm, vfloat32m8_t vd,
                                    vfloat16m4_t vs1, vfloat16m4_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwnmacc_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmacc_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                    vfloat16m4_t vs2, unsigned int frm,
                                    size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_tumu(vbool64_t vm, vfloat64m1_t vd,
@@ -9925,31 +9917,31 @@ vfloat64m8_t __riscv_vfwnmacc_tumu(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwmsac_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmsac_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                   float16_t vs1, vfloat16mf4_t vs2,
-                                   unsigned int frm, size_t vl);
+vfloat32mf2_t __riscv_vfwmsac_tumu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
+                                   vfloat16mf4_t vs2, unsigned int frm,
+                                   size_t vl);
 vfloat32m1_t __riscv_vfwmsac_tumu(vbool32_t vm, vfloat32m1_t vd,
                                   vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmsac_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmsac_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                   vfloat16mf2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32m2_t __riscv_vfwmsac_tumu(vbool16_t vm, vfloat32m2_t vd,
                                   vfloat16m1_t vs1, vfloat16m1_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmsac_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmsac_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                   vfloat16m1_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32m4_t __riscv_vfwmsac_tumu(vbool8_t vm, vfloat32m4_t vd,
                                   vfloat16m2_t vs1, vfloat16m2_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmsac_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmsac_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                   vfloat16m2_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32m8_t __riscv_vfwmsac_tumu(vbool4_t vm, vfloat32m8_t vd,
                                   vfloat16m4_t vs1, vfloat16m4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmsac_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmsac_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                   vfloat16m4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat64m1_t __riscv_vfwmsac_tumu(vbool64_t vm, vfloat64m1_t vd,
@@ -9980,30 +9972,30 @@ vfloat32mf2_t __riscv_vfwnmsac_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                     vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                     unsigned int frm, size_t vl);
 vfloat32mf2_t __riscv_vfwnmsac_tumu(vbool64_t vm, vfloat32mf2_t vd,
-                                    float16_t vs1, vfloat16mf4_t vs2,
+                                    _Float16 vs1, vfloat16mf4_t vs2,
                                     unsigned int frm, size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_tumu(vbool32_t vm, vfloat32m1_t vd,
                                    vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwnmsac_tumu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmsac_tumu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                    vfloat16mf2_t vs2, unsigned int frm,
                                    size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_tumu(vbool16_t vm, vfloat32m2_t vd,
                                    vfloat16m1_t vs1, vfloat16m1_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwnmsac_tumu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmsac_tumu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                    vfloat16m1_t vs2, unsigned int frm,
                                    size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_tumu(vbool8_t vm, vfloat32m4_t vd,
                                    vfloat16m2_t vs1, vfloat16m2_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwnmsac_tumu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmsac_tumu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                    vfloat16m2_t vs2, unsigned int frm,
                                    size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_tumu(vbool4_t vm, vfloat32m8_t vd,
                                    vfloat16m4_t vs1, vfloat16m4_t vs2,
                                    unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwnmsac_tumu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmsac_tumu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                    vfloat16m4_t vs2, unsigned int frm,
                                    size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_tumu(vbool64_t vm, vfloat64m1_t vd,
@@ -10034,25 +10026,25 @@ vfloat64m8_t __riscv_vfwnmsac_tumu(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwmacc_mu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmacc_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmacc_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat32m1_t __riscv_vfwmacc_mu(vbool32_t vm, vfloat32m1_t vd,
                                 vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                 unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmacc_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmacc_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                 vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmacc_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmacc_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmacc_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmacc_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmacc_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmacc_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmacc_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmacc_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmacc_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmacc_mu(vbool64_t vm, vfloat64m1_t vd,
                                 vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -10074,27 +10066,27 @@ vfloat64m8_t __riscv_vfwmacc_mu(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwnmacc_mu(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwnmacc_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmacc_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                   vfloat16mf4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32m1_t __riscv_vfwnmacc_mu(vbool32_t vm, vfloat32m1_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwnmacc_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmacc_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat32m2_t __riscv_vfwnmacc_mu(vbool16_t vm, vfloat32m2_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwnmacc_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmacc_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                  vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmacc_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwnmacc_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmacc_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmacc_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwnmacc_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmacc_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmacc_mu(vbool64_t vm, vfloat64m1_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -10119,25 +10111,25 @@ vfloat64m8_t __riscv_vfwnmacc_mu(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwmsac_mu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwmsac_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwmsac_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                  vfloat16mf4_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat32m1_t __riscv_vfwmsac_mu(vbool32_t vm, vfloat32m1_t vd,
                                 vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                 unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwmsac_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwmsac_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                 vfloat16mf2_t vs2, unsigned int frm, size_t vl);
 vfloat32m2_t __riscv_vfwmsac_mu(vbool16_t vm, vfloat32m2_t vd, vfloat16m1_t vs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwmsac_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwmsac_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                 vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwmsac_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwmsac_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwmsac_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                 vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwmsac_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwmsac_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwmsac_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                 vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwmsac_mu(vbool64_t vm, vfloat64m1_t vd,
                                 vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -10159,27 +10151,27 @@ vfloat64m8_t __riscv_vfwmsac_mu(vbool8_t vm, vfloat64m8_t vd, float32_t vs1,
 vfloat32mf2_t __riscv_vfwnmsac_mu(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat16mf4_t vs1, vfloat16mf4_t vs2,
                                   unsigned int frm, size_t vl);
-vfloat32mf2_t __riscv_vfwnmsac_mu(vbool64_t vm, vfloat32mf2_t vd, float16_t vs1,
+vfloat32mf2_t __riscv_vfwnmsac_mu(vbool64_t vm, vfloat32mf2_t vd, _Float16 vs1,
                                   vfloat16mf4_t vs2, unsigned int frm,
                                   size_t vl);
 vfloat32m1_t __riscv_vfwnmsac_mu(vbool32_t vm, vfloat32m1_t vd,
                                  vfloat16mf2_t vs1, vfloat16mf2_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat32m1_t __riscv_vfwnmsac_mu(vbool32_t vm, vfloat32m1_t vd, float16_t vs1,
+vfloat32m1_t __riscv_vfwnmsac_mu(vbool32_t vm, vfloat32m1_t vd, _Float16 vs1,
                                  vfloat16mf2_t vs2, unsigned int frm,
                                  size_t vl);
 vfloat32m2_t __riscv_vfwnmsac_mu(vbool16_t vm, vfloat32m2_t vd,
                                  vfloat16m1_t vs1, vfloat16m1_t vs2,
                                  unsigned int frm, size_t vl);
-vfloat32m2_t __riscv_vfwnmsac_mu(vbool16_t vm, vfloat32m2_t vd, float16_t vs1,
+vfloat32m2_t __riscv_vfwnmsac_mu(vbool16_t vm, vfloat32m2_t vd, _Float16 vs1,
                                  vfloat16m1_t vs2, unsigned int frm, size_t vl);
 vfloat32m4_t __riscv_vfwnmsac_mu(vbool8_t vm, vfloat32m4_t vd, vfloat16m2_t vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
-vfloat32m4_t __riscv_vfwnmsac_mu(vbool8_t vm, vfloat32m4_t vd, float16_t vs1,
+vfloat32m4_t __riscv_vfwnmsac_mu(vbool8_t vm, vfloat32m4_t vd, _Float16 vs1,
                                  vfloat16m2_t vs2, unsigned int frm, size_t vl);
 vfloat32m8_t __riscv_vfwnmsac_mu(vbool4_t vm, vfloat32m8_t vd, vfloat16m4_t vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
-vfloat32m8_t __riscv_vfwnmsac_mu(vbool4_t vm, vfloat32m8_t vd, float16_t vs1,
+vfloat32m8_t __riscv_vfwnmsac_mu(vbool4_t vm, vfloat32m8_t vd, _Float16 vs1,
                                  vfloat16m4_t vs2, unsigned int frm, size_t vl);
 vfloat64m1_t __riscv_vfwnmsac_mu(vbool64_t vm, vfloat64m1_t vd,
                                  vfloat32mf2_t vs1, vfloat32mf2_t vs2,
@@ -10817,26 +10809,26 @@ vfloat64m8_t __riscv_vfrec7_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfmin_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfmin_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmin_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfmin_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmin_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfmin_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfmin_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m2_t __riscv_vfmin_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfmin_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfmin_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m4_t __riscv_vfmin_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfmin_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfmin_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m8_t __riscv_vfmin_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfmin_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfmin_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat32mf2_t __riscv_vfmin_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, size_t vl);
@@ -10877,26 +10869,26 @@ vfloat64m8_t __riscv_vfmin_tu(vfloat64m8_t vd, vfloat64m8_t vs2, float64_t rs1,
 vfloat16mf4_t __riscv_vfmax_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfmax_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmax_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfmax_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmax_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfmax_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfmax_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m2_t __riscv_vfmax_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfmax_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfmax_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m4_t __riscv_vfmax_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfmax_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfmax_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat16m8_t __riscv_vfmax_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfmax_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfmax_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1,
                               size_t vl);
 vfloat32mf2_t __riscv_vfmax_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                vfloat32mf2_t vs1, size_t vl);
@@ -10939,28 +10931,28 @@ vfloat16mf4_t __riscv_vfmin_tum(vbool64_t vm, vfloat16mf4_t vd,
                                 vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 size_t vl);
 vfloat16mf4_t __riscv_vfmin_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmin_tum(vbool32_t vm, vfloat16mf2_t vd,
                                 vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                 size_t vl);
 vfloat16mf2_t __riscv_vfmin_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmin_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfmin_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmin_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfmin_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmin_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfmin_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmin_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfmin_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmin_tum(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                 size_t vl);
@@ -11002,28 +10994,28 @@ vfloat16mf4_t __riscv_vfmax_tum(vbool64_t vm, vfloat16mf4_t vd,
                                 vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 size_t vl);
 vfloat16mf4_t __riscv_vfmax_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmax_tum(vbool32_t vm, vfloat16mf2_t vd,
                                 vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                 size_t vl);
 vfloat16mf2_t __riscv_vfmax_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmax_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfmax_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmax_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfmax_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmax_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfmax_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmax_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfmax_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmax_tum(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                 size_t vl);
@@ -11066,28 +11058,28 @@ vfloat16mf4_t __riscv_vfmin_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                  size_t vl);
 vfloat16mf4_t __riscv_vfmin_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                 vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmin_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfmin_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                 vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmin_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                 vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfmin_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmin_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                 vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfmin_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmin_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                 vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfmin_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmin_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                 vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfmin_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmin_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                  size_t vl);
@@ -11129,28 +11121,28 @@ vfloat16mf4_t __riscv_vfmax_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                  size_t vl);
 vfloat16mf4_t __riscv_vfmax_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                 vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmax_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfmax_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                 vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmax_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                 vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfmax_tumu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmax_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                 vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfmax_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmax_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                 vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfmax_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmax_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                 vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfmax_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmax_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                  size_t vl);
@@ -11192,27 +11184,27 @@ vfloat64m8_t __riscv_vfmax_tumu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfmin_mu(vbool64_t vm, vfloat16mf4_t vd,
                                vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfmin_mu(vbool64_t vm, vfloat16mf4_t vd,
-                               vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                               vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmin_mu(vbool32_t vm, vfloat16mf2_t vd,
                                vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfmin_mu(vbool32_t vm, vfloat16mf2_t vd,
-                               vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                               vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmin_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfmin_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmin_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfmin_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmin_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfmin_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmin_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfmin_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmin_mu(vbool64_t vm, vfloat32mf2_t vd,
                                vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmin_mu(vbool64_t vm, vfloat32mf2_t vd,
@@ -11252,27 +11244,27 @@ vfloat64m8_t __riscv_vfmin_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfmax_mu(vbool64_t vm, vfloat16mf4_t vd,
                                vfloat16mf4_t vs2, vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfmax_mu(vbool64_t vm, vfloat16mf4_t vd,
-                               vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                               vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfmax_mu(vbool32_t vm, vfloat16mf2_t vd,
                                vfloat16mf2_t vs2, vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfmax_mu(vbool32_t vm, vfloat16mf2_t vd,
-                               vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                               vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfmax_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                               vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfmax_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfmax_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                               vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfmax_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfmax_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                               vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfmax_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfmax_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                               vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfmax_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                              float16_t rs1, size_t vl);
+                              _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmax_mu(vbool64_t vm, vfloat32mf2_t vd,
                                vfloat32mf2_t vs2, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmax_mu(vbool64_t vm, vfloat32mf2_t vd,
@@ -11319,26 +11311,26 @@ vfloat64m8_t __riscv_vfmax_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfsgnj_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                 vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnj_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                 vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnj_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                                vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfsgnj_tu(vfloat16m1_t vd, vfloat16m1_t vs2, float16_t rs1,
+vfloat16m1_t __riscv_vfsgnj_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat16m2_t __riscv_vfsgnj_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                                vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfsgnj_tu(vfloat16m2_t vd, vfloat16m2_t vs2, float16_t rs1,
+vfloat16m2_t __riscv_vfsgnj_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat16m4_t __riscv_vfsgnj_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                                vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfsgnj_tu(vfloat16m4_t vd, vfloat16m4_t vs2, float16_t rs1,
+vfloat16m4_t __riscv_vfsgnj_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat16m8_t __riscv_vfsgnj_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                                vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfsgnj_tu(vfloat16m8_t vd, vfloat16m8_t vs2, float16_t rs1,
+vfloat16m8_t __riscv_vfsgnj_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1,
                                size_t vl);
 vfloat32mf2_t __riscv_vfsgnj_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                 vfloat32mf2_t vs1, size_t vl);
@@ -11379,27 +11371,27 @@ vfloat64m8_t __riscv_vfsgnj_tu(vfloat64m8_t vd, vfloat64m8_t vs2, float64_t rs1,
 vfloat16mf4_t __riscv_vfsgnjn_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                  vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnjn_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                  vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                                 vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfsgnjn_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfsgnjn_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1,
+                                size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                                 vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfsgnjn_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfsgnjn_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1,
+                                size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                                 vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfsgnjn_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfsgnjn_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1,
+                                size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                                 vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfsgnjn_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfsgnjn_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1,
+                                size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                  vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
@@ -11439,27 +11431,27 @@ vfloat64m8_t __riscv_vfsgnjn_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vfsgnjx_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                  vfloat16mf4_t vs1, size_t vl);
 vfloat16mf4_t __riscv_vfsgnjx_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                  vfloat16mf2_t vs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                                 vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfsgnjx_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfsgnjx_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1,
+                                size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                                 vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfsgnjx_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfsgnjx_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1,
+                                size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                                 vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfsgnjx_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfsgnjx_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1,
+                                size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                                 vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfsgnjx_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfsgnjx_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1,
+                                size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                  vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
@@ -11501,28 +11493,28 @@ vfloat16mf4_t __riscv_vfsgnj_tum(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                  size_t vl);
 vfloat16mf4_t __riscv_vfsgnj_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                 vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_tum(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                 vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnj_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                 vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnj_tum(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnj_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                 vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnj_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnj_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                 vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnj_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnj_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                 vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnj_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnj_tum(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                  size_t vl);
@@ -11564,28 +11556,28 @@ vfloat16mf4_t __riscv_vfsgnjn_tum(vbool64_t vm, vfloat16mf4_t vd,
                                   vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                   size_t vl);
 vfloat16mf4_t __riscv_vfsgnjn_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                  vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_tum(vbool32_t vm, vfloat16mf2_t vd,
                                   vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                   size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                  vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_tum(vbool16_t vm, vfloat16m1_t vd,
                                  vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_tum(vbool16_t vm, vfloat16m1_t vd,
-                                 vfloat16m1_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                  vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                  vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                  vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn_tum(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                   size_t vl);
@@ -11627,28 +11619,28 @@ vfloat16mf4_t __riscv_vfsgnjx_tum(vbool64_t vm, vfloat16mf4_t vd,
                                   vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                   size_t vl);
 vfloat16mf4_t __riscv_vfsgnjx_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                  vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_tum(vbool32_t vm, vfloat16mf2_t vd,
                                   vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                   size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                  vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_tum(vbool16_t vm, vfloat16m1_t vd,
                                  vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_tum(vbool16_t vm, vfloat16m1_t vd,
-                                 vfloat16m1_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                  vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_tum(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                  vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_tum(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                  vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_tum(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx_tum(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                   size_t vl);
@@ -11691,28 +11683,28 @@ vfloat16mf4_t __riscv_vfsgnj_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                   vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                   size_t vl);
 vfloat16mf4_t __riscv_vfsgnj_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                  vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                   vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                   size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                  vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnj_tumu(vbool16_t vm, vfloat16m1_t vd,
                                  vfloat16m1_t vs2, vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnj_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                 vfloat16m1_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnj_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                  vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnj_tumu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnj_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                  vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnj_tumu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnj_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                  vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnj_tumu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                 float16_t rs1, size_t vl);
+                                 _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnj_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                   vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                   size_t vl);
@@ -11754,32 +11746,32 @@ vfloat16mf4_t __riscv_vfsgnjn_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                    vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                    size_t vl);
 vfloat16mf4_t __riscv_vfsgnjn_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                   vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                   vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                    vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                    size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                   vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                   vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_tumu(vbool16_t vm, vfloat16m1_t vd,
                                   vfloat16m1_t vs2, vfloat16m1_t vs1,
                                   size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                  vfloat16m1_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_tumu(vbool8_t vm, vfloat16m2_t vd,
                                   vfloat16m2_t vs2, vfloat16m2_t vs1,
                                   size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                  vfloat16m2_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_tumu(vbool4_t vm, vfloat16m4_t vd,
                                   vfloat16m4_t vs2, vfloat16m4_t vs1,
                                   size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                  vfloat16m4_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_tumu(vbool2_t vm, vfloat16m8_t vd,
                                   vfloat16m8_t vs2, vfloat16m8_t vs1,
                                   size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                  vfloat16m8_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                    size_t vl);
@@ -11829,32 +11821,32 @@ vfloat16mf4_t __riscv_vfsgnjx_tumu(vbool64_t vm, vfloat16mf4_t vd,
                                    vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                    size_t vl);
 vfloat16mf4_t __riscv_vfsgnjx_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                   vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                   vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_tumu(vbool32_t vm, vfloat16mf2_t vd,
                                    vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                    size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                   vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                   vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_tumu(vbool16_t vm, vfloat16m1_t vd,
                                   vfloat16m1_t vs2, vfloat16m1_t vs1,
                                   size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                  vfloat16m1_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_tumu(vbool8_t vm, vfloat16m2_t vd,
                                   vfloat16m2_t vs2, vfloat16m2_t vs1,
                                   size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                  vfloat16m2_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_tumu(vbool4_t vm, vfloat16m4_t vd,
                                   vfloat16m4_t vs2, vfloat16m4_t vs1,
                                   size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                  vfloat16m4_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_tumu(vbool2_t vm, vfloat16m8_t vd,
                                   vfloat16m8_t vs2, vfloat16m8_t vs1,
                                   size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                  vfloat16m8_t vs2, float16_t rs1, size_t vl);
+                                  vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                    vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                    size_t vl);
@@ -11905,28 +11897,28 @@ vfloat16mf4_t __riscv_vfsgnj_mu(vbool64_t vm, vfloat16mf4_t vd,
                                 vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                 size_t vl);
 vfloat16mf4_t __riscv_vfsgnj_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_mu(vbool32_t vm, vfloat16mf2_t vd,
                                 vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                 size_t vl);
 vfloat16mf2_t __riscv_vfsgnj_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnj_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnj_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnj_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnj_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnj_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnj_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnj_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnj_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                               float16_t rs1, size_t vl);
+                               _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnj_mu(vbool64_t vm, vfloat32mf2_t vd,
                                 vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                 size_t vl);
@@ -11968,28 +11960,28 @@ vfloat16mf4_t __riscv_vfsgnjn_mu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                  size_t vl);
 vfloat16mf4_t __riscv_vfsgnjn_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                 vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_mu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfsgnjn_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                 vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                 vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjn_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                 vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjn_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                 vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjn_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                 vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjn_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjn_mu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                  size_t vl);
@@ -12031,28 +12023,28 @@ vfloat16mf4_t __riscv_vfsgnjx_mu(vbool64_t vm, vfloat16mf4_t vd,
                                  vfloat16mf4_t vs2, vfloat16mf4_t vs1,
                                  size_t vl);
 vfloat16mf4_t __riscv_vfsgnjx_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                 vfloat16mf4_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_mu(vbool32_t vm, vfloat16mf2_t vd,
                                  vfloat16mf2_t vs2, vfloat16mf2_t vs1,
                                  size_t vl);
 vfloat16mf2_t __riscv_vfsgnjx_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                 vfloat16mf2_t vs2, float16_t rs1, size_t vl);
+                                 vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
                                 vfloat16m1_t vs1, size_t vl);
 vfloat16m1_t __riscv_vfsgnjx_mu(vbool16_t vm, vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
                                 vfloat16m2_t vs1, size_t vl);
 vfloat16m2_t __riscv_vfsgnjx_mu(vbool8_t vm, vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
                                 vfloat16m4_t vs1, size_t vl);
 vfloat16m4_t __riscv_vfsgnjx_mu(vbool4_t vm, vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
                                 vfloat16m8_t vs1, size_t vl);
 vfloat16m8_t __riscv_vfsgnjx_mu(vbool2_t vm, vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, size_t vl);
+                                _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfsgnjx_mu(vbool64_t vm, vfloat32mf2_t vd,
                                  vfloat32mf2_t vs2, vfloat32mf2_t vs1,
                                  size_t vl);
@@ -12216,27 +12208,27 @@ vfloat64m8_t __riscv_vfabs_mu(vbool8_t vm, vfloat64m8_t vd, vfloat64m8_t vs2,
 vbool64_t __riscv_vmfeq_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2,
                            vfloat16mf4_t vs1, size_t vl);
 vbool64_t __riscv_vmfeq_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2,
-                           float16_t rs1, size_t vl);
+                           _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfeq_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2,
                            vfloat16mf2_t vs1, size_t vl);
 vbool32_t __riscv_vmfeq_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2,
-                           float16_t rs1, size_t vl);
+                           _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfeq_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2,
                            vfloat16m1_t vs1, size_t vl);
 vbool16_t __riscv_vmfeq_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2,
-                           float16_t rs1, size_t vl);
+                           _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfeq_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
                           vfloat16m2_t vs1, size_t vl);
 vbool8_t __riscv_vmfeq_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
-                          float16_t rs1, size_t vl);
+                          _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfeq_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
                           vfloat16m4_t vs1, size_t vl);
 vbool4_t __riscv_vmfeq_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
-                          float16_t rs1, size_t vl);
+                          _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfeq_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
                           vfloat16m8_t vs1, size_t vl);
 vbool2_t __riscv_vmfeq_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
-                          float16_t rs1, size_t vl);
+                          _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfeq_mu(vbool64_t vm, vbool64_t vd, vfloat32mf2_t vs2,
                            vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfeq_mu(vbool64_t vm, vbool64_t vd, vfloat32mf2_t vs2,
@@ -12276,27 +12268,27 @@ vbool8_t __riscv_vmfeq_mu(vbool8_t vm, vbool8_t vd, vfloat64m8_t vs2,
 vbool64_t __riscv_vmfne_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2,
                            vfloat16mf4_t vs1, size_t vl);
 vbool64_t __riscv_vmfne_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2,
-                           float16_t rs1, size_t vl);
+                           _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfne_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2,
                            vfloat16mf2_t vs1, size_t vl);
 vbool32_t __riscv_vmfne_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2,
-                           float16_t rs1, size_t vl);
+                           _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfne_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2,
                            vfloat16m1_t vs1, size_t vl);
 vbool16_t __riscv_vmfne_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2,
-                           float16_t rs1, size_t vl);
+                           _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfne_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
                           vfloat16m2_t vs1, size_t vl);
 vbool8_t __riscv_vmfne_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
-                          float16_t rs1, size_t vl);
+                          _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfne_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
                           vfloat16m4_t vs1, size_t vl);
 vbool4_t __riscv_vmfne_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
-                          float16_t rs1, size_t vl);
+                          _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfne_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
                           vfloat16m8_t vs1, size_t vl);
 vbool2_t __riscv_vmfne_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
-                          float16_t rs1, size_t vl);
+                          _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfne_mu(vbool64_t vm, vbool64_t vd, vfloat32mf2_t vs2,
                            vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfne_mu(vbool64_t vm, vbool64_t vd, vfloat32mf2_t vs2,
@@ -12336,27 +12328,27 @@ vbool8_t __riscv_vmfne_mu(vbool8_t vm, vbool8_t vd, vfloat64m8_t vs2,
 vbool64_t __riscv_vmflt_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2,
                            vfloat16mf4_t vs1, size_t vl);
 vbool64_t __riscv_vmflt_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2,
-                           float16_t rs1, size_t vl);
+                           _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmflt_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2,
                            vfloat16mf2_t vs1, size_t vl);
 vbool32_t __riscv_vmflt_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2,
-                           float16_t rs1, size_t vl);
+                           _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmflt_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2,
                            vfloat16m1_t vs1, size_t vl);
 vbool16_t __riscv_vmflt_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2,
-                           float16_t rs1, size_t vl);
+                           _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmflt_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
                           vfloat16m2_t vs1, size_t vl);
 vbool8_t __riscv_vmflt_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
-                          float16_t rs1, size_t vl);
+                          _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmflt_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
                           vfloat16m4_t vs1, size_t vl);
 vbool4_t __riscv_vmflt_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
-                          float16_t rs1, size_t vl);
+                          _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmflt_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
                           vfloat16m8_t vs1, size_t vl);
 vbool2_t __riscv_vmflt_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
-                          float16_t rs1, size_t vl);
+                          _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmflt_mu(vbool64_t vm, vbool64_t vd, vfloat32mf2_t vs2,
                            vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmflt_mu(vbool64_t vm, vbool64_t vd, vfloat32mf2_t vs2,
@@ -12396,27 +12388,27 @@ vbool8_t __riscv_vmflt_mu(vbool8_t vm, vbool8_t vd, vfloat64m8_t vs2,
 vbool64_t __riscv_vmfle_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2,
                            vfloat16mf4_t vs1, size_t vl);
 vbool64_t __riscv_vmfle_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2,
-                           float16_t rs1, size_t vl);
+                           _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfle_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2,
                            vfloat16mf2_t vs1, size_t vl);
 vbool32_t __riscv_vmfle_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2,
-                           float16_t rs1, size_t vl);
+                           _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfle_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2,
                            vfloat16m1_t vs1, size_t vl);
 vbool16_t __riscv_vmfle_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2,
-                           float16_t rs1, size_t vl);
+                           _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfle_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
                           vfloat16m2_t vs1, size_t vl);
 vbool8_t __riscv_vmfle_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
-                          float16_t rs1, size_t vl);
+                          _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfle_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
                           vfloat16m4_t vs1, size_t vl);
 vbool4_t __riscv_vmfle_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
-                          float16_t rs1, size_t vl);
+                          _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfle_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
                           vfloat16m8_t vs1, size_t vl);
 vbool2_t __riscv_vmfle_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
-                          float16_t rs1, size_t vl);
+                          _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfle_mu(vbool64_t vm, vbool64_t vd, vfloat32mf2_t vs2,
                            vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfle_mu(vbool64_t vm, vbool64_t vd, vfloat32mf2_t vs2,
@@ -12456,27 +12448,27 @@ vbool8_t __riscv_vmfle_mu(vbool8_t vm, vbool8_t vd, vfloat64m8_t vs2,
 vbool64_t __riscv_vmfgt_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2,
                            vfloat16mf4_t vs1, size_t vl);
 vbool64_t __riscv_vmfgt_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2,
-                           float16_t rs1, size_t vl);
+                           _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfgt_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2,
                            vfloat16mf2_t vs1, size_t vl);
 vbool32_t __riscv_vmfgt_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2,
-                           float16_t rs1, size_t vl);
+                           _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfgt_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2,
                            vfloat16m1_t vs1, size_t vl);
 vbool16_t __riscv_vmfgt_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2,
-                           float16_t rs1, size_t vl);
+                           _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfgt_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
                           vfloat16m2_t vs1, size_t vl);
 vbool8_t __riscv_vmfgt_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
-                          float16_t rs1, size_t vl);
+                          _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfgt_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
                           vfloat16m4_t vs1, size_t vl);
 vbool4_t __riscv_vmfgt_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
-                          float16_t rs1, size_t vl);
+                          _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfgt_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
                           vfloat16m8_t vs1, size_t vl);
 vbool2_t __riscv_vmfgt_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
-                          float16_t rs1, size_t vl);
+                          _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfgt_mu(vbool64_t vm, vbool64_t vd, vfloat32mf2_t vs2,
                            vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfgt_mu(vbool64_t vm, vbool64_t vd, vfloat32mf2_t vs2,
@@ -12516,27 +12508,27 @@ vbool8_t __riscv_vmfgt_mu(vbool8_t vm, vbool8_t vd, vfloat64m8_t vs2,
 vbool64_t __riscv_vmfge_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2,
                            vfloat16mf4_t vs1, size_t vl);
 vbool64_t __riscv_vmfge_mu(vbool64_t vm, vbool64_t vd, vfloat16mf4_t vs2,
-                           float16_t rs1, size_t vl);
+                           _Float16 rs1, size_t vl);
 vbool32_t __riscv_vmfge_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2,
                            vfloat16mf2_t vs1, size_t vl);
 vbool32_t __riscv_vmfge_mu(vbool32_t vm, vbool32_t vd, vfloat16mf2_t vs2,
-                           float16_t rs1, size_t vl);
+                           _Float16 rs1, size_t vl);
 vbool16_t __riscv_vmfge_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2,
                            vfloat16m1_t vs1, size_t vl);
 vbool16_t __riscv_vmfge_mu(vbool16_t vm, vbool16_t vd, vfloat16m1_t vs2,
-                           float16_t rs1, size_t vl);
+                           _Float16 rs1, size_t vl);
 vbool8_t __riscv_vmfge_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
                           vfloat16m2_t vs1, size_t vl);
 vbool8_t __riscv_vmfge_mu(vbool8_t vm, vbool8_t vd, vfloat16m2_t vs2,
-                          float16_t rs1, size_t vl);
+                          _Float16 rs1, size_t vl);
 vbool4_t __riscv_vmfge_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
                           vfloat16m4_t vs1, size_t vl);
 vbool4_t __riscv_vmfge_mu(vbool4_t vm, vbool4_t vd, vfloat16m4_t vs2,
-                          float16_t rs1, size_t vl);
+                          _Float16 rs1, size_t vl);
 vbool2_t __riscv_vmfge_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
                           vfloat16m8_t vs1, size_t vl);
 vbool2_t __riscv_vmfge_mu(vbool2_t vm, vbool2_t vd, vfloat16m8_t vs2,
-                          float16_t rs1, size_t vl);
+                          _Float16 rs1, size_t vl);
 vbool64_t __riscv_vmfge_mu(vbool64_t vm, vbool64_t vd, vfloat32mf2_t vs2,
                            vfloat32mf2_t vs1, size_t vl);
 vbool64_t __riscv_vmfge_mu(vbool64_t vm, vbool64_t vd, vfloat32mf2_t vs2,
@@ -12698,27 +12690,27 @@ vuint64m8_t __riscv_vfclass_mu(vbool8_t vm, vuint64m8_t vd, vfloat64m8_t vs2,
 vfloat16mf4_t __riscv_vmerge_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
                                 vfloat16mf4_t vs1, vbool64_t v0, size_t vl);
 vfloat16mf4_t __riscv_vfmerge_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                 float16_t rs1, vbool64_t v0, size_t vl);
+                                 _Float16 rs1, vbool64_t v0, size_t vl);
 vfloat16mf2_t __riscv_vmerge_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
                                 vfloat16mf2_t vs1, vbool32_t v0, size_t vl);
 vfloat16mf2_t __riscv_vfmerge_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                 float16_t rs1, vbool32_t v0, size_t vl);
+                                 _Float16 rs1, vbool32_t v0, size_t vl);
 vfloat16m1_t __riscv_vmerge_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
                                vfloat16m1_t vs1, vbool16_t v0, size_t vl);
-vfloat16m1_t __riscv_vfmerge_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                float16_t rs1, vbool16_t v0, size_t vl);
+vfloat16m1_t __riscv_vfmerge_tu(vfloat16m1_t vd, vfloat16m1_t vs2, _Float16 rs1,
+                                vbool16_t v0, size_t vl);
 vfloat16m2_t __riscv_vmerge_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
                                vfloat16m2_t vs1, vbool8_t v0, size_t vl);
-vfloat16m2_t __riscv_vfmerge_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                float16_t rs1, vbool8_t v0, size_t vl);
+vfloat16m2_t __riscv_vfmerge_tu(vfloat16m2_t vd, vfloat16m2_t vs2, _Float16 rs1,
+                                vbool8_t v0, size_t vl);
 vfloat16m4_t __riscv_vmerge_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
                                vfloat16m4_t vs1, vbool4_t v0, size_t vl);
-vfloat16m4_t __riscv_vfmerge_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                float16_t rs1, vbool4_t v0, size_t vl);
+vfloat16m4_t __riscv_vfmerge_tu(vfloat16m4_t vd, vfloat16m4_t vs2, _Float16 rs1,
+                                vbool4_t v0, size_t vl);
 vfloat16m8_t __riscv_vmerge_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
                                vfloat16m8_t vs1, vbool2_t v0, size_t vl);
-vfloat16m8_t __riscv_vfmerge_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                float16_t rs1, vbool2_t v0, size_t vl);
+vfloat16m8_t __riscv_vfmerge_tu(vfloat16m8_t vd, vfloat16m8_t vs2, _Float16 rs1,
+                                vbool2_t v0, size_t vl);
 vfloat32mf2_t __riscv_vmerge_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                 vfloat32mf2_t vs1, vbool64_t v0, size_t vl);
 vfloat32mf2_t __riscv_vfmerge_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
@@ -12763,17 +12755,17 @@ vfloat64m8_t __riscv_vfmerge_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
 [,c]
 ----
 vfloat16mf4_t __riscv_vmv_v_tu(vfloat16mf4_t vd, vfloat16mf4_t vs1, size_t vl);
-vfloat16mf4_t __riscv_vfmv_v_tu(vfloat16mf4_t vd, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfmv_v_tu(vfloat16mf4_t vd, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vmv_v_tu(vfloat16mf2_t vd, vfloat16mf2_t vs1, size_t vl);
-vfloat16mf2_t __riscv_vfmv_v_tu(vfloat16mf2_t vd, float16_t rs1, size_t vl);
+vfloat16mf2_t __riscv_vfmv_v_tu(vfloat16mf2_t vd, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vmv_v_tu(vfloat16m1_t vd, vfloat16m1_t vs1, size_t vl);
-vfloat16m1_t __riscv_vfmv_v_tu(vfloat16m1_t vd, float16_t rs1, size_t vl);
+vfloat16m1_t __riscv_vfmv_v_tu(vfloat16m1_t vd, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vmv_v_tu(vfloat16m2_t vd, vfloat16m2_t vs1, size_t vl);
-vfloat16m2_t __riscv_vfmv_v_tu(vfloat16m2_t vd, float16_t rs1, size_t vl);
+vfloat16m2_t __riscv_vfmv_v_tu(vfloat16m2_t vd, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vmv_v_tu(vfloat16m4_t vd, vfloat16m4_t vs1, size_t vl);
-vfloat16m4_t __riscv_vfmv_v_tu(vfloat16m4_t vd, float16_t rs1, size_t vl);
+vfloat16m4_t __riscv_vfmv_v_tu(vfloat16m4_t vd, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vmv_v_tu(vfloat16m8_t vd, vfloat16m8_t vs1, size_t vl);
-vfloat16m8_t __riscv_vfmv_v_tu(vfloat16m8_t vd, float16_t rs1, size_t vl);
+vfloat16m8_t __riscv_vfmv_v_tu(vfloat16m8_t vd, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vmv_v_tu(vfloat32mf2_t vd, vfloat32mf2_t vs1, size_t vl);
 vfloat32mf2_t __riscv_vfmv_v_tu(vfloat32mf2_t vd, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vmv_v_tu(vfloat32m1_t vd, vfloat32m1_t vs1, size_t vl);

--- a/auto-generated/policy_funcs/overloaded_intrinsic_funcs/07_vector_permutation_instructions.adoc
+++ b/auto-generated/policy_funcs/overloaded_intrinsic_funcs/07_vector_permutation_instructions.adoc
@@ -6,12 +6,12 @@
 
 [,c]
 ----
-vfloat16mf4_t __riscv_vfmv_s_tu(vfloat16mf4_t vd, float16_t rs1, size_t vl);
-vfloat16mf2_t __riscv_vfmv_s_tu(vfloat16mf2_t vd, float16_t rs1, size_t vl);
-vfloat16m1_t __riscv_vfmv_s_tu(vfloat16m1_t vd, float16_t rs1, size_t vl);
-vfloat16m2_t __riscv_vfmv_s_tu(vfloat16m2_t vd, float16_t rs1, size_t vl);
-vfloat16m4_t __riscv_vfmv_s_tu(vfloat16m4_t vd, float16_t rs1, size_t vl);
-vfloat16m8_t __riscv_vfmv_s_tu(vfloat16m8_t vd, float16_t rs1, size_t vl);
+vfloat16mf4_t __riscv_vfmv_s_tu(vfloat16mf4_t vd, _Float16 rs1, size_t vl);
+vfloat16mf2_t __riscv_vfmv_s_tu(vfloat16mf2_t vd, _Float16 rs1, size_t vl);
+vfloat16m1_t __riscv_vfmv_s_tu(vfloat16m1_t vd, _Float16 rs1, size_t vl);
+vfloat16m2_t __riscv_vfmv_s_tu(vfloat16m2_t vd, _Float16 rs1, size_t vl);
+vfloat16m4_t __riscv_vfmv_s_tu(vfloat16m4_t vd, _Float16 rs1, size_t vl);
+vfloat16m8_t __riscv_vfmv_s_tu(vfloat16m8_t vd, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfmv_s_tu(vfloat32mf2_t vd, float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfmv_s_tu(vfloat32m1_t vd, float32_t rs1, size_t vl);
 vfloat32m2_t __riscv_vfmv_s_tu(vfloat32m2_t vd, float32_t rs1, size_t vl);
@@ -1037,17 +1037,17 @@ vuint64m8_t __riscv_vslidedown_mu(vbool8_t vm, vuint64m8_t vd, vuint64m8_t vs2,
 [,c]
 ----
 vfloat16mf4_t __riscv_vfslide1up_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                    float16_t rs1, size_t vl);
+                                    _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfslide1up_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                    float16_t rs1, size_t vl);
+                                    _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfslide1up_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                   float16_t rs1, size_t vl);
+                                   _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfslide1up_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                   float16_t rs1, size_t vl);
+                                   _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfslide1up_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                   float16_t rs1, size_t vl);
+                                   _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfslide1up_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                   float16_t rs1, size_t vl);
+                                   _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfslide1up_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                     float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfslide1up_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
@@ -1067,17 +1067,17 @@ vfloat64m4_t __riscv_vfslide1up_tu(vfloat64m4_t vd, vfloat64m4_t vs2,
 vfloat64m8_t __riscv_vfslide1up_tu(vfloat64m8_t vd, vfloat64m8_t vs2,
                                    float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfslide1down_tu(vfloat16mf4_t vd, vfloat16mf4_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfslide1down_tu(vfloat16mf2_t vd, vfloat16mf2_t vs2,
-                                      float16_t rs1, size_t vl);
+                                      _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfslide1down_tu(vfloat16m1_t vd, vfloat16m1_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfslide1down_tu(vfloat16m2_t vd, vfloat16m2_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfslide1down_tu(vfloat16m4_t vd, vfloat16m4_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfslide1down_tu(vfloat16m8_t vd, vfloat16m8_t vs2,
-                                     float16_t rs1, size_t vl);
+                                     _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfslide1down_tu(vfloat32mf2_t vd, vfloat32mf2_t vs2,
                                       float32_t rs1, size_t vl);
 vfloat32m1_t __riscv_vfslide1down_tu(vfloat32m1_t vd, vfloat32m1_t vs2,
@@ -1274,19 +1274,19 @@ vuint64m8_t __riscv_vslide1down_tu(vuint64m8_t vd, vuint64m8_t vs2,
                                    uint64_t rs1, size_t vl);
 // masked functions
 vfloat16mf4_t __riscv_vfslide1up_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                     vfloat16mf4_t vs2, float16_t rs1,
+                                     vfloat16mf4_t vs2, _Float16 rs1,
                                      size_t vl);
 vfloat16mf2_t __riscv_vfslide1up_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                     vfloat16mf2_t vs2, float16_t rs1,
+                                     vfloat16mf2_t vs2, _Float16 rs1,
                                      size_t vl);
 vfloat16m1_t __riscv_vfslide1up_tum(vbool16_t vm, vfloat16m1_t vd,
-                                    vfloat16m1_t vs2, float16_t rs1, size_t vl);
+                                    vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfslide1up_tum(vbool8_t vm, vfloat16m2_t vd,
-                                    vfloat16m2_t vs2, float16_t rs1, size_t vl);
+                                    vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfslide1up_tum(vbool4_t vm, vfloat16m4_t vd,
-                                    vfloat16m4_t vs2, float16_t rs1, size_t vl);
+                                    vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfslide1up_tum(vbool2_t vm, vfloat16m8_t vd,
-                                    vfloat16m8_t vs2, float16_t rs1, size_t vl);
+                                    vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfslide1up_tum(vbool64_t vm, vfloat32mf2_t vd,
                                      vfloat32mf2_t vs2, float32_t rs1,
                                      size_t vl);
@@ -1307,22 +1307,22 @@ vfloat64m4_t __riscv_vfslide1up_tum(vbool16_t vm, vfloat64m4_t vd,
 vfloat64m8_t __riscv_vfslide1up_tum(vbool8_t vm, vfloat64m8_t vd,
                                     vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfslide1down_tum(vbool64_t vm, vfloat16mf4_t vd,
-                                       vfloat16mf4_t vs2, float16_t rs1,
+                                       vfloat16mf4_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16mf2_t __riscv_vfslide1down_tum(vbool32_t vm, vfloat16mf2_t vd,
-                                       vfloat16mf2_t vs2, float16_t rs1,
+                                       vfloat16mf2_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m1_t __riscv_vfslide1down_tum(vbool16_t vm, vfloat16m1_t vd,
-                                      vfloat16m1_t vs2, float16_t rs1,
+                                      vfloat16m1_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m2_t __riscv_vfslide1down_tum(vbool8_t vm, vfloat16m2_t vd,
-                                      vfloat16m2_t vs2, float16_t rs1,
+                                      vfloat16m2_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m4_t __riscv_vfslide1down_tum(vbool4_t vm, vfloat16m4_t vd,
-                                      vfloat16m4_t vs2, float16_t rs1,
+                                      vfloat16m4_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m8_t __riscv_vfslide1down_tum(vbool2_t vm, vfloat16m8_t vd,
-                                      vfloat16m8_t vs2, float16_t rs1,
+                                      vfloat16m8_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat32mf2_t __riscv_vfslide1down_tum(vbool64_t vm, vfloat32mf2_t vd,
                                        vfloat32mf2_t vs2, float32_t rs1,
@@ -1529,23 +1529,19 @@ vuint64m8_t __riscv_vslide1down_tum(vbool8_t vm, vuint64m8_t vd,
                                     vuint64m8_t vs2, uint64_t rs1, size_t vl);
 // masked functions
 vfloat16mf4_t __riscv_vfslide1up_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16mf2_t __riscv_vfslide1up_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m1_t __riscv_vfslide1up_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+                                     vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfslide1up_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
-                                     size_t vl);
+                                     vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfslide1up_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
-                                     size_t vl);
+                                     vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfslide1up_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
-                                     size_t vl);
+                                     vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfslide1up_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                       vfloat32mf2_t vs2, float32_t rs1,
                                       size_t vl);
@@ -1574,22 +1570,22 @@ vfloat64m8_t __riscv_vfslide1up_tumu(vbool8_t vm, vfloat64m8_t vd,
                                      vfloat64m8_t vs2, float64_t rs1,
                                      size_t vl);
 vfloat16mf4_t __riscv_vfslide1down_tumu(vbool64_t vm, vfloat16mf4_t vd,
-                                        vfloat16mf4_t vs2, float16_t rs1,
+                                        vfloat16mf4_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16mf2_t __riscv_vfslide1down_tumu(vbool32_t vm, vfloat16mf2_t vd,
-                                        vfloat16mf2_t vs2, float16_t rs1,
+                                        vfloat16mf2_t vs2, _Float16 rs1,
                                         size_t vl);
 vfloat16m1_t __riscv_vfslide1down_tumu(vbool16_t vm, vfloat16m1_t vd,
-                                       vfloat16m1_t vs2, float16_t rs1,
+                                       vfloat16m1_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m2_t __riscv_vfslide1down_tumu(vbool8_t vm, vfloat16m2_t vd,
-                                       vfloat16m2_t vs2, float16_t rs1,
+                                       vfloat16m2_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m4_t __riscv_vfslide1down_tumu(vbool4_t vm, vfloat16m4_t vd,
-                                       vfloat16m4_t vs2, float16_t rs1,
+                                       vfloat16m4_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat16m8_t __riscv_vfslide1down_tumu(vbool2_t vm, vfloat16m8_t vd,
-                                       vfloat16m8_t vs2, float16_t rs1,
+                                       vfloat16m8_t vs2, _Float16 rs1,
                                        size_t vl);
 vfloat32mf2_t __riscv_vfslide1down_tumu(vbool64_t vm, vfloat32mf2_t vd,
                                         vfloat32mf2_t vs2, float32_t rs1,
@@ -1799,19 +1795,17 @@ vuint64m8_t __riscv_vslide1down_tumu(vbool8_t vm, vuint64m8_t vd,
                                      vuint64m8_t vs2, uint64_t rs1, size_t vl);
 // masked functions
 vfloat16mf4_t __riscv_vfslide1up_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                    vfloat16mf4_t vs2, float16_t rs1,
-                                    size_t vl);
+                                    vfloat16mf4_t vs2, _Float16 rs1, size_t vl);
 vfloat16mf2_t __riscv_vfslide1up_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                    vfloat16mf2_t vs2, float16_t rs1,
-                                    size_t vl);
+                                    vfloat16mf2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m1_t __riscv_vfslide1up_mu(vbool16_t vm, vfloat16m1_t vd,
-                                   vfloat16m1_t vs2, float16_t rs1, size_t vl);
+                                   vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfslide1up_mu(vbool8_t vm, vfloat16m2_t vd,
-                                   vfloat16m2_t vs2, float16_t rs1, size_t vl);
+                                   vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfslide1up_mu(vbool4_t vm, vfloat16m4_t vd,
-                                   vfloat16m4_t vs2, float16_t rs1, size_t vl);
+                                   vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfslide1up_mu(vbool2_t vm, vfloat16m8_t vd,
-                                   vfloat16m8_t vs2, float16_t rs1, size_t vl);
+                                   vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfslide1up_mu(vbool64_t vm, vfloat32mf2_t vd,
                                     vfloat32mf2_t vs2, float32_t rs1,
                                     size_t vl);
@@ -1832,23 +1826,19 @@ vfloat64m4_t __riscv_vfslide1up_mu(vbool16_t vm, vfloat64m4_t vd,
 vfloat64m8_t __riscv_vfslide1up_mu(vbool8_t vm, vfloat64m8_t vd,
                                    vfloat64m8_t vs2, float64_t rs1, size_t vl);
 vfloat16mf4_t __riscv_vfslide1down_mu(vbool64_t vm, vfloat16mf4_t vd,
-                                      vfloat16mf4_t vs2, float16_t rs1,
+                                      vfloat16mf4_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16mf2_t __riscv_vfslide1down_mu(vbool32_t vm, vfloat16mf2_t vd,
-                                      vfloat16mf2_t vs2, float16_t rs1,
+                                      vfloat16mf2_t vs2, _Float16 rs1,
                                       size_t vl);
 vfloat16m1_t __riscv_vfslide1down_mu(vbool16_t vm, vfloat16m1_t vd,
-                                     vfloat16m1_t vs2, float16_t rs1,
-                                     size_t vl);
+                                     vfloat16m1_t vs2, _Float16 rs1, size_t vl);
 vfloat16m2_t __riscv_vfslide1down_mu(vbool8_t vm, vfloat16m2_t vd,
-                                     vfloat16m2_t vs2, float16_t rs1,
-                                     size_t vl);
+                                     vfloat16m2_t vs2, _Float16 rs1, size_t vl);
 vfloat16m4_t __riscv_vfslide1down_mu(vbool4_t vm, vfloat16m4_t vd,
-                                     vfloat16m4_t vs2, float16_t rs1,
-                                     size_t vl);
+                                     vfloat16m4_t vs2, _Float16 rs1, size_t vl);
 vfloat16m8_t __riscv_vfslide1down_mu(vbool2_t vm, vfloat16m8_t vd,
-                                     vfloat16m8_t vs2, float16_t rs1,
-                                     size_t vl);
+                                     vfloat16m8_t vs2, _Float16 rs1, size_t vl);
 vfloat32mf2_t __riscv_vfslide1down_mu(vbool64_t vm, vfloat32mf2_t vd,
                                       vfloat32mf2_t vs2, float32_t rs1,
                                       size_t vl);

--- a/doc/rvv-intrinsic-spec.adoc
+++ b/doc/rvv-intrinsic-spec.adoc
@@ -621,14 +621,20 @@ The `vlenb` intrinsic returns what is held inside the read-only CSR `vlenb` ^29^
 
 [,c]
 ----
-unsigned vlenb();
+unsigned __riscv_vlenb();
 ----
 
 == Programming Notes
 
-=== Semantic of assignment (`=`) in the C language
+=== Copying vector register group contents
 
-Without optimizations, the compiler is conservative and assumes an object of RVV type to represent an allocated space on the stack. The assignment operator (`=`) represents a whole register store for the object on the right hand side, and a load for the object on the left hand side.
+There is no intrinsic that directly maps to the whole vector register move instructions (`vmv<nr>r.v`) ^30^.
+
+For copying of the vector contents in whole, we encourage the users to use the assignment operator (`=`).
+
+The assignment operator (`=`) represents the semantic of a whole vector register (group) copy for the expression on the right hand side to the RVV type object on the left hand side. The semantic will still maintain a whole vector register content copy for fractional LMUL types. This enables the compiler to coalesce register usage when possible.
+
+Users may leverage the vector move intrinsics (`vmv_v_v`) intrinsics if they hope to copy vector register groups with `vl != VLMAX`.
 
 === The passthrough (`vd`) argument in the intrinsics
 
@@ -671,7 +677,7 @@ The compiler will be conservative to registers (`vtype`, `vxrm`, `frm`) when enc
 
 === The `new_vl` argument in fault-only-first load intrinsics
 
-The fault-only-first load intrinsics write the new value inside the `vl` register into the address of the `new_vl` argument. Providing an illegal memory location will result in a memory access violation.
+The fault-only-first load intrinsics write the new value inside the `vl` register into the address of the `new_vl` argument. Providing an illegal memory location is undefined behavior.
 
 == References
 
@@ -736,3 +742,5 @@ NOTE: Standard extensions are merged into `riscv/riscv-isa-manual` after ratific
 ^28^Section 6.4 (Example of stripmining and changes to SEW) in the specification ^0^
 
 ^29^Section 3.6 (Vector Byte Length `vlenb`) in the specification ^0^
+
+^30^Section 16.6 (Whole Vector Register Move) in the specification ^0^

--- a/doc/rvv-intrinsic-spec.adoc
+++ b/doc/rvv-intrinsic-spec.adoc
@@ -409,7 +409,7 @@ Due to the limitation of the C language (without the aid of features like C++ te
 
 The intrinsics are designed to be strongly-typed. The intrinsics provide `vreinterpret` intrinsics to help users go across the strongly-typed scheme if necessary.
 
-Non-mask (integer and floating-point) data types have SEW and LMUL encoded. 
+Non-mask (integer and floating-point) data types have SEW and LMUL encoded.
 
 [[integer-type]]
 === Integer types
@@ -588,14 +588,14 @@ The `vundefined` intrinsics are placeholders for `vset` and `vcreate` to represe
 [[pseudo-vget]]
 === `vget`
 
-The `vget` intrinsics allow users to obtain small LMUL values from larger LMUL ones. The `vget` intrinsics also allows users to extract non-tuple (`NFIELD=1`) types from tuple (`NFIELD>1`) types after segment load intrinsics.
+The `vget` intrinsics allow users to obtain small LMUL values from larger LMUL ones. The `vget` intrinsics also allows users to extract non-tuple (`NFIELD=1`) types from tuple (`NFIELD>1`) types after segment load intrinsics. The index provided must be a constant known at compile time.
 
 The intrinsics do not map to any real instruction. Whether if the implementation will generate vector move instructions is an optimization issue.
 
 [[pseudo-vset]]
 === `vset`
 
-The `vset` intrinsics allow users to combine small LMUL values into larger LMUL ones. The `vset` intrinsics also allows users to combine non-tuple (`NFIELD=1`) types to tuple (`NFIELD>1`) types for segment store intrinsics.
+The `vset` intrinsics allow users to combine small LMUL values into larger LMUL ones. The `vset` intrinsics also allows users to combine non-tuple (`NFIELD=1`) types to tuple (`NFIELD>1`) types for segment store intrinsics. The index provided must be a constant known at compile time.
 
 The intrinsics do not map to any real instruction. Whether if the implementation will generate vector move instructions is an optimization issue.
 
@@ -614,7 +614,21 @@ The `vlmul_ext` intrinsics are syntactic sugars that have the same semantic as `
 
 The `vcreate` intrinsics are syntactic sugars for tuple types creation. They have the same semantic as multiple `vset`-s filling in values accordingly into the tuple type.
 
+[[pseudo-vlenb]]
+=== `vlenb`
+
+The `vlenb` intrinsic returns what is held inside the read-only CSR `vlenb` ^29^, which is the vector register length in bytes.
+
+[,c]
+----
+unsigned vlenb();
+----
+
 == Programming Notes
+
+=== Semantic of assignment (`=`) in the C language
+
+Without optimizations, the compiler is conservative and assumes an object of RVV type to represent an allocated space on the stack. The assignment operator (`=`) represents a whole register store for the object on the right hand side, and a load for the object on the left hand side.
 
 === The passthrough (`vd`) argument in the intrinsics
 
@@ -650,6 +664,14 @@ In other words, the compiler does not guarantee generating the instruction for a
 The intrinsics provide variants with operand mnemonics of `vv` and `vx`, but not `vi`. This was an intentional design to reduce the total amount of out-going intrinsics.
 
 It is an optimization issue for the implementation to emit instructions with operand mnemonics of `vi` when an immediate that can be expressed within 5-bit is provided to the intrinsics.
+
+=== Mixing inline assembly and intrinsics
+
+The compiler will be conservative to registers (`vtype`, `vxrm`, `frm`) when encountering inline assembly. Users should be aware that mixing uses of intrinsics and inline assembly will result in extra save and restore.
+
+=== The `new_vl` argument in fault-only-first load intrinsics
+
+The fault-only-first load intrinsics write the new value inside the `vl` register into the address of the `new_vl` argument. Providing an illegal memory location will result in a memory access violation.
 
 == References
 
@@ -712,3 +734,5 @@ NOTE: Standard extensions are merged into `riscv/riscv-isa-manual` after ratific
 ^27^Section 6.3 (Constraints on Setting `vl`) in the specficiation ^0^
 
 ^28^Section 6.4 (Example of stripmining and changes to SEW) in the specification ^0^
+
+^29^Section 3.6 (Vector Byte Length `vlenb`) in the specification ^0^

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mask_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mask_template.py
@@ -71,7 +71,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
         G.func(
             inst_info_m,
             name="{OP}_m_b{MLEN}".format_map(args) + decorator.func_suffix,
-            return_type=type_helper.ulong,
+            return_type=type_helper.uint,
             **decorator.mask_args(type_helper.m),
             vs2=type_helper.m,
             vl=type_helper.size_t)
@@ -79,7 +79,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
         G.func(
             inst_info_m,
             name="{OP}_m_b{MLEN}".format_map(args) + decorator.func_suffix,
-            return_type=type_helper.long,
+            return_type=type_helper.int,
             **decorator.mask_args(type_helper.m),
             vs2=type_helper.m,
             vl=type_helper.size_t)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/utils.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/utils.py
@@ -130,6 +130,8 @@ class TypeHelper:
 
   @property
   def s(self):
+    if self.args["TYPE"] == "float" and self.args["SEW"] == 16:
+      return "_Float16"
     return "{TYPE}{SEW}_t".format_map(self.args)
 
   @property


### PR DESCRIPTION
While cleaning up the issue threads, I found some more details we need to have in the specification.

This PR:
- Resolves #74 by adding a description of "Semantic of assignment (`=`) in the C language" under the programming note section of the spec
- Resolves #242 by adding a description of "Mixing inline assembly and intrinsics" under the programming note section of the spec
- Replace `float16_t` with `_Float16` that is now supported by both LLVM and GCC.  This keeps us away from the need to define our own type. (Resolves #31, and alongside also resolves #166.
- Adds missing description to the `vlenb` utility function
- Adds description to `new_vl` argument in fault-only-first load intrinsics
