### PR TITLE
Fix CI and missing implementations in derived classes

### DIFF
--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -815,6 +815,9 @@ _14, _15, _16, _17, _18, _19, _20, NAME, ...) NAME
   def inst_group_prologue(self):
     return ""
 
+  def inst_group_epilogue(self):
+    return ""
+
   def function_group(self, template, title, link, op_list, type_list, sew_list,
                      lmul_list, decorator_list):
     if self.has_tail_policy and len(decorator_list) == 0:

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -443,6 +443,9 @@ class APITestGenerator(Generator):
     # different op name
     self.test_file_names = []
 
+  def start_group(self, group_name):
+    pass
+
   def write_file_header(self, has_float_type, has_bfloat16_type):
     #pylint: disable=line-too-long
     int_llvm_header = r"""// REQUIRES: riscv-registered-target

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -809,6 +809,9 @@ _14, _15, _16, _17, _18, _19, _20, NAME, ...) NAME
   def write(self, text):
     self.fd.write(text)
 
+  def start_group(self, group_name):
+    pass
+
   def function_group(self, template, title, link, op_list, type_list, sew_list,
                      lmul_list, decorator_list):
     if self.has_tail_policy and len(decorator_list) == 0:

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -446,6 +446,9 @@ class APITestGenerator(Generator):
   def start_group(self, group_name):
     pass
 
+  def inst_group_prologue(self):
+    return ""
+
   def write_file_header(self, has_float_type, has_bfloat16_type):
     #pylint: disable=line-too-long
     int_llvm_header = r"""// REQUIRES: riscv-registered-target

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -443,6 +443,9 @@ class APITestGenerator(Generator):
     # different op name
     self.test_file_names = []
 
+  def write(self, text):
+    pass
+
   def start_group(self, group_name):
     pass
 

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -812,6 +812,9 @@ _14, _15, _16, _17, _18, _19, _20, NAME, ...) NAME
   def start_group(self, group_name):
     pass
 
+  def inst_group_prologue(self):
+    return ""
+
   def function_group(self, template, title, link, op_list, type_list, sew_list,
                      lmul_list, decorator_list):
     if self.has_tail_policy and len(decorator_list) == 0:

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -449,6 +449,9 @@ class APITestGenerator(Generator):
   def inst_group_prologue(self):
     return ""
 
+  def inst_group_epilogue(self):
+    return ""
+
   def write_file_header(self, has_float_type, has_bfloat16_type):
     #pylint: disable=line-too-long
     int_llvm_header = r"""// REQUIRES: riscv-registered-target

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -43,7 +43,7 @@ class Generator(ABC):
     raise NotImplementedError
 
   def gen_prologue(self):
-    raise NotImplementedError
+    pass
 
   def inst_group_prologue(self):
     raise NotImplementedError

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -367,7 +367,6 @@ class DocGenerator(Generator):
     # NOTE: If is_all_in_one is False, separate files of the grouped intrinsics
     # will be created, therefore we are allowing overriding the file descriptor
     # here.
-    super().start_group(group_name)
     if not self.is_all_in_one:
       file_name = f"{self.group_counter:02d}_{group_name}.adoc"
       file_name = file_name.replace(" ", "_")

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_intcarry_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_intcarry_template.py
@@ -38,6 +38,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
       s = type_helper.s
       m = type_helper.m
 
+      assert args["OP"] is not None
       args["OP"] = "v" + args["OP"]
 
       inst_info_vvm = InstInfo.get(args, decorator, InstType.VVVM)
@@ -71,6 +72,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
       s = type_helper.s
       m = type_helper.m
 
+      assert args["OP"] is not None
       args["OP"] = "v" + args["OP"]
 
       inst_info_vvm = InstInfo.get(args, None, InstType.VVVM)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_nop_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_nop_template.py
@@ -45,6 +45,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
         SEW=sew_list,
         LMUL=lmul_list,
         OP2=["v", "s"]):
+      assert args["OP"] is not None
       data_type = args["TYPE"]
       op = args["OP"]
       op2 = args["OP2"]

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_op_template.py
@@ -40,6 +40,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
         SEW=sew_list,
         LMUL=lmul_list,
         OP2=["v", "s"]):
+      assert args["OP"] is not None
       data_type = args["TYPE"]
       op = args["OP"]
       sew = args["SEW"]

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_wop_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_wop_template.py
@@ -33,6 +33,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
   for decorator in decorator_list:
     decorator.write_text_header(G)
     for args in prod(OP=op_list, TYPE=type_list, SEW=sew_list, LMUL=lmul_list):
+      assert args["OP"] is not None
       data_type = args["TYPE"]
       op = args["OP"]
 

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/cmp_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/cmp_template.py
@@ -38,6 +38,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
         SEW=sew_list,
         LMUL=lmul_list,
         OP2=["v", "s"]):
+      assert args["OP"] is not None
       data_type = args["TYPE"]
       op = args["OP"]
       op2 = args["OP2"]

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/cvt_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/cvt_op_template.py
@@ -53,6 +53,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
                      ["float", "f", "float", "f"]]
     for args in prod(
         OP=op_list, SEW=sew_list, TYPES=convert_set, LMUL=lmul_list):
+      assert args["TYPES"] is not None
       op = args["OP"]
 
       type_helper = TypeHelper(**args)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/load_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/load_template.py
@@ -37,6 +37,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
     decorator.write_text_header(G)
     for args in prod(
         OP=op_list, TYPE=type_list, SEW=sew_list, EEW=sew_list, LMUL=lmul_list):
+      assert args["OP"] is not None
       op = args["OP"]
       sew = args["SEW"]
       eew = args["EEW"]

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mac_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mac_template.py
@@ -34,6 +34,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
   for decorator in decorator_list:
     decorator.write_text_header(G)
     for args in prod(OP=op_list, TYPE=type_list, SEW=sew_list, LMUL=lmul_list):
+      assert args["TYPE"] is not None
       data_type = args["TYPE"]
       op = args["OP"]
 

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mask_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mask_template.py
@@ -33,6 +33,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
     decorator.write_text_header(G)
     # treat sew_list as MLEN
     for args in prod(OP=op_list, TYPE=type_list, MLEN=sew_list):
+      assert args["OP"] is not None
       op = args["OP"]
       if op not in ["cpop", "first"]:
         args["OP"] = "m" + args["OP"]
@@ -94,6 +95,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
             vl=type_helper.size_t)
 
     for args in prod(OP=op_list, TYPE=type_list, SEW=sew_list, LMUL=lmul_list):
+      assert args["OP"] is not None
       op = args["OP"]
       type_helper = TypeHelper(**args)
 

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/misc_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/misc_op_template.py
@@ -43,6 +43,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
     inst_type = None
     for args in prod(OP=op_list, TYPE=type_list, SEW=sew_list, LMUL=lmul_list):
       type_helper = TypeHelper(**args)
+      inst_type = InstType.UNKNOWN
       if args["OP"] not in ["vundefined"]:
         break
       if args["TYPE"] == "float" and args["SEW"] == 8:
@@ -73,6 +74,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
         LMUL=lmul_list,
         NF=nf_list):
       type_helper = TypeHelper(**args)
+      inst_type = InstType.UNKNOWN
       if args["OP"] not in ["vundefined"]:
         break
       if args["TYPE"] == "float" and args["SEW"] == 8:
@@ -94,6 +96,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
         SEW=sew_list,
         LMUL=lmul_list,
         DST_LMUL=lmul_list):
+      assert args["TYPE"] is not None
       op = args["OP"]
       src_lmul = args["LMUL"]
       dst_lmul = args["DST_LMUL"]
@@ -174,6 +177,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
         SEW=sew_list,
         LMUL=lmul_list,
         NF=nf_list):
+      assert args["NF"] is not None
       type_helper = TypeHelper(**args)
 
       # This intrinsic appears after v0.12

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/reduction_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/reduction_template.py
@@ -34,6 +34,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
   for decorator in decorator_list:
     decorator.write_text_header(G)
     for args in prod(OP=op_list, TYPE=type_list, SEW=sew_list, LMUL=lmul_list):
+      assert args["OP"] is not None
       data_type = args["TYPE"]
       op = args["OP"]
       sew = args["SEW"]

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/reint_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/reint_op_template.py
@@ -50,6 +50,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
     for args in prod(
         OP=op_list, SEW=sew_list, TYPES=convert_set, LMUL=lmul_list):
       sew = args["SEW"]
+      assert args["TYPES"] is not None
 
       type_helper = TypeHelper(**args)
       args["TYPES0"] = args["TYPES"][0]
@@ -128,6 +129,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
     convert_set = [["int", "i"], ["uint", "u"]]
     for args in prod(
         OP=op_list, SEW=sew_list, TYPES=convert_set, LMUL=lmul_list):
+      assert args["TYPES"] is not None
 
       type_helper = TypeHelper(**args)
       args["TYPES0"] = args["TYPES"][0]

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_load_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_load_template.py
@@ -47,6 +47,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
         EEW=sew_list,
         LMUL=lmul_list,
         NF=nf_list):
+      assert args["OP"] is not None
       op = args["OP"]
       nf = str(args["NF"])
       sew = args["SEW"]

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_store_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_store_template.py
@@ -47,6 +47,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
         EEW=sew_list,
         LMUL=lmul_list,
         NF=nf_list):
+      assert args["OP"] is not None
       op = args["OP"]
       nf = str(args["NF"])
       sew = args["SEW"]

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/store_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/store_template.py
@@ -36,6 +36,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
     decorator.write_text_header(G)
     for args in prod(
         OP=op_list, TYPE=type_list, SEW=sew_list, EEW=sew_list, LMUL=lmul_list):
+      assert args["OP"] is not None
       op = args["OP"]
       sew = args["SEW"]
       eew = args["EEW"]


### PR DESCRIPTION
- Fixed derived classes do not have their own member function implementation, causing a runtime error.
- All the linting/typecheck/yapf tests should be pass now
- ~~The `diff-autogen` test is failed due to some target feature missing in the  `bfloat16` API test, @4vtomat please help to check this~~ It seems that the test files are not updated.

```
diff ./rvv-intrinsic-generator/.tmp/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg8ei16.c  rvv-intrinsic-doc-dev/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg8ei16.c
2c2,3
< // RUN: %clang_cc1 -triple riscv64 -target-feature +v \
---
> // RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
> // RUN:   -target-feature +experimental-zvfh \
```

Signed-off-by: Jerry Zhang Jian <jerry.zhangjian@sifive.com>