### PR TITLE
Mark the document as in Freeze state

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -13,8 +13,8 @@
 # the Doc Template for RISC-V Extensions.
 
 DATE ?= $(shell date +%Y-%m-%d)
-VERSION ?= v0.13.0-draft
-REVMARK ?= Draft
+VERSION ?= v1.0-rc1
+REVMARK ?= Freeze
 
 HEADER_SOURCE := header.adoc
 PDF_RESULT := v-intrinsic-spec.pdf

--- a/doc/header.adoc
+++ b/doc/header.adoc
@@ -36,11 +36,9 @@ endif::[]
 :bibtex-throw: false
 
 [WARNING]
-.This document is in the link:http://riscv.org/spec-state[Development state]
+.This document is in the link:http://riscv.org/spec-state[Freeze state]
 ====
-Expect potential changes. This draft specification is likely to evolve before
-it is accepted as a standard. Implementations based on this draft
-may not conform to the future standard.
+Change is unlikely at this point of the specification.
 ====
 
 include::preface.adoc[]


### PR DESCRIPTION
**Note: this is a merge to v1.0.x**

Using 1.0-rc1 because 1.0-rc0 was already used during ARC review.

See #338  