### PR TITLE
Add a quick-build target to Makefile

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -40,6 +40,11 @@ build:
 	$(ASCIIDOCTOR_PDF) $(OPTIONS) $(REQUIRES) --out-file=$(PDF_RESULT) $(HEADER_SOURCE)
 	@echo "Build completed successfully."
 
+quick-build:
+	@echo "Starting build..."
+	$(ASCIIDOCTOR_PDF) $(OPTIONS) $(REQUIRES) -a build-type=quick --out-file=$(PDF_RESULT) $(HEADER_SOURCE)
+	@echo "Build completed successfully."
+
 clean:
 	@echo "Cleaning up generated files..."
 	rm -f $(PDF_RESULT)

--- a/doc/header.adoc
+++ b/doc/header.adoc
@@ -51,6 +51,7 @@ Copyright 2023 by RISC-V International.
 
 include::rvv-intrinsic-spec.adoc[]
 
+ifeval::["{build-type}" != "quick"]
 [appendix]
 == Explicit (Non-overloaded) intrinsics
 include::../auto-generated/intrinsic_funcs/00_vector_loads_and_stores_intrinsics.adoc[]
@@ -98,3 +99,5 @@ include::../auto-generated/policy_funcs/overloaded_intrinsic_funcs/05_vector_red
 include::../auto-generated/policy_funcs/overloaded_intrinsic_funcs/06_vector_mask_intrinsics.adoc[]
 include::../auto-generated/policy_funcs/overloaded_intrinsic_funcs/07_vector_permutation_intrinsics.adoc[]
 include::../auto-generated/policy_funcs/overloaded_intrinsic_funcs/08_miscellaneous_vector_utility_intrinsics.adoc[]
+
+endif::[]


### PR DESCRIPTION
Full PDF generation will spend lot of time due to compile all of the function list, however most time we edit the document we don't really care about that part, so I try to add a quick-build target to reduce the PDF build time for quick preview for the changes.