### PR TITLE
Fix typo of vreinterpret in bfloat

### DIFF
--- a/auto-generated/bfloat16/llvm-api-tests/vcreate.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vcreate.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vfncvtbf16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vfncvtbf16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vfwcvtbf16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vfwcvtbf16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vfwmaccbf16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vfwmaccbf16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vget.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vget.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vle16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vle16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vle16ff.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vle16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlmul_ext_v.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlmul_ext_v.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlmul_trunc_v.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlmul_trunc_v.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vloxei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vloxei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vloxseg2ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vloxseg2ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vloxseg3ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vloxseg3ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vloxseg4ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vloxseg4ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vloxseg5ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vloxseg5ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vloxseg6ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vloxseg6ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vloxseg7ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vloxseg7ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vloxseg8ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vloxseg8ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlse16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlse16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg2e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg2e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg2e16ff.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg2e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg3e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg3e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg3e16ff.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg3e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg4e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg4e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg4e16ff.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg4e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg5e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg5e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg5e16ff.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg5e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg6e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg6e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg6e16ff.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg6e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg7e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg7e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg7e16ff.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg7e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg8e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg8e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg8e16ff.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg8e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlsseg2e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlsseg2e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlsseg3e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlsseg3e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlsseg4e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlsseg4e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlsseg5e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlsseg5e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlsseg6e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlsseg6e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlsseg7e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlsseg7e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vlsseg8e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlsseg8e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vluxei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vluxei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vluxseg2ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vluxseg2ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vluxseg3ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vluxseg3ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vluxseg4ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vluxseg4ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vluxseg5ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vluxseg5ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vluxseg6ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vluxseg6ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vluxseg7ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vluxseg7ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vluxseg8ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vluxseg8ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vreinterpret.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vreinterpret.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vse16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vse16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vset.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vset.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsoxei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsoxei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsoxseg2ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsoxseg2ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsoxseg3ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsoxseg3ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsoxseg4ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsoxseg4ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsoxseg5ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsoxseg5ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsoxseg6ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsoxseg6ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsoxseg7ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsoxseg7ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsoxseg8ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsoxseg8ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsse16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsse16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsseg2e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsseg2e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsseg3e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsseg3e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsseg4e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsseg4e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsseg5e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsseg5e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsseg6e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsseg6e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsseg7e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsseg7e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsseg8e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsseg8e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vssseg2e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vssseg2e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vssseg3e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vssseg3e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vssseg4e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vssseg4e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vssseg5e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vssseg5e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vssseg6e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vssseg6e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vssseg7e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vssseg7e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vssseg8e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vssseg8e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsuxei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsuxei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsuxseg2ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsuxseg2ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsuxseg3ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsuxseg3ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsuxseg4ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsuxseg4ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsuxseg5ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsuxseg5ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsuxseg6ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsuxseg6ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsuxseg7ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsuxseg7ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vsuxseg8ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsuxseg8ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-api-tests/vundefined.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vundefined.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vfncvtbf16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vfncvtbf16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vfwcvtbf16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vfwcvtbf16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vfwmaccbf16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vfwmaccbf16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vget.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vget.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vle16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vle16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vle16ff.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vle16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlmul_ext_v.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlmul_ext_v.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlmul_trunc_v.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlmul_trunc_v.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vloxei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vloxei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg2ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg2ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg3ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg3ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg4ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg4ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg5ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg5ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg6ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg6ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg7ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg7ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg8ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg8ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlse16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlse16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg2e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg2e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg2e16ff.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg2e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg3e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg3e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg3e16ff.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg3e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg4e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg4e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg4e16ff.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg4e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg5e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg5e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg5e16ff.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg5e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg6e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg6e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg6e16ff.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg6e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg7e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg7e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg7e16ff.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg7e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg8e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg8e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg8e16ff.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg8e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg2e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg2e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg3e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg3e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg4e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg4e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg5e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg5e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg6e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg6e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg7e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg7e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg8e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg8e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vluxei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vluxei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg2ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg2ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg3ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg3ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg4ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg4ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg5ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg5ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg6ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg6ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg7ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg7ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg8ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg8ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vreinterpret.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vreinterpret.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vse16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vse16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vset.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vset.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsoxei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsoxei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg2ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg2ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg3ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg3ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg4ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg4ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg5ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg5ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg6ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg6ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg7ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg7ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg8ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg8ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsse16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsse16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsseg2e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsseg2e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsseg3e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsseg3e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsseg4e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsseg4e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsseg5e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsseg5e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsseg6e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsseg6e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsseg7e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsseg7e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsseg8e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsseg8e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vssseg2e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vssseg2e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vssseg3e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vssseg3e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vssseg4e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vssseg4e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vssseg5e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vssseg5e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vssseg6e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vssseg6e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vssseg7e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vssseg7e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vssseg8e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vssseg8e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsuxei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsuxei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg2ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg2ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg3ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg3ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg4ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg4ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg5ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg5ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg6ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg6ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg7ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg7ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg8ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg8ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vfncvtbf16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vfncvtbf16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vfwcvtbf16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vfwcvtbf16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vfwmaccbf16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vfwmaccbf16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vle16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vle16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vle16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vle16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg2ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg2ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg3ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg3ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg4ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg4ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg5ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg5ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg6ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg6ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg7ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg7ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg8ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg8ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlse16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlse16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg2e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg2e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg2e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg2e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg3e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg3e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg3e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg3e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg4e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg4e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg4e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg4e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg5e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg5e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg5e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg5e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg6e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg6e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg6e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg6e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg7e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg7e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg7e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg7e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg8e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg8e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg8e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg8e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg2e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg2e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg3e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg3e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg4e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg4e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg5e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg5e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg6e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg6e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg7e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg7e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg8e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg8e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg2ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg2ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg3ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg3ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg4ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg4ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg5ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg5ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg6ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg6ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg7ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg7ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg8ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg8ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vfncvtbf16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vfncvtbf16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vfwcvtbf16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vfwcvtbf16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vfwmaccbf16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vfwmaccbf16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vle16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vle16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vle16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vle16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg2ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg2ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg3ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg3ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg4ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg4ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg5ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg5ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg6ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg6ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg7ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg7ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg8ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg8ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlse16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlse16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg2e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg2e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg2e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg2e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg3e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg3e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg3e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg3e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg4e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg4e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg4e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg4e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg5e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg5e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg5e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg5e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg6e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg6e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg6e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg6e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg7e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg7e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg7e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg7e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg8e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg8e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg8e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg8e16ff.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg2e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg2e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg3e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg3e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg4e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg4e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg5e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg5e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg6e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg6e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg7e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg7e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg8e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg8e16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg2ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg2ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg3ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg3ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg4ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg4ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg5ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg5ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg6ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg6ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg7ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg7ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg8ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg8ei16.c
@@ -1,6 +1,5 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zfh \
-// RUN:   -target-feature +experimental-zvfh \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
 // RUN:   -target-feature +experimental-zvfbfmin \
 // RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/bfloat16_inst.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/bfloat16_inst.py
@@ -130,7 +130,7 @@ def gen(g):
   g.start_group("BFloat16 Miscellaneous Vector Utility Intrinsics")
 
   g.function_group(reint_op_template, "Reinterpret Cast Conversion Intrinsics",
-                   "reinterpret-cast-conversion", ["reinterpret"], "bfloat16",
+                   "reinterpret-cast-conversion", ["vreinterpret"], "bfloat16",
                    SEWS, LMULS, decorators.has_no_masking)
 
   g.function_group(misc_op_template, "Vector LMUL Extension Intrinsics",


### PR DESCRIPTION
This PR also updates the tests that are missing in previous PR.

Fix https://github.com/riscv-non-isa/rvv-intrinsic-doc/issues/335