### PR TITLE
Remove a redundant space in LLVM float testcases header

### DIFF
--- a/auto-generated/llvm-api-tests/vcompress.c
+++ b/auto-generated/llvm-api-tests/vcompress.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vcpop.c
+++ b/auto-generated/llvm-api-tests/vcpop.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vcreate.c
+++ b/auto-generated/llvm-api-tests/vcreate.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfabs.c
+++ b/auto-generated/llvm-api-tests/vfabs.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfadd.c
+++ b/auto-generated/llvm-api-tests/vfadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfclass.c
+++ b/auto-generated/llvm-api-tests/vfclass.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfcvt.c
+++ b/auto-generated/llvm-api-tests/vfcvt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfcvt_rtz.c
+++ b/auto-generated/llvm-api-tests/vfcvt_rtz.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfdiv.c
+++ b/auto-generated/llvm-api-tests/vfdiv.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfmacc.c
+++ b/auto-generated/llvm-api-tests/vfmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfmadd.c
+++ b/auto-generated/llvm-api-tests/vfmadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfmax.c
+++ b/auto-generated/llvm-api-tests/vfmax.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfmerge.c
+++ b/auto-generated/llvm-api-tests/vfmerge.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfmin.c
+++ b/auto-generated/llvm-api-tests/vfmin.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfmsac.c
+++ b/auto-generated/llvm-api-tests/vfmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfmsub.c
+++ b/auto-generated/llvm-api-tests/vfmsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfmul.c
+++ b/auto-generated/llvm-api-tests/vfmul.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfmv.c
+++ b/auto-generated/llvm-api-tests/vfmv.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfncvt.c
+++ b/auto-generated/llvm-api-tests/vfncvt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfncvt_rod.c
+++ b/auto-generated/llvm-api-tests/vfncvt_rod.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfncvt_rtz.c
+++ b/auto-generated/llvm-api-tests/vfncvt_rtz.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfneg.c
+++ b/auto-generated/llvm-api-tests/vfneg.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfnmacc.c
+++ b/auto-generated/llvm-api-tests/vfnmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfnmadd.c
+++ b/auto-generated/llvm-api-tests/vfnmadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfnmsac.c
+++ b/auto-generated/llvm-api-tests/vfnmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfnmsub.c
+++ b/auto-generated/llvm-api-tests/vfnmsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfrdiv.c
+++ b/auto-generated/llvm-api-tests/vfrdiv.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfrec7.c
+++ b/auto-generated/llvm-api-tests/vfrec7.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfredmax.c
+++ b/auto-generated/llvm-api-tests/vfredmax.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfredmin.c
+++ b/auto-generated/llvm-api-tests/vfredmin.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfredosum.c
+++ b/auto-generated/llvm-api-tests/vfredosum.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfredusum.c
+++ b/auto-generated/llvm-api-tests/vfredusum.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfrsqrt7.c
+++ b/auto-generated/llvm-api-tests/vfrsqrt7.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfrsub.c
+++ b/auto-generated/llvm-api-tests/vfrsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfsgnj.c
+++ b/auto-generated/llvm-api-tests/vfsgnj.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfsgnjn.c
+++ b/auto-generated/llvm-api-tests/vfsgnjn.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfsgnjx.c
+++ b/auto-generated/llvm-api-tests/vfsgnjx.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfslide1down.c
+++ b/auto-generated/llvm-api-tests/vfslide1down.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfslide1up.c
+++ b/auto-generated/llvm-api-tests/vfslide1up.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfsqrt.c
+++ b/auto-generated/llvm-api-tests/vfsqrt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfsub.c
+++ b/auto-generated/llvm-api-tests/vfsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfwadd.c
+++ b/auto-generated/llvm-api-tests/vfwadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfwcvt.c
+++ b/auto-generated/llvm-api-tests/vfwcvt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfwcvt_rtz.c
+++ b/auto-generated/llvm-api-tests/vfwcvt_rtz.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfwmacc.c
+++ b/auto-generated/llvm-api-tests/vfwmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfwmsac.c
+++ b/auto-generated/llvm-api-tests/vfwmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfwmul.c
+++ b/auto-generated/llvm-api-tests/vfwmul.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfwnmacc.c
+++ b/auto-generated/llvm-api-tests/vfwnmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfwnmsac.c
+++ b/auto-generated/llvm-api-tests/vfwnmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfwredosum.c
+++ b/auto-generated/llvm-api-tests/vfwredosum.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfwredusum.c
+++ b/auto-generated/llvm-api-tests/vfwredusum.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vfwsub.c
+++ b/auto-generated/llvm-api-tests/vfwsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vget.c
+++ b/auto-generated/llvm-api-tests/vget.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vle16.c
+++ b/auto-generated/llvm-api-tests/vle16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vle16ff.c
+++ b/auto-generated/llvm-api-tests/vle16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vle32.c
+++ b/auto-generated/llvm-api-tests/vle32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vle32ff.c
+++ b/auto-generated/llvm-api-tests/vle32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vle64.c
+++ b/auto-generated/llvm-api-tests/vle64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vle64ff.c
+++ b/auto-generated/llvm-api-tests/vle64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vle8.c
+++ b/auto-generated/llvm-api-tests/vle8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vle8ff.c
+++ b/auto-generated/llvm-api-tests/vle8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlmul_ext_v.c
+++ b/auto-generated/llvm-api-tests/vlmul_ext_v.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlmul_trunc_v.c
+++ b/auto-generated/llvm-api-tests/vlmul_trunc_v.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxei16.c
+++ b/auto-generated/llvm-api-tests/vloxei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxei32.c
+++ b/auto-generated/llvm-api-tests/vloxei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxei64.c
+++ b/auto-generated/llvm-api-tests/vloxei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxei8.c
+++ b/auto-generated/llvm-api-tests/vloxei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg2ei16.c
+++ b/auto-generated/llvm-api-tests/vloxseg2ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg2ei32.c
+++ b/auto-generated/llvm-api-tests/vloxseg2ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg2ei64.c
+++ b/auto-generated/llvm-api-tests/vloxseg2ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg2ei8.c
+++ b/auto-generated/llvm-api-tests/vloxseg2ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg3ei16.c
+++ b/auto-generated/llvm-api-tests/vloxseg3ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg3ei32.c
+++ b/auto-generated/llvm-api-tests/vloxseg3ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg3ei64.c
+++ b/auto-generated/llvm-api-tests/vloxseg3ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg3ei8.c
+++ b/auto-generated/llvm-api-tests/vloxseg3ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg4ei16.c
+++ b/auto-generated/llvm-api-tests/vloxseg4ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg4ei32.c
+++ b/auto-generated/llvm-api-tests/vloxseg4ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg4ei64.c
+++ b/auto-generated/llvm-api-tests/vloxseg4ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg4ei8.c
+++ b/auto-generated/llvm-api-tests/vloxseg4ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg5ei16.c
+++ b/auto-generated/llvm-api-tests/vloxseg5ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg5ei32.c
+++ b/auto-generated/llvm-api-tests/vloxseg5ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg5ei64.c
+++ b/auto-generated/llvm-api-tests/vloxseg5ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg5ei8.c
+++ b/auto-generated/llvm-api-tests/vloxseg5ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg6ei16.c
+++ b/auto-generated/llvm-api-tests/vloxseg6ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg6ei32.c
+++ b/auto-generated/llvm-api-tests/vloxseg6ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg6ei64.c
+++ b/auto-generated/llvm-api-tests/vloxseg6ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg6ei8.c
+++ b/auto-generated/llvm-api-tests/vloxseg6ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg7ei16.c
+++ b/auto-generated/llvm-api-tests/vloxseg7ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg7ei32.c
+++ b/auto-generated/llvm-api-tests/vloxseg7ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg7ei64.c
+++ b/auto-generated/llvm-api-tests/vloxseg7ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg7ei8.c
+++ b/auto-generated/llvm-api-tests/vloxseg7ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg8ei16.c
+++ b/auto-generated/llvm-api-tests/vloxseg8ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg8ei32.c
+++ b/auto-generated/llvm-api-tests/vloxseg8ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg8ei64.c
+++ b/auto-generated/llvm-api-tests/vloxseg8ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vloxseg8ei8.c
+++ b/auto-generated/llvm-api-tests/vloxseg8ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlse16.c
+++ b/auto-generated/llvm-api-tests/vlse16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlse32.c
+++ b/auto-generated/llvm-api-tests/vlse32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlse64.c
+++ b/auto-generated/llvm-api-tests/vlse64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg2e16.c
+++ b/auto-generated/llvm-api-tests/vlseg2e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg2e16ff.c
+++ b/auto-generated/llvm-api-tests/vlseg2e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg2e32.c
+++ b/auto-generated/llvm-api-tests/vlseg2e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg2e32ff.c
+++ b/auto-generated/llvm-api-tests/vlseg2e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg2e64.c
+++ b/auto-generated/llvm-api-tests/vlseg2e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg2e64ff.c
+++ b/auto-generated/llvm-api-tests/vlseg2e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg2e8ff.c
+++ b/auto-generated/llvm-api-tests/vlseg2e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg3e16.c
+++ b/auto-generated/llvm-api-tests/vlseg3e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg3e16ff.c
+++ b/auto-generated/llvm-api-tests/vlseg3e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg3e32.c
+++ b/auto-generated/llvm-api-tests/vlseg3e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg3e32ff.c
+++ b/auto-generated/llvm-api-tests/vlseg3e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg3e64.c
+++ b/auto-generated/llvm-api-tests/vlseg3e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg3e64ff.c
+++ b/auto-generated/llvm-api-tests/vlseg3e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg3e8ff.c
+++ b/auto-generated/llvm-api-tests/vlseg3e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg4e16.c
+++ b/auto-generated/llvm-api-tests/vlseg4e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg4e16ff.c
+++ b/auto-generated/llvm-api-tests/vlseg4e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg4e32.c
+++ b/auto-generated/llvm-api-tests/vlseg4e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg4e32ff.c
+++ b/auto-generated/llvm-api-tests/vlseg4e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg4e64.c
+++ b/auto-generated/llvm-api-tests/vlseg4e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg4e64ff.c
+++ b/auto-generated/llvm-api-tests/vlseg4e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg4e8ff.c
+++ b/auto-generated/llvm-api-tests/vlseg4e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg5e16.c
+++ b/auto-generated/llvm-api-tests/vlseg5e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg5e16ff.c
+++ b/auto-generated/llvm-api-tests/vlseg5e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg5e32.c
+++ b/auto-generated/llvm-api-tests/vlseg5e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg5e32ff.c
+++ b/auto-generated/llvm-api-tests/vlseg5e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg5e64.c
+++ b/auto-generated/llvm-api-tests/vlseg5e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg5e64ff.c
+++ b/auto-generated/llvm-api-tests/vlseg5e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg5e8ff.c
+++ b/auto-generated/llvm-api-tests/vlseg5e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg6e16.c
+++ b/auto-generated/llvm-api-tests/vlseg6e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg6e16ff.c
+++ b/auto-generated/llvm-api-tests/vlseg6e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg6e32.c
+++ b/auto-generated/llvm-api-tests/vlseg6e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg6e32ff.c
+++ b/auto-generated/llvm-api-tests/vlseg6e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg6e64.c
+++ b/auto-generated/llvm-api-tests/vlseg6e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg6e64ff.c
+++ b/auto-generated/llvm-api-tests/vlseg6e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg6e8ff.c
+++ b/auto-generated/llvm-api-tests/vlseg6e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg7e16.c
+++ b/auto-generated/llvm-api-tests/vlseg7e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg7e16ff.c
+++ b/auto-generated/llvm-api-tests/vlseg7e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg7e32.c
+++ b/auto-generated/llvm-api-tests/vlseg7e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg7e32ff.c
+++ b/auto-generated/llvm-api-tests/vlseg7e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg7e64.c
+++ b/auto-generated/llvm-api-tests/vlseg7e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg7e64ff.c
+++ b/auto-generated/llvm-api-tests/vlseg7e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg7e8ff.c
+++ b/auto-generated/llvm-api-tests/vlseg7e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg8e16.c
+++ b/auto-generated/llvm-api-tests/vlseg8e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg8e16ff.c
+++ b/auto-generated/llvm-api-tests/vlseg8e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg8e32.c
+++ b/auto-generated/llvm-api-tests/vlseg8e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg8e32ff.c
+++ b/auto-generated/llvm-api-tests/vlseg8e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg8e64.c
+++ b/auto-generated/llvm-api-tests/vlseg8e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg8e64ff.c
+++ b/auto-generated/llvm-api-tests/vlseg8e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlseg8e8ff.c
+++ b/auto-generated/llvm-api-tests/vlseg8e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg2e16.c
+++ b/auto-generated/llvm-api-tests/vlsseg2e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg2e32.c
+++ b/auto-generated/llvm-api-tests/vlsseg2e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg2e64.c
+++ b/auto-generated/llvm-api-tests/vlsseg2e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg3e16.c
+++ b/auto-generated/llvm-api-tests/vlsseg3e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg3e32.c
+++ b/auto-generated/llvm-api-tests/vlsseg3e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg3e64.c
+++ b/auto-generated/llvm-api-tests/vlsseg3e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg4e16.c
+++ b/auto-generated/llvm-api-tests/vlsseg4e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg4e32.c
+++ b/auto-generated/llvm-api-tests/vlsseg4e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg4e64.c
+++ b/auto-generated/llvm-api-tests/vlsseg4e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg5e16.c
+++ b/auto-generated/llvm-api-tests/vlsseg5e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg5e32.c
+++ b/auto-generated/llvm-api-tests/vlsseg5e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg5e64.c
+++ b/auto-generated/llvm-api-tests/vlsseg5e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg6e16.c
+++ b/auto-generated/llvm-api-tests/vlsseg6e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg6e32.c
+++ b/auto-generated/llvm-api-tests/vlsseg6e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg6e64.c
+++ b/auto-generated/llvm-api-tests/vlsseg6e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg7e16.c
+++ b/auto-generated/llvm-api-tests/vlsseg7e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg7e32.c
+++ b/auto-generated/llvm-api-tests/vlsseg7e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg7e64.c
+++ b/auto-generated/llvm-api-tests/vlsseg7e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg8e16.c
+++ b/auto-generated/llvm-api-tests/vlsseg8e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg8e32.c
+++ b/auto-generated/llvm-api-tests/vlsseg8e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vlsseg8e64.c
+++ b/auto-generated/llvm-api-tests/vlsseg8e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxei16.c
+++ b/auto-generated/llvm-api-tests/vluxei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxei32.c
+++ b/auto-generated/llvm-api-tests/vluxei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxei64.c
+++ b/auto-generated/llvm-api-tests/vluxei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxei8.c
+++ b/auto-generated/llvm-api-tests/vluxei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg2ei16.c
+++ b/auto-generated/llvm-api-tests/vluxseg2ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg2ei32.c
+++ b/auto-generated/llvm-api-tests/vluxseg2ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg2ei64.c
+++ b/auto-generated/llvm-api-tests/vluxseg2ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg2ei8.c
+++ b/auto-generated/llvm-api-tests/vluxseg2ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg3ei16.c
+++ b/auto-generated/llvm-api-tests/vluxseg3ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg3ei32.c
+++ b/auto-generated/llvm-api-tests/vluxseg3ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg3ei64.c
+++ b/auto-generated/llvm-api-tests/vluxseg3ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg3ei8.c
+++ b/auto-generated/llvm-api-tests/vluxseg3ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg4ei16.c
+++ b/auto-generated/llvm-api-tests/vluxseg4ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg4ei32.c
+++ b/auto-generated/llvm-api-tests/vluxseg4ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg4ei64.c
+++ b/auto-generated/llvm-api-tests/vluxseg4ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg4ei8.c
+++ b/auto-generated/llvm-api-tests/vluxseg4ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg5ei16.c
+++ b/auto-generated/llvm-api-tests/vluxseg5ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg5ei32.c
+++ b/auto-generated/llvm-api-tests/vluxseg5ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg5ei64.c
+++ b/auto-generated/llvm-api-tests/vluxseg5ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg5ei8.c
+++ b/auto-generated/llvm-api-tests/vluxseg5ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg6ei16.c
+++ b/auto-generated/llvm-api-tests/vluxseg6ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg6ei32.c
+++ b/auto-generated/llvm-api-tests/vluxseg6ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg6ei64.c
+++ b/auto-generated/llvm-api-tests/vluxseg6ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg6ei8.c
+++ b/auto-generated/llvm-api-tests/vluxseg6ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg7ei16.c
+++ b/auto-generated/llvm-api-tests/vluxseg7ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg7ei32.c
+++ b/auto-generated/llvm-api-tests/vluxseg7ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg7ei64.c
+++ b/auto-generated/llvm-api-tests/vluxseg7ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg7ei8.c
+++ b/auto-generated/llvm-api-tests/vluxseg7ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg8ei16.c
+++ b/auto-generated/llvm-api-tests/vluxseg8ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg8ei32.c
+++ b/auto-generated/llvm-api-tests/vluxseg8ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg8ei64.c
+++ b/auto-generated/llvm-api-tests/vluxseg8ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vluxseg8ei8.c
+++ b/auto-generated/llvm-api-tests/vluxseg8ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmacc.c
+++ b/auto-generated/llvm-api-tests/vmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmadd.c
+++ b/auto-generated/llvm-api-tests/vmadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmerge.c
+++ b/auto-generated/llvm-api-tests/vmerge.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmfeq.c
+++ b/auto-generated/llvm-api-tests/vmfeq.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmfge.c
+++ b/auto-generated/llvm-api-tests/vmfge.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmfgt.c
+++ b/auto-generated/llvm-api-tests/vmfgt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmfle.c
+++ b/auto-generated/llvm-api-tests/vmfle.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmflt.c
+++ b/auto-generated/llvm-api-tests/vmflt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmfne.c
+++ b/auto-generated/llvm-api-tests/vmfne.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmmv.c
+++ b/auto-generated/llvm-api-tests/vmmv.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmseq.c
+++ b/auto-generated/llvm-api-tests/vmseq.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmsge.c
+++ b/auto-generated/llvm-api-tests/vmsge.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmsgeu.c
+++ b/auto-generated/llvm-api-tests/vmsgeu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmsgt.c
+++ b/auto-generated/llvm-api-tests/vmsgt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmsgtu.c
+++ b/auto-generated/llvm-api-tests/vmsgtu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmsle.c
+++ b/auto-generated/llvm-api-tests/vmsle.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmsleu.c
+++ b/auto-generated/llvm-api-tests/vmsleu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmslt.c
+++ b/auto-generated/llvm-api-tests/vmslt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmsltu.c
+++ b/auto-generated/llvm-api-tests/vmsltu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmsne.c
+++ b/auto-generated/llvm-api-tests/vmsne.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vmv.c
+++ b/auto-generated/llvm-api-tests/vmv.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vneg.c
+++ b/auto-generated/llvm-api-tests/vneg.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vnmsac.c
+++ b/auto-generated/llvm-api-tests/vnmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vnmsub.c
+++ b/auto-generated/llvm-api-tests/vnmsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vreinterpret.c
+++ b/auto-generated/llvm-api-tests/vreinterpret.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vrgather.c
+++ b/auto-generated/llvm-api-tests/vrgather.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vrgatherei16.c
+++ b/auto-generated/llvm-api-tests/vrgatherei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vse16.c
+++ b/auto-generated/llvm-api-tests/vse16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vse32.c
+++ b/auto-generated/llvm-api-tests/vse32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vse64.c
+++ b/auto-generated/llvm-api-tests/vse64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vset.c
+++ b/auto-generated/llvm-api-tests/vset.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vslidedown.c
+++ b/auto-generated/llvm-api-tests/vslidedown.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vslideup.c
+++ b/auto-generated/llvm-api-tests/vslideup.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxei16.c
+++ b/auto-generated/llvm-api-tests/vsoxei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxei32.c
+++ b/auto-generated/llvm-api-tests/vsoxei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxei64.c
+++ b/auto-generated/llvm-api-tests/vsoxei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxei8.c
+++ b/auto-generated/llvm-api-tests/vsoxei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg2ei16.c
+++ b/auto-generated/llvm-api-tests/vsoxseg2ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg2ei32.c
+++ b/auto-generated/llvm-api-tests/vsoxseg2ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg2ei64.c
+++ b/auto-generated/llvm-api-tests/vsoxseg2ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg2ei8.c
+++ b/auto-generated/llvm-api-tests/vsoxseg2ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg3ei16.c
+++ b/auto-generated/llvm-api-tests/vsoxseg3ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg3ei32.c
+++ b/auto-generated/llvm-api-tests/vsoxseg3ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg3ei64.c
+++ b/auto-generated/llvm-api-tests/vsoxseg3ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg3ei8.c
+++ b/auto-generated/llvm-api-tests/vsoxseg3ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg4ei16.c
+++ b/auto-generated/llvm-api-tests/vsoxseg4ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg4ei32.c
+++ b/auto-generated/llvm-api-tests/vsoxseg4ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg4ei64.c
+++ b/auto-generated/llvm-api-tests/vsoxseg4ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg4ei8.c
+++ b/auto-generated/llvm-api-tests/vsoxseg4ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg5ei16.c
+++ b/auto-generated/llvm-api-tests/vsoxseg5ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg5ei32.c
+++ b/auto-generated/llvm-api-tests/vsoxseg5ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg5ei64.c
+++ b/auto-generated/llvm-api-tests/vsoxseg5ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg5ei8.c
+++ b/auto-generated/llvm-api-tests/vsoxseg5ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg6ei16.c
+++ b/auto-generated/llvm-api-tests/vsoxseg6ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg6ei32.c
+++ b/auto-generated/llvm-api-tests/vsoxseg6ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg6ei64.c
+++ b/auto-generated/llvm-api-tests/vsoxseg6ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg6ei8.c
+++ b/auto-generated/llvm-api-tests/vsoxseg6ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg7ei16.c
+++ b/auto-generated/llvm-api-tests/vsoxseg7ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg7ei32.c
+++ b/auto-generated/llvm-api-tests/vsoxseg7ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg7ei64.c
+++ b/auto-generated/llvm-api-tests/vsoxseg7ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg7ei8.c
+++ b/auto-generated/llvm-api-tests/vsoxseg7ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg8ei16.c
+++ b/auto-generated/llvm-api-tests/vsoxseg8ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg8ei32.c
+++ b/auto-generated/llvm-api-tests/vsoxseg8ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg8ei64.c
+++ b/auto-generated/llvm-api-tests/vsoxseg8ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsoxseg8ei8.c
+++ b/auto-generated/llvm-api-tests/vsoxseg8ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsse16.c
+++ b/auto-generated/llvm-api-tests/vsse16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsse32.c
+++ b/auto-generated/llvm-api-tests/vsse32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsse64.c
+++ b/auto-generated/llvm-api-tests/vsse64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg2e16.c
+++ b/auto-generated/llvm-api-tests/vsseg2e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg2e32.c
+++ b/auto-generated/llvm-api-tests/vsseg2e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg2e64.c
+++ b/auto-generated/llvm-api-tests/vsseg2e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg3e16.c
+++ b/auto-generated/llvm-api-tests/vsseg3e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg3e32.c
+++ b/auto-generated/llvm-api-tests/vsseg3e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg3e64.c
+++ b/auto-generated/llvm-api-tests/vsseg3e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg4e16.c
+++ b/auto-generated/llvm-api-tests/vsseg4e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg4e32.c
+++ b/auto-generated/llvm-api-tests/vsseg4e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg4e64.c
+++ b/auto-generated/llvm-api-tests/vsseg4e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg5e16.c
+++ b/auto-generated/llvm-api-tests/vsseg5e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg5e32.c
+++ b/auto-generated/llvm-api-tests/vsseg5e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg5e64.c
+++ b/auto-generated/llvm-api-tests/vsseg5e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg6e16.c
+++ b/auto-generated/llvm-api-tests/vsseg6e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg6e32.c
+++ b/auto-generated/llvm-api-tests/vsseg6e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg6e64.c
+++ b/auto-generated/llvm-api-tests/vsseg6e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg7e16.c
+++ b/auto-generated/llvm-api-tests/vsseg7e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg7e32.c
+++ b/auto-generated/llvm-api-tests/vsseg7e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg7e64.c
+++ b/auto-generated/llvm-api-tests/vsseg7e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg8e16.c
+++ b/auto-generated/llvm-api-tests/vsseg8e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg8e32.c
+++ b/auto-generated/llvm-api-tests/vsseg8e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsseg8e64.c
+++ b/auto-generated/llvm-api-tests/vsseg8e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg2e16.c
+++ b/auto-generated/llvm-api-tests/vssseg2e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg2e32.c
+++ b/auto-generated/llvm-api-tests/vssseg2e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg2e64.c
+++ b/auto-generated/llvm-api-tests/vssseg2e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg3e16.c
+++ b/auto-generated/llvm-api-tests/vssseg3e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg3e32.c
+++ b/auto-generated/llvm-api-tests/vssseg3e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg3e64.c
+++ b/auto-generated/llvm-api-tests/vssseg3e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg4e16.c
+++ b/auto-generated/llvm-api-tests/vssseg4e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg4e32.c
+++ b/auto-generated/llvm-api-tests/vssseg4e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg4e64.c
+++ b/auto-generated/llvm-api-tests/vssseg4e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg5e16.c
+++ b/auto-generated/llvm-api-tests/vssseg5e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg5e32.c
+++ b/auto-generated/llvm-api-tests/vssseg5e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg5e64.c
+++ b/auto-generated/llvm-api-tests/vssseg5e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg6e16.c
+++ b/auto-generated/llvm-api-tests/vssseg6e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg6e32.c
+++ b/auto-generated/llvm-api-tests/vssseg6e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg6e64.c
+++ b/auto-generated/llvm-api-tests/vssseg6e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg7e16.c
+++ b/auto-generated/llvm-api-tests/vssseg7e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg7e32.c
+++ b/auto-generated/llvm-api-tests/vssseg7e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg7e64.c
+++ b/auto-generated/llvm-api-tests/vssseg7e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg8e16.c
+++ b/auto-generated/llvm-api-tests/vssseg8e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg8e32.c
+++ b/auto-generated/llvm-api-tests/vssseg8e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vssseg8e64.c
+++ b/auto-generated/llvm-api-tests/vssseg8e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxei16.c
+++ b/auto-generated/llvm-api-tests/vsuxei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxei32.c
+++ b/auto-generated/llvm-api-tests/vsuxei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxei64.c
+++ b/auto-generated/llvm-api-tests/vsuxei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxei8.c
+++ b/auto-generated/llvm-api-tests/vsuxei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg2ei16.c
+++ b/auto-generated/llvm-api-tests/vsuxseg2ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg2ei32.c
+++ b/auto-generated/llvm-api-tests/vsuxseg2ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg2ei64.c
+++ b/auto-generated/llvm-api-tests/vsuxseg2ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg2ei8.c
+++ b/auto-generated/llvm-api-tests/vsuxseg2ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg3ei16.c
+++ b/auto-generated/llvm-api-tests/vsuxseg3ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg3ei32.c
+++ b/auto-generated/llvm-api-tests/vsuxseg3ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg3ei64.c
+++ b/auto-generated/llvm-api-tests/vsuxseg3ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg3ei8.c
+++ b/auto-generated/llvm-api-tests/vsuxseg3ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg4ei16.c
+++ b/auto-generated/llvm-api-tests/vsuxseg4ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg4ei32.c
+++ b/auto-generated/llvm-api-tests/vsuxseg4ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg4ei64.c
+++ b/auto-generated/llvm-api-tests/vsuxseg4ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg4ei8.c
+++ b/auto-generated/llvm-api-tests/vsuxseg4ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg5ei16.c
+++ b/auto-generated/llvm-api-tests/vsuxseg5ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg5ei32.c
+++ b/auto-generated/llvm-api-tests/vsuxseg5ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg5ei64.c
+++ b/auto-generated/llvm-api-tests/vsuxseg5ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg5ei8.c
+++ b/auto-generated/llvm-api-tests/vsuxseg5ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg6ei16.c
+++ b/auto-generated/llvm-api-tests/vsuxseg6ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg6ei32.c
+++ b/auto-generated/llvm-api-tests/vsuxseg6ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg6ei64.c
+++ b/auto-generated/llvm-api-tests/vsuxseg6ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg6ei8.c
+++ b/auto-generated/llvm-api-tests/vsuxseg6ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg7ei16.c
+++ b/auto-generated/llvm-api-tests/vsuxseg7ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg7ei32.c
+++ b/auto-generated/llvm-api-tests/vsuxseg7ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg7ei64.c
+++ b/auto-generated/llvm-api-tests/vsuxseg7ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg7ei8.c
+++ b/auto-generated/llvm-api-tests/vsuxseg7ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg8ei16.c
+++ b/auto-generated/llvm-api-tests/vsuxseg8ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg8ei32.c
+++ b/auto-generated/llvm-api-tests/vsuxseg8ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg8ei64.c
+++ b/auto-generated/llvm-api-tests/vsuxseg8ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vsuxseg8ei8.c
+++ b/auto-generated/llvm-api-tests/vsuxseg8ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vundefined.c
+++ b/auto-generated/llvm-api-tests/vundefined.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vwmacc.c
+++ b/auto-generated/llvm-api-tests/vwmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vwmaccsu.c
+++ b/auto-generated/llvm-api-tests/vwmaccsu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vwmaccu.c
+++ b/auto-generated/llvm-api-tests/vwmaccu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-api-tests/vwmaccus.c
+++ b/auto-generated/llvm-api-tests/vwmaccus.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vcompress.c
+++ b/auto-generated/llvm-overloaded-tests/vcompress.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vcpop.c
+++ b/auto-generated/llvm-overloaded-tests/vcpop.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfabs.c
+++ b/auto-generated/llvm-overloaded-tests/vfabs.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfadd.c
+++ b/auto-generated/llvm-overloaded-tests/vfadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfclass.c
+++ b/auto-generated/llvm-overloaded-tests/vfclass.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfcvt.c
+++ b/auto-generated/llvm-overloaded-tests/vfcvt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfcvt_rtz.c
+++ b/auto-generated/llvm-overloaded-tests/vfcvt_rtz.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfdiv.c
+++ b/auto-generated/llvm-overloaded-tests/vfdiv.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfmacc.c
+++ b/auto-generated/llvm-overloaded-tests/vfmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfmadd.c
+++ b/auto-generated/llvm-overloaded-tests/vfmadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfmax.c
+++ b/auto-generated/llvm-overloaded-tests/vfmax.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfmerge.c
+++ b/auto-generated/llvm-overloaded-tests/vfmerge.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfmin.c
+++ b/auto-generated/llvm-overloaded-tests/vfmin.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfmsac.c
+++ b/auto-generated/llvm-overloaded-tests/vfmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfmsub.c
+++ b/auto-generated/llvm-overloaded-tests/vfmsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfmul.c
+++ b/auto-generated/llvm-overloaded-tests/vfmul.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfmv.c
+++ b/auto-generated/llvm-overloaded-tests/vfmv.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfncvt.c
+++ b/auto-generated/llvm-overloaded-tests/vfncvt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfncvt_rod.c
+++ b/auto-generated/llvm-overloaded-tests/vfncvt_rod.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfncvt_rtz.c
+++ b/auto-generated/llvm-overloaded-tests/vfncvt_rtz.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfneg.c
+++ b/auto-generated/llvm-overloaded-tests/vfneg.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfnmacc.c
+++ b/auto-generated/llvm-overloaded-tests/vfnmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfnmadd.c
+++ b/auto-generated/llvm-overloaded-tests/vfnmadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfnmsac.c
+++ b/auto-generated/llvm-overloaded-tests/vfnmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfnmsub.c
+++ b/auto-generated/llvm-overloaded-tests/vfnmsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfrdiv.c
+++ b/auto-generated/llvm-overloaded-tests/vfrdiv.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfrec7.c
+++ b/auto-generated/llvm-overloaded-tests/vfrec7.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfredmax.c
+++ b/auto-generated/llvm-overloaded-tests/vfredmax.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfredmin.c
+++ b/auto-generated/llvm-overloaded-tests/vfredmin.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfredosum.c
+++ b/auto-generated/llvm-overloaded-tests/vfredosum.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfredusum.c
+++ b/auto-generated/llvm-overloaded-tests/vfredusum.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfrsqrt7.c
+++ b/auto-generated/llvm-overloaded-tests/vfrsqrt7.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfrsub.c
+++ b/auto-generated/llvm-overloaded-tests/vfrsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfsgnj.c
+++ b/auto-generated/llvm-overloaded-tests/vfsgnj.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfsgnjn.c
+++ b/auto-generated/llvm-overloaded-tests/vfsgnjn.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfsgnjx.c
+++ b/auto-generated/llvm-overloaded-tests/vfsgnjx.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfslide1down.c
+++ b/auto-generated/llvm-overloaded-tests/vfslide1down.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfslide1up.c
+++ b/auto-generated/llvm-overloaded-tests/vfslide1up.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfsqrt.c
+++ b/auto-generated/llvm-overloaded-tests/vfsqrt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfsub.c
+++ b/auto-generated/llvm-overloaded-tests/vfsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfwadd.c
+++ b/auto-generated/llvm-overloaded-tests/vfwadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfwcvt.c
+++ b/auto-generated/llvm-overloaded-tests/vfwcvt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfwcvt_rtz.c
+++ b/auto-generated/llvm-overloaded-tests/vfwcvt_rtz.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfwmacc.c
+++ b/auto-generated/llvm-overloaded-tests/vfwmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfwmsac.c
+++ b/auto-generated/llvm-overloaded-tests/vfwmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfwmul.c
+++ b/auto-generated/llvm-overloaded-tests/vfwmul.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfwnmacc.c
+++ b/auto-generated/llvm-overloaded-tests/vfwnmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfwnmsac.c
+++ b/auto-generated/llvm-overloaded-tests/vfwnmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfwredosum.c
+++ b/auto-generated/llvm-overloaded-tests/vfwredosum.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfwredusum.c
+++ b/auto-generated/llvm-overloaded-tests/vfwredusum.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vfwsub.c
+++ b/auto-generated/llvm-overloaded-tests/vfwsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vget.c
+++ b/auto-generated/llvm-overloaded-tests/vget.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vle16.c
+++ b/auto-generated/llvm-overloaded-tests/vle16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vle16ff.c
+++ b/auto-generated/llvm-overloaded-tests/vle16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vle32.c
+++ b/auto-generated/llvm-overloaded-tests/vle32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vle32ff.c
+++ b/auto-generated/llvm-overloaded-tests/vle32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vle64.c
+++ b/auto-generated/llvm-overloaded-tests/vle64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vle64ff.c
+++ b/auto-generated/llvm-overloaded-tests/vle64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vle8.c
+++ b/auto-generated/llvm-overloaded-tests/vle8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vle8ff.c
+++ b/auto-generated/llvm-overloaded-tests/vle8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlmul_ext_v.c
+++ b/auto-generated/llvm-overloaded-tests/vlmul_ext_v.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlmul_trunc_v.c
+++ b/auto-generated/llvm-overloaded-tests/vlmul_trunc_v.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxei16.c
+++ b/auto-generated/llvm-overloaded-tests/vloxei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxei32.c
+++ b/auto-generated/llvm-overloaded-tests/vloxei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxei64.c
+++ b/auto-generated/llvm-overloaded-tests/vloxei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxei8.c
+++ b/auto-generated/llvm-overloaded-tests/vloxei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg2ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg2ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg2ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg2ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg2ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg2ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg2ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg2ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg3ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg3ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg3ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg3ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg3ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg3ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg3ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg3ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg4ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg4ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg4ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg4ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg4ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg4ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg4ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg4ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg5ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg5ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg5ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg5ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg5ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg5ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg5ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg5ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg6ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg6ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg6ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg6ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg6ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg6ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg6ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg6ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg7ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg7ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg7ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg7ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg7ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg7ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg7ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg7ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg8ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg8ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg8ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg8ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg8ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg8ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vloxseg8ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vloxseg8ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlse16.c
+++ b/auto-generated/llvm-overloaded-tests/vlse16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlse32.c
+++ b/auto-generated/llvm-overloaded-tests/vlse32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlse64.c
+++ b/auto-generated/llvm-overloaded-tests/vlse64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg2e16.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg2e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg2e16ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg2e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg2e32.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg2e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg2e32ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg2e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg2e64.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg2e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg2e64ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg2e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg2e8ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg2e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg3e16.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg3e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg3e16ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg3e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg3e32.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg3e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg3e32ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg3e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg3e64.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg3e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg3e64ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg3e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg3e8ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg3e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg4e16.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg4e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg4e16ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg4e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg4e32.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg4e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg4e32ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg4e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg4e64.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg4e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg4e64ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg4e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg4e8ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg4e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg5e16.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg5e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg5e16ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg5e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg5e32.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg5e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg5e32ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg5e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg5e64.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg5e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg5e64ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg5e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg5e8ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg5e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg6e16.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg6e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg6e16ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg6e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg6e32.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg6e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg6e32ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg6e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg6e64.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg6e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg6e64ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg6e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg6e8ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg6e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg7e16.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg7e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg7e16ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg7e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg7e32.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg7e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg7e32ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg7e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg7e64.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg7e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg7e64ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg7e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg7e8ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg7e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg8e16.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg8e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg8e16ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg8e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg8e32.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg8e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg8e32ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg8e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg8e64.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg8e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg8e64ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg8e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlseg8e8ff.c
+++ b/auto-generated/llvm-overloaded-tests/vlseg8e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg2e16.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg2e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg2e32.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg2e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg2e64.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg2e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg3e16.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg3e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg3e32.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg3e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg3e64.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg3e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg4e16.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg4e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg4e32.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg4e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg4e64.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg4e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg5e16.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg5e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg5e32.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg5e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg5e64.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg5e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg6e16.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg6e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg6e32.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg6e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg6e64.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg6e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg7e16.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg7e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg7e32.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg7e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg7e64.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg7e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg8e16.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg8e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg8e32.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg8e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vlsseg8e64.c
+++ b/auto-generated/llvm-overloaded-tests/vlsseg8e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxei16.c
+++ b/auto-generated/llvm-overloaded-tests/vluxei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxei32.c
+++ b/auto-generated/llvm-overloaded-tests/vluxei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxei64.c
+++ b/auto-generated/llvm-overloaded-tests/vluxei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxei8.c
+++ b/auto-generated/llvm-overloaded-tests/vluxei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg2ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg2ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg2ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg2ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg2ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg2ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg2ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg2ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg3ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg3ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg3ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg3ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg3ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg3ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg3ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg3ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg4ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg4ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg4ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg4ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg4ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg4ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg4ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg4ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg5ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg5ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg5ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg5ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg5ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg5ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg5ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg5ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg6ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg6ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg6ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg6ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg6ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg6ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg6ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg6ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg7ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg7ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg7ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg7ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg7ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg7ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg7ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg7ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg8ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg8ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg8ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg8ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg8ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg8ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vluxseg8ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vluxseg8ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmacc.c
+++ b/auto-generated/llvm-overloaded-tests/vmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmadd.c
+++ b/auto-generated/llvm-overloaded-tests/vmadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmerge.c
+++ b/auto-generated/llvm-overloaded-tests/vmerge.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmfeq.c
+++ b/auto-generated/llvm-overloaded-tests/vmfeq.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmfge.c
+++ b/auto-generated/llvm-overloaded-tests/vmfge.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmfgt.c
+++ b/auto-generated/llvm-overloaded-tests/vmfgt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmfle.c
+++ b/auto-generated/llvm-overloaded-tests/vmfle.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmflt.c
+++ b/auto-generated/llvm-overloaded-tests/vmflt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmfne.c
+++ b/auto-generated/llvm-overloaded-tests/vmfne.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmmv.c
+++ b/auto-generated/llvm-overloaded-tests/vmmv.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmseq.c
+++ b/auto-generated/llvm-overloaded-tests/vmseq.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmsge.c
+++ b/auto-generated/llvm-overloaded-tests/vmsge.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmsgeu.c
+++ b/auto-generated/llvm-overloaded-tests/vmsgeu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmsgt.c
+++ b/auto-generated/llvm-overloaded-tests/vmsgt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmsgtu.c
+++ b/auto-generated/llvm-overloaded-tests/vmsgtu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmsle.c
+++ b/auto-generated/llvm-overloaded-tests/vmsle.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmsleu.c
+++ b/auto-generated/llvm-overloaded-tests/vmsleu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmslt.c
+++ b/auto-generated/llvm-overloaded-tests/vmslt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmsltu.c
+++ b/auto-generated/llvm-overloaded-tests/vmsltu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmsne.c
+++ b/auto-generated/llvm-overloaded-tests/vmsne.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vmv.c
+++ b/auto-generated/llvm-overloaded-tests/vmv.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vneg.c
+++ b/auto-generated/llvm-overloaded-tests/vneg.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vnmsac.c
+++ b/auto-generated/llvm-overloaded-tests/vnmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vnmsub.c
+++ b/auto-generated/llvm-overloaded-tests/vnmsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vreinterpret.c
+++ b/auto-generated/llvm-overloaded-tests/vreinterpret.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vrgather.c
+++ b/auto-generated/llvm-overloaded-tests/vrgather.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vrgatherei16.c
+++ b/auto-generated/llvm-overloaded-tests/vrgatherei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vse16.c
+++ b/auto-generated/llvm-overloaded-tests/vse16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vse32.c
+++ b/auto-generated/llvm-overloaded-tests/vse32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vse64.c
+++ b/auto-generated/llvm-overloaded-tests/vse64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vset.c
+++ b/auto-generated/llvm-overloaded-tests/vset.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vslidedown.c
+++ b/auto-generated/llvm-overloaded-tests/vslidedown.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vslideup.c
+++ b/auto-generated/llvm-overloaded-tests/vslideup.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxei16.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxei32.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxei64.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxei8.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg2ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg2ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg2ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg2ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg2ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg2ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg2ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg2ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg3ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg3ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg3ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg3ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg3ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg3ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg3ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg3ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg4ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg4ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg4ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg4ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg4ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg4ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg4ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg4ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg5ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg5ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg5ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg5ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg5ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg5ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg5ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg5ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg6ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg6ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg6ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg6ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg6ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg6ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg6ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg6ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg7ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg7ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg7ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg7ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg7ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg7ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg7ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg7ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg8ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg8ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg8ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg8ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg8ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg8ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsoxseg8ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vsoxseg8ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsse16.c
+++ b/auto-generated/llvm-overloaded-tests/vsse16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsse32.c
+++ b/auto-generated/llvm-overloaded-tests/vsse32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsse64.c
+++ b/auto-generated/llvm-overloaded-tests/vsse64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg2e16.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg2e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg2e32.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg2e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg2e64.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg2e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg3e16.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg3e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg3e32.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg3e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg3e64.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg3e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg4e16.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg4e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg4e32.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg4e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg4e64.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg4e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg5e16.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg5e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg5e32.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg5e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg5e64.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg5e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg6e16.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg6e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg6e32.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg6e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg6e64.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg6e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg7e16.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg7e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg7e32.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg7e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg7e64.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg7e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg8e16.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg8e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg8e32.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg8e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsseg8e64.c
+++ b/auto-generated/llvm-overloaded-tests/vsseg8e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg2e16.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg2e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg2e32.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg2e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg2e64.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg2e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg3e16.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg3e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg3e32.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg3e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg3e64.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg3e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg4e16.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg4e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg4e32.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg4e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg4e64.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg4e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg5e16.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg5e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg5e32.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg5e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg5e64.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg5e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg6e16.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg6e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg6e32.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg6e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg6e64.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg6e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg7e16.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg7e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg7e32.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg7e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg7e64.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg7e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg8e16.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg8e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg8e32.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg8e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vssseg8e64.c
+++ b/auto-generated/llvm-overloaded-tests/vssseg8e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxei16.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxei32.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxei64.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxei8.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg2ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg2ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg2ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg2ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg2ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg2ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg2ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg2ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg3ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg3ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg3ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg3ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg3ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg3ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg3ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg3ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg4ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg4ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg4ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg4ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg4ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg4ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg4ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg4ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg5ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg5ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg5ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg5ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg5ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg5ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg5ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg5ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg6ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg6ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg6ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg6ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg6ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg6ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg6ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg6ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg7ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg7ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg7ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg7ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg7ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg7ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg7ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg7ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg8ei16.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg8ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg8ei32.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg8ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg8ei64.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg8ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vsuxseg8ei8.c
+++ b/auto-generated/llvm-overloaded-tests/vsuxseg8ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vwmacc.c
+++ b/auto-generated/llvm-overloaded-tests/vwmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vwmaccsu.c
+++ b/auto-generated/llvm-overloaded-tests/vwmaccsu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vwmaccu.c
+++ b/auto-generated/llvm-overloaded-tests/vwmaccu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/llvm-overloaded-tests/vwmaccus.c
+++ b/auto-generated/llvm-overloaded-tests/vwmaccus.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vcompress.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vcompress.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfabs.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfabs.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfadd.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfclass.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfclass.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfcvt.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfcvt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfcvt_rtz.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfcvt_rtz.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfdiv.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfdiv.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfmacc.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfmadd.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfmadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfmax.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfmax.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfmerge.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfmerge.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfmin.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfmin.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfmsac.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfmsub.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfmsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfmul.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfmul.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfmv.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfmv.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfncvt.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfncvt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfncvt_rod.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfncvt_rod.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfncvt_rtz.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfncvt_rtz.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfneg.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfneg.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfnmacc.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfnmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfnmadd.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfnmadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfnmsac.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfnmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfnmsub.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfnmsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfrdiv.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfrdiv.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfrec7.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfrec7.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfredmax.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfredmax.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfredmin.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfredmin.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfredosum.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfredosum.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfredusum.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfredusum.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfrsqrt7.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfrsqrt7.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfrsub.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfrsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfsgnj.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfsgnj.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfsgnjn.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfsgnjn.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfsgnjx.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfsgnjx.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfslide1down.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfslide1down.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfslide1up.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfslide1up.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfsqrt.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfsqrt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfsub.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfwadd.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfwadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfwcvt.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfwcvt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfwcvt_rtz.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfwcvt_rtz.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfwmacc.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfwmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfwmsac.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfwmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfwmul.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfwmul.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfwnmacc.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfwnmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfwnmsac.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfwnmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfwredosum.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfwredosum.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfwredusum.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfwredusum.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vfwsub.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfwsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vle16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vle16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vle16ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vle16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vle32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vle32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vle32ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vle32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vle64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vle64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vle64ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vle64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vle8.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vle8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vle8ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vle8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxei16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxei32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxei64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxei8.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg2ei16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg2ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg2ei32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg2ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg2ei64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg2ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg2ei8.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg2ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg3ei16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg3ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg3ei32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg3ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg3ei64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg3ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg3ei8.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg3ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg4ei16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg4ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg4ei32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg4ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg4ei64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg4ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg4ei8.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg4ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg5ei16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg5ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg5ei32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg5ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg5ei64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg5ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg5ei8.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg5ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg6ei16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg6ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg6ei32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg6ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg6ei64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg6ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg6ei8.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg6ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg7ei16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg7ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg7ei32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg7ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg7ei64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg7ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg7ei8.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg7ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg8ei16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg8ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg8ei32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg8ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg8ei64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg8ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vloxseg8ei8.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vloxseg8ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlse16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlse16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlse32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlse32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlse64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlse64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg2e16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg2e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg2e16ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg2e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg2e32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg2e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg2e32ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg2e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg2e64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg2e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg2e64ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg2e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg2e8ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg2e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg3e16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg3e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg3e16ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg3e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg3e32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg3e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg3e32ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg3e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg3e64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg3e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg3e64ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg3e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg3e8ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg3e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg4e16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg4e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg4e16ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg4e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg4e32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg4e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg4e32ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg4e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg4e64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg4e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg4e64ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg4e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg4e8ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg4e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg5e16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg5e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg5e16ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg5e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg5e32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg5e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg5e32ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg5e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg5e64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg5e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg5e64ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg5e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg5e8ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg5e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg6e16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg6e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg6e16ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg6e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg6e32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg6e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg6e32ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg6e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg6e64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg6e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg6e64ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg6e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg6e8ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg6e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg7e16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg7e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg7e16ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg7e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg7e32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg7e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg7e32ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg7e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg7e64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg7e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg7e64ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg7e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg7e8ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg7e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg8e16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg8e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg8e16ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg8e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg8e32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg8e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg8e32ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg8e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg8e64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg8e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg8e64ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg8e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlseg8e8ff.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlseg8e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg2e16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg2e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg2e32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg2e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg2e64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg2e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg3e16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg3e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg3e32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg3e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg3e64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg3e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg4e16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg4e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg4e32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg4e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg4e64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg4e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg5e16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg5e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg5e32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg5e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg5e64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg5e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg6e16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg6e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg6e32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg6e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg6e64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg6e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg7e16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg7e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg7e32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg7e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg7e64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg7e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg8e16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg8e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg8e32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg8e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vlsseg8e64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vlsseg8e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxei16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxei32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxei64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxei8.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg2ei16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg2ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg2ei32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg2ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg2ei64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg2ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg2ei8.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg2ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg3ei16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg3ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg3ei32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg3ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg3ei64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg3ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg3ei8.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg3ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg4ei16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg4ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg4ei32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg4ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg4ei64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg4ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg4ei8.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg4ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg5ei16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg5ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg5ei32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg5ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg5ei64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg5ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg5ei8.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg5ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg6ei16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg6ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg6ei32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg6ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg6ei64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg6ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg6ei8.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg6ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg7ei16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg7ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg7ei32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg7ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg7ei64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg7ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg7ei8.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg7ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg8ei16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg8ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg8ei32.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg8ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg8ei64.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg8ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vluxseg8ei8.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vluxseg8ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmacc.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmadd.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmerge.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmerge.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmfeq.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmfeq.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmfge.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmfge.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmfgt.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmfgt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmfle.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmfle.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmflt.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmflt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmfne.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmfne.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmseq.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmseq.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmsge.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmsge.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmsgeu.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmsgeu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmsgt.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmsgt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmsgtu.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmsgtu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmsle.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmsle.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmsleu.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmsleu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmslt.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmslt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmsltu.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmsltu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmsne.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmsne.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vmv.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vmv.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vneg.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vneg.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vnmsac.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vnmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vnmsub.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vnmsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vrgather.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vrgather.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vrgatherei16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vrgatherei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vslidedown.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vslidedown.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vslideup.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vslideup.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vwmacc.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vwmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vwmaccsu.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vwmaccsu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vwmaccu.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vwmaccu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-api-tests/vwmaccus.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vwmaccus.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vcompress.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vcompress.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfabs.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfabs.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfadd.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfclass.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfclass.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfcvt.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfcvt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfcvt_rtz.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfcvt_rtz.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfdiv.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfdiv.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfmacc.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfmadd.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfmadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfmax.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfmax.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfmerge.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfmerge.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfmin.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfmin.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfmsac.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfmsub.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfmsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfmul.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfmul.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfmv.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfmv.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfncvt.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfncvt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfncvt_rod.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfncvt_rod.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfncvt_rtz.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfncvt_rtz.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfneg.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfneg.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfnmacc.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfnmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfnmadd.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfnmadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfnmsac.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfnmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfnmsub.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfnmsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfrdiv.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfrdiv.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfrec7.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfrec7.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfredmax.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfredmax.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfredmin.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfredmin.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfredosum.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfredosum.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfredusum.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfredusum.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfrsqrt7.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfrsqrt7.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfrsub.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfrsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfsgnj.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfsgnj.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfsgnjn.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfsgnjn.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfsgnjx.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfsgnjx.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfslide1down.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfslide1down.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfslide1up.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfslide1up.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfsqrt.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfsqrt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfsub.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfwadd.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfwadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfwcvt.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfwcvt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfwcvt_rtz.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfwcvt_rtz.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfwmacc.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfwmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfwmsac.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfwmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfwmul.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfwmul.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfwnmacc.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfwnmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfwnmsac.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfwnmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfwredosum.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfwredosum.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfwredusum.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfwredusum.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfwsub.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfwsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vle16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vle16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vle16ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vle16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vle32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vle32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vle32ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vle32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vle64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vle64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vle64ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vle64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vle8.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vle8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vle8ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vle8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxei16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxei32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxei64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxei8.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg2ei16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg2ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg2ei32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg2ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg2ei64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg2ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg2ei8.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg2ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg3ei16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg3ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg3ei32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg3ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg3ei64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg3ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg3ei8.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg3ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg4ei16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg4ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg4ei32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg4ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg4ei64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg4ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg4ei8.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg4ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg5ei16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg5ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg5ei32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg5ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg5ei64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg5ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg5ei8.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg5ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg6ei16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg6ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg6ei32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg6ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg6ei64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg6ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg6ei8.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg6ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg7ei16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg7ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg7ei32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg7ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg7ei64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg7ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg7ei8.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg7ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg8ei16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg8ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg8ei32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg8ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg8ei64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg8ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg8ei8.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vloxseg8ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlse16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlse16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlse32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlse32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlse64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlse64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg2e16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg2e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg2e16ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg2e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg2e32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg2e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg2e32ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg2e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg2e64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg2e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg2e64ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg2e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg2e8ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg2e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg3e16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg3e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg3e16ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg3e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg3e32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg3e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg3e32ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg3e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg3e64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg3e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg3e64ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg3e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg3e8ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg3e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg4e16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg4e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg4e16ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg4e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg4e32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg4e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg4e32ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg4e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg4e64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg4e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg4e64ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg4e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg4e8ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg4e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg5e16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg5e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg5e16ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg5e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg5e32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg5e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg5e32ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg5e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg5e64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg5e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg5e64ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg5e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg5e8ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg5e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg6e16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg6e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg6e16ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg6e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg6e32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg6e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg6e32ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg6e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg6e64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg6e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg6e64ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg6e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg6e8ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg6e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg7e16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg7e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg7e16ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg7e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg7e32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg7e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg7e32ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg7e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg7e64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg7e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg7e64ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg7e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg7e8ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg7e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg8e16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg8e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg8e16ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg8e16ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg8e32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg8e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg8e32ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg8e32ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg8e64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg8e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg8e64ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg8e64ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg8e8ff.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlseg8e8ff.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg2e16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg2e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg2e32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg2e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg2e64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg2e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg3e16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg3e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg3e32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg3e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg3e64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg3e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg4e16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg4e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg4e32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg4e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg4e64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg4e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg5e16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg5e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg5e32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg5e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg5e64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg5e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg6e16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg6e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg6e32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg6e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg6e64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg6e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg7e16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg7e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg7e32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg7e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg7e64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg7e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg8e16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg8e16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg8e32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg8e32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg8e64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vlsseg8e64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxei16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxei32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxei64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxei8.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg2ei16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg2ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg2ei32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg2ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg2ei64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg2ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg2ei8.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg2ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg3ei16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg3ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg3ei32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg3ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg3ei64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg3ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg3ei8.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg3ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg4ei16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg4ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg4ei32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg4ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg4ei64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg4ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg4ei8.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg4ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg5ei16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg5ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg5ei32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg5ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg5ei64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg5ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg5ei8.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg5ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg6ei16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg6ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg6ei32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg6ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg6ei64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg6ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg6ei8.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg6ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg7ei16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg7ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg7ei32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg7ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg7ei64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg7ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg7ei8.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg7ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg8ei16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg8ei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg8ei32.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg8ei32.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg8ei64.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg8ei64.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg8ei8.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vluxseg8ei8.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmacc.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmadd.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmadd.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmerge.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmerge.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmfeq.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmfeq.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmfge.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmfge.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmfgt.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmfgt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmfle.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmfle.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmflt.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmflt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmfne.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmfne.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmseq.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmseq.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmsge.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmsge.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmsgeu.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmsgeu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmsgt.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmsgt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmsgtu.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmsgtu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmsle.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmsle.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmsleu.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmsleu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmslt.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmslt.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmsltu.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmsltu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmsne.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmsne.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vmv.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vmv.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vneg.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vneg.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vnmsac.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vnmsac.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vnmsub.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vnmsub.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vrgather.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vrgather.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vrgatherei16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vrgatherei16.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vslidedown.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vslidedown.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vslideup.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vslideup.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vwmacc.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vwmacc.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vwmaccsu.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vwmaccsu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vwmaccu.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vwmaccu.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vwmaccus.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vwmaccus.c
@@ -1,6 +1,6 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -452,7 +452,7 @@ class APITestGenerator(Generator):
 """)
     float_llvm_header = (r"""// REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone  \
+// RUN:   -target-feature +experimental-zvfh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 


### PR DESCRIPTION
It has two spaces between `-disable-O0-optnone` and `\`.