### PR TITLE
Adjust vundefined intrinsic test case  and support gcc overloaded intrinsic test

### DIFF
--- a/auto-generated/gnu-api-tests/vundefined.c
+++ b/auto-generated/gnu-api-tests/vundefined.c
@@ -1146,4 +1146,4 @@ vuint64m2x4_t test_vundefined_u64m2x4() {
 vuint64m4x2_t test_vundefined_u64m4x2() {
   return __riscv_vundefined_u64m4x2();
 }
-/* { dg-final { scan-assembler-times {vs[1248e][r123468]+\.[ivxfswum.]+\s+[,\sa-x0-9()]+} 285 } } */
+/* { dg-final { scan-assembler-times {vs[1248e][r123468]+\.[ivxfswum.]+\s+[,\sa-x0-9()]+} 619 } } */

--- a/rvv-intrinsic-generator/Makefile
+++ b/rvv-intrinsic-generator/Makefile
@@ -364,9 +364,13 @@ report-gnu:
 	cd ${GNU_TOOLCHAIN_DIR} && make -j 8
 	mkdir -p $(GCC_CASES_DIR)/gnu-api-tests
 	mkdir -p $(GCC_CASES_DIR)/policy_funcs/gnu-api-tests
+	mkdir -p $(GCC_CASES_DIR)/gnu-overloaded-tests
+	mkdir -p $(GCC_CASES_DIR)/policy_funcs/gnu-overloaded-tests
 	cp $(DIR)/../gcc-auto-generated.exp $(GCC_CASES_DIR)/auto-generated.exp
 	cp -r $(DIR)/gnu-api-tests/* $(GCC_CASES_DIR)/gnu-api-tests/
 	cp -r $(DIR)/policy_funcs/gnu-api-tests/* $(GCC_CASES_DIR)/policy_funcs/gnu-api-tests/
+	cp -r $(DIR)/gnu-overloaded-tests/* $(GCC_CASES_DIR)/gnu-overloaded-tests/
+	cp -r $(DIR)/policy_funcs/gnu-overloaded-tests/* $(GCC_CASES_DIR)/policy_funcs/gnu-overloaded-tests/
 	mkdir -p $(G++_CASES_DIR)/gnu-api-tests
 	mkdir -p $(G++_CASES_DIR)/policy_funcs/gnu-api-tests
 	mkdir -p $(G++_CASES_DIR)/gnu-overloaded-tests

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -167,6 +167,8 @@ class Generator():
       api_count = 66
     if test_file == "vcreate.c":
       api_count = 506
+    if test_file == "vundefined.c":
+      api_count = 619
     if test_file == "vmv.c":
       api_count = 218
       if is_overloaded and not has_policy:


### PR DESCRIPTION
Recently, gcc supports vundefined fo tuple types intrinsic s and gcc overloaded intrinsics, so this PR is used to adapt to gnu CI.