### PR TITLE
Change return type of vcpop and vfirst back to `unsigned long` and `long` respectively

### DIFF
--- a/auto-generated/api-testing/vcpop.c
+++ b/auto-generated/api-testing/vcpop.c
@@ -1,58 +1,58 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 
-unsigned int test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vcpop_m_b1(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vcpop_m_b2(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vcpop_m_b4(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vcpop_m_b8(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vcpop_m_b16(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vcpop_m_b32(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vcpop_m_b64(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vcpop_m_b1_m(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vcpop_m_b2_m(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vcpop_m_b4_m(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vcpop_m_b8_m(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vcpop_m_b16_m(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vcpop_m_b32_m(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vcpop_m_b64_m(vm, vs2, vl);
 }

--- a/auto-generated/api-testing/vfirst.c
+++ b/auto-generated/api-testing/vfirst.c
@@ -1,58 +1,58 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 
-int test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
+long test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vfirst_m_b1(vs2, vl);
 }
 
-int test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
+long test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vfirst_m_b2(vs2, vl);
 }
 
-int test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
+long test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vfirst_m_b4(vs2, vl);
 }
 
-int test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
+long test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vfirst_m_b8(vs2, vl);
 }
 
-int test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
+long test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vfirst_m_b16(vs2, vl);
 }
 
-int test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
+long test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vfirst_m_b32(vs2, vl);
 }
 
-int test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
+long test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vfirst_m_b64(vs2, vl);
 }
 
-int test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+long test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vfirst_m_b1_m(vm, vs2, vl);
 }
 
-int test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+long test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vfirst_m_b2_m(vm, vs2, vl);
 }
 
-int test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+long test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vfirst_m_b4_m(vm, vs2, vl);
 }
 
-int test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+long test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vfirst_m_b8_m(vm, vs2, vl);
 }
 
-int test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+long test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vfirst_m_b16_m(vm, vs2, vl);
 }
 
-int test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+long test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vfirst_m_b32_m(vm, vs2, vl);
 }
 
-int test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+long test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vfirst_m_b64_m(vm, vs2, vl);
 }

--- a/auto-generated/gnu-api-tests/vcpop.c
+++ b/auto-generated/gnu-api-tests/vcpop.c
@@ -3,59 +3,59 @@
 
 #include <riscv_vector.h>
 
-unsigned int test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vcpop_m_b1(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vcpop_m_b2(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vcpop_m_b4(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vcpop_m_b8(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vcpop_m_b16(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vcpop_m_b32(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vcpop_m_b64(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vcpop_m_b1_m(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vcpop_m_b2_m(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vcpop_m_b4_m(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vcpop_m_b8_m(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vcpop_m_b16_m(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vcpop_m_b32_m(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vcpop_m_b64_m(vm, vs2, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vcpop\.[ivxfswum.]+\s+} 14 } } */

--- a/auto-generated/gnu-api-tests/vfirst.c
+++ b/auto-generated/gnu-api-tests/vfirst.c
@@ -3,59 +3,59 @@
 
 #include <riscv_vector.h>
 
-int test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
+long test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vfirst_m_b1(vs2, vl);
 }
 
-int test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
+long test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vfirst_m_b2(vs2, vl);
 }
 
-int test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
+long test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vfirst_m_b4(vs2, vl);
 }
 
-int test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
+long test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vfirst_m_b8(vs2, vl);
 }
 
-int test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
+long test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vfirst_m_b16(vs2, vl);
 }
 
-int test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
+long test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vfirst_m_b32(vs2, vl);
 }
 
-int test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
+long test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vfirst_m_b64(vs2, vl);
 }
 
-int test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+long test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vfirst_m_b1_m(vm, vs2, vl);
 }
 
-int test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+long test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vfirst_m_b2_m(vm, vs2, vl);
 }
 
-int test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+long test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vfirst_m_b4_m(vm, vs2, vl);
 }
 
-int test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+long test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vfirst_m_b8_m(vm, vs2, vl);
 }
 
-int test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+long test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vfirst_m_b16_m(vm, vs2, vl);
 }
 
-int test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+long test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vfirst_m_b32_m(vm, vs2, vl);
 }
 
-int test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+long test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vfirst_m_b64_m(vm, vs2, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfirst\.[ivxfswum.]+\s+} 14 } } */

--- a/auto-generated/gnu-overloaded-tests/vcpop.c
+++ b/auto-generated/gnu-overloaded-tests/vcpop.c
@@ -3,59 +3,59 @@
 
 #include <riscv_vector.h>
 
-unsigned int test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vcpop\.[ivxfswum.]+\s+} 14 } } */

--- a/auto-generated/gnu-overloaded-tests/vfirst.c
+++ b/auto-generated/gnu-overloaded-tests/vfirst.c
@@ -3,59 +3,59 @@
 
 #include <riscv_vector.h>
 
-int test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
+long test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
+long test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
+long test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
+long test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
+long test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
+long test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
+long test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+long test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-int test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+long test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-int test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+long test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-int test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+long test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-int test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+long test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-int test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+long test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-int test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+long test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfirst\.[ivxfswum.]+\s+} 14 } } */

--- a/auto-generated/intrinsic_funcs.adoc
+++ b/auto-generated/intrinsic_funcs.adoc
@@ -48390,21 +48390,21 @@ vbool64_t __riscv_vmnot_m_b64(vbool64_t vs, size_t vl);
 
 [,c]
 ----
-unsigned int __riscv_vcpop_m_b1(vbool1_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b2(vbool2_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b4(vbool4_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b8(vbool8_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b16(vbool16_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b32(vbool32_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b64(vbool64_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b1(vbool1_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b2(vbool2_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b4(vbool4_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b8(vbool8_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b16(vbool16_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b32(vbool32_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b64(vbool64_t vs2, size_t vl);
 // masked functions
-unsigned int __riscv_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
 ----
 
 [[vfirst-find-first-set-mask-bit]]
@@ -48412,21 +48412,21 @@ unsigned int __riscv_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
 
 [,c]
 ----
-int __riscv_vfirst_m_b1(vbool1_t vs2, size_t vl);
-int __riscv_vfirst_m_b2(vbool2_t vs2, size_t vl);
-int __riscv_vfirst_m_b4(vbool4_t vs2, size_t vl);
-int __riscv_vfirst_m_b8(vbool8_t vs2, size_t vl);
-int __riscv_vfirst_m_b16(vbool16_t vs2, size_t vl);
-int __riscv_vfirst_m_b32(vbool32_t vs2, size_t vl);
-int __riscv_vfirst_m_b64(vbool64_t vs2, size_t vl);
+long __riscv_vfirst_m_b1(vbool1_t vs2, size_t vl);
+long __riscv_vfirst_m_b2(vbool2_t vs2, size_t vl);
+long __riscv_vfirst_m_b4(vbool4_t vs2, size_t vl);
+long __riscv_vfirst_m_b8(vbool8_t vs2, size_t vl);
+long __riscv_vfirst_m_b16(vbool16_t vs2, size_t vl);
+long __riscv_vfirst_m_b32(vbool32_t vs2, size_t vl);
+long __riscv_vfirst_m_b64(vbool64_t vs2, size_t vl);
 // masked functions
-int __riscv_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl);
-int __riscv_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl);
-int __riscv_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl);
-int __riscv_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl);
-int __riscv_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl);
-int __riscv_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl);
-int __riscv_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
+long __riscv_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl);
+long __riscv_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl);
+long __riscv_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl);
+long __riscv_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl);
+long __riscv_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl);
+long __riscv_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl);
+long __riscv_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
 ----
 
 [[vmsbfm-set-before-first-mask-bit]]

--- a/auto-generated/intrinsic_funcs/06_vector_mask_intrinsics.adoc
+++ b/auto-generated/intrinsic_funcs/06_vector_mask_intrinsics.adoc
@@ -97,21 +97,21 @@ vbool64_t __riscv_vmnot_m_b64(vbool64_t vs, size_t vl);
 
 [,c]
 ----
-unsigned int __riscv_vcpop_m_b1(vbool1_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b2(vbool2_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b4(vbool4_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b8(vbool8_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b16(vbool16_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b32(vbool32_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b64(vbool64_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b1(vbool1_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b2(vbool2_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b4(vbool4_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b8(vbool8_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b16(vbool16_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b32(vbool32_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b64(vbool64_t vs2, size_t vl);
 // masked functions
-unsigned int __riscv_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl);
-unsigned int __riscv_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl);
+unsigned long __riscv_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
 ----
 
 [[vfirst-find-first-set-mask-bit]]
@@ -119,21 +119,21 @@ unsigned int __riscv_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
 
 [,c]
 ----
-int __riscv_vfirst_m_b1(vbool1_t vs2, size_t vl);
-int __riscv_vfirst_m_b2(vbool2_t vs2, size_t vl);
-int __riscv_vfirst_m_b4(vbool4_t vs2, size_t vl);
-int __riscv_vfirst_m_b8(vbool8_t vs2, size_t vl);
-int __riscv_vfirst_m_b16(vbool16_t vs2, size_t vl);
-int __riscv_vfirst_m_b32(vbool32_t vs2, size_t vl);
-int __riscv_vfirst_m_b64(vbool64_t vs2, size_t vl);
+long __riscv_vfirst_m_b1(vbool1_t vs2, size_t vl);
+long __riscv_vfirst_m_b2(vbool2_t vs2, size_t vl);
+long __riscv_vfirst_m_b4(vbool4_t vs2, size_t vl);
+long __riscv_vfirst_m_b8(vbool8_t vs2, size_t vl);
+long __riscv_vfirst_m_b16(vbool16_t vs2, size_t vl);
+long __riscv_vfirst_m_b32(vbool32_t vs2, size_t vl);
+long __riscv_vfirst_m_b64(vbool64_t vs2, size_t vl);
 // masked functions
-int __riscv_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl);
-int __riscv_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl);
-int __riscv_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl);
-int __riscv_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl);
-int __riscv_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl);
-int __riscv_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl);
-int __riscv_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
+long __riscv_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl);
+long __riscv_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl);
+long __riscv_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl);
+long __riscv_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl);
+long __riscv_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl);
+long __riscv_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl);
+long __riscv_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl);
 ----
 
 [[vmsbfm-set-before-first-mask-bit]]

--- a/auto-generated/llvm-api-tests/vcpop.c
+++ b/auto-generated/llvm-api-tests/vcpop.c
@@ -6,58 +6,58 @@
 
 #include <riscv_vector.h>
 
-unsigned int test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vcpop_m_b1(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vcpop_m_b2(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vcpop_m_b4(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vcpop_m_b8(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vcpop_m_b16(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vcpop_m_b32(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vcpop_m_b64(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vcpop_m_b1_m(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vcpop_m_b2_m(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vcpop_m_b4_m(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vcpop_m_b8_m(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vcpop_m_b16_m(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vcpop_m_b32_m(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vcpop_m_b64_m(vm, vs2, vl);
 }

--- a/auto-generated/llvm-api-tests/vfirst.c
+++ b/auto-generated/llvm-api-tests/vfirst.c
@@ -5,58 +5,58 @@
 
 #include <riscv_vector.h>
 
-int test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
+long test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vfirst_m_b1(vs2, vl);
 }
 
-int test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
+long test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vfirst_m_b2(vs2, vl);
 }
 
-int test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
+long test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vfirst_m_b4(vs2, vl);
 }
 
-int test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
+long test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vfirst_m_b8(vs2, vl);
 }
 
-int test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
+long test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vfirst_m_b16(vs2, vl);
 }
 
-int test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
+long test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vfirst_m_b32(vs2, vl);
 }
 
-int test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
+long test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vfirst_m_b64(vs2, vl);
 }
 
-int test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+long test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vfirst_m_b1_m(vm, vs2, vl);
 }
 
-int test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+long test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vfirst_m_b2_m(vm, vs2, vl);
 }
 
-int test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+long test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vfirst_m_b4_m(vm, vs2, vl);
 }
 
-int test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+long test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vfirst_m_b8_m(vm, vs2, vl);
 }
 
-int test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+long test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vfirst_m_b16_m(vm, vs2, vl);
 }
 
-int test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+long test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vfirst_m_b32_m(vm, vs2, vl);
 }
 
-int test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+long test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vfirst_m_b64_m(vm, vs2, vl);
 }

--- a/auto-generated/llvm-overloaded-tests/vcpop.c
+++ b/auto-generated/llvm-overloaded-tests/vcpop.c
@@ -6,58 +6,58 @@
 
 #include <riscv_vector.h>
 
-unsigned int test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }

--- a/auto-generated/llvm-overloaded-tests/vfirst.c
+++ b/auto-generated/llvm-overloaded-tests/vfirst.c
@@ -5,58 +5,58 @@
 
 #include <riscv_vector.h>
 
-int test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
+long test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
+long test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
+long test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
+long test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
+long test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
+long test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
+long test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+long test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-int test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+long test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-int test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+long test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-int test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+long test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-int test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+long test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-int test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+long test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-int test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+long test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }

--- a/auto-generated/overloaded-api-testing/vcpop.c
+++ b/auto-generated/overloaded-api-testing/vcpop.c
@@ -1,58 +1,58 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 
-unsigned int test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vcpop(vs2, vl);
 }
 
-unsigned int test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }
 
-unsigned int test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+unsigned long test_vcpop_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vcpop(vm, vs2, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfirst.c
+++ b/auto-generated/overloaded-api-testing/vfirst.c
@@ -1,58 +1,58 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 
-int test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
+long test_vfirst_m_b1(vbool1_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
+long test_vfirst_m_b2(vbool2_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
+long test_vfirst_m_b4(vbool4_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
+long test_vfirst_m_b8(vbool8_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
+long test_vfirst_m_b16(vbool16_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
+long test_vfirst_m_b32(vbool32_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
+long test_vfirst_m_b64(vbool64_t vs2, size_t vl) {
   return __riscv_vfirst(vs2, vl);
 }
 
-int test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
+long test_vfirst_m_b1_m(vbool1_t vm, vbool1_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-int test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
+long test_vfirst_m_b2_m(vbool2_t vm, vbool2_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-int test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
+long test_vfirst_m_b4_m(vbool4_t vm, vbool4_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-int test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
+long test_vfirst_m_b8_m(vbool8_t vm, vbool8_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-int test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
+long test_vfirst_m_b16_m(vbool16_t vm, vbool16_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-int test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
+long test_vfirst_m_b32_m(vbool32_t vm, vbool32_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }
 
-int test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
+long test_vfirst_m_b64_m(vbool64_t vm, vbool64_t vs2, size_t vl) {
   return __riscv_vfirst(vm, vs2, vl);
 }

--- a/auto-generated/overloaded_intrinsic_funcs.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs.adoc
@@ -38718,21 +38718,21 @@ vbool64_t __riscv_vmnot(vbool64_t vs, size_t vl);
 
 [,c]
 ----
-unsigned int __riscv_vcpop(vbool1_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool2_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool4_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool8_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool16_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool32_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool64_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool1_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool2_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool4_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool8_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool16_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool32_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool64_t vs2, size_t vl);
 // masked functions
-unsigned int __riscv_vcpop(vbool1_t vm, vbool1_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool2_t vm, vbool2_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool4_t vm, vbool4_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool8_t vm, vbool8_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool16_t vm, vbool16_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool32_t vm, vbool32_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool64_t vm, vbool64_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool1_t vm, vbool1_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool2_t vm, vbool2_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool4_t vm, vbool4_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool8_t vm, vbool8_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool16_t vm, vbool16_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool32_t vm, vbool32_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool64_t vm, vbool64_t vs2, size_t vl);
 ----
 
 [[overloaded-vfirst-find-first-set-mask-bit]]
@@ -38740,21 +38740,21 @@ unsigned int __riscv_vcpop(vbool64_t vm, vbool64_t vs2, size_t vl);
 
 [,c]
 ----
-int __riscv_vfirst(vbool1_t vs2, size_t vl);
-int __riscv_vfirst(vbool2_t vs2, size_t vl);
-int __riscv_vfirst(vbool4_t vs2, size_t vl);
-int __riscv_vfirst(vbool8_t vs2, size_t vl);
-int __riscv_vfirst(vbool16_t vs2, size_t vl);
-int __riscv_vfirst(vbool32_t vs2, size_t vl);
-int __riscv_vfirst(vbool64_t vs2, size_t vl);
+long __riscv_vfirst(vbool1_t vs2, size_t vl);
+long __riscv_vfirst(vbool2_t vs2, size_t vl);
+long __riscv_vfirst(vbool4_t vs2, size_t vl);
+long __riscv_vfirst(vbool8_t vs2, size_t vl);
+long __riscv_vfirst(vbool16_t vs2, size_t vl);
+long __riscv_vfirst(vbool32_t vs2, size_t vl);
+long __riscv_vfirst(vbool64_t vs2, size_t vl);
 // masked functions
-int __riscv_vfirst(vbool1_t vm, vbool1_t vs2, size_t vl);
-int __riscv_vfirst(vbool2_t vm, vbool2_t vs2, size_t vl);
-int __riscv_vfirst(vbool4_t vm, vbool4_t vs2, size_t vl);
-int __riscv_vfirst(vbool8_t vm, vbool8_t vs2, size_t vl);
-int __riscv_vfirst(vbool16_t vm, vbool16_t vs2, size_t vl);
-int __riscv_vfirst(vbool32_t vm, vbool32_t vs2, size_t vl);
-int __riscv_vfirst(vbool64_t vm, vbool64_t vs2, size_t vl);
+long __riscv_vfirst(vbool1_t vm, vbool1_t vs2, size_t vl);
+long __riscv_vfirst(vbool2_t vm, vbool2_t vs2, size_t vl);
+long __riscv_vfirst(vbool4_t vm, vbool4_t vs2, size_t vl);
+long __riscv_vfirst(vbool8_t vm, vbool8_t vs2, size_t vl);
+long __riscv_vfirst(vbool16_t vm, vbool16_t vs2, size_t vl);
+long __riscv_vfirst(vbool32_t vm, vbool32_t vs2, size_t vl);
+long __riscv_vfirst(vbool64_t vm, vbool64_t vs2, size_t vl);
 ----
 
 [[overloaded-vmsbfm-set-before-first-mask-bit]]

--- a/auto-generated/overloaded_intrinsic_funcs/06_vector_mask_intrinsics.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs/06_vector_mask_intrinsics.adoc
@@ -83,21 +83,21 @@ vbool64_t __riscv_vmnot(vbool64_t vs, size_t vl);
 
 [,c]
 ----
-unsigned int __riscv_vcpop(vbool1_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool2_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool4_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool8_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool16_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool32_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool64_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool1_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool2_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool4_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool8_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool16_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool32_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool64_t vs2, size_t vl);
 // masked functions
-unsigned int __riscv_vcpop(vbool1_t vm, vbool1_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool2_t vm, vbool2_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool4_t vm, vbool4_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool8_t vm, vbool8_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool16_t vm, vbool16_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool32_t vm, vbool32_t vs2, size_t vl);
-unsigned int __riscv_vcpop(vbool64_t vm, vbool64_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool1_t vm, vbool1_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool2_t vm, vbool2_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool4_t vm, vbool4_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool8_t vm, vbool8_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool16_t vm, vbool16_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool32_t vm, vbool32_t vs2, size_t vl);
+unsigned long __riscv_vcpop(vbool64_t vm, vbool64_t vs2, size_t vl);
 ----
 
 [[overloaded-vfirst-find-first-set-mask-bit]]
@@ -105,21 +105,21 @@ unsigned int __riscv_vcpop(vbool64_t vm, vbool64_t vs2, size_t vl);
 
 [,c]
 ----
-int __riscv_vfirst(vbool1_t vs2, size_t vl);
-int __riscv_vfirst(vbool2_t vs2, size_t vl);
-int __riscv_vfirst(vbool4_t vs2, size_t vl);
-int __riscv_vfirst(vbool8_t vs2, size_t vl);
-int __riscv_vfirst(vbool16_t vs2, size_t vl);
-int __riscv_vfirst(vbool32_t vs2, size_t vl);
-int __riscv_vfirst(vbool64_t vs2, size_t vl);
+long __riscv_vfirst(vbool1_t vs2, size_t vl);
+long __riscv_vfirst(vbool2_t vs2, size_t vl);
+long __riscv_vfirst(vbool4_t vs2, size_t vl);
+long __riscv_vfirst(vbool8_t vs2, size_t vl);
+long __riscv_vfirst(vbool16_t vs2, size_t vl);
+long __riscv_vfirst(vbool32_t vs2, size_t vl);
+long __riscv_vfirst(vbool64_t vs2, size_t vl);
 // masked functions
-int __riscv_vfirst(vbool1_t vm, vbool1_t vs2, size_t vl);
-int __riscv_vfirst(vbool2_t vm, vbool2_t vs2, size_t vl);
-int __riscv_vfirst(vbool4_t vm, vbool4_t vs2, size_t vl);
-int __riscv_vfirst(vbool8_t vm, vbool8_t vs2, size_t vl);
-int __riscv_vfirst(vbool16_t vm, vbool16_t vs2, size_t vl);
-int __riscv_vfirst(vbool32_t vm, vbool32_t vs2, size_t vl);
-int __riscv_vfirst(vbool64_t vm, vbool64_t vs2, size_t vl);
+long __riscv_vfirst(vbool1_t vm, vbool1_t vs2, size_t vl);
+long __riscv_vfirst(vbool2_t vm, vbool2_t vs2, size_t vl);
+long __riscv_vfirst(vbool4_t vm, vbool4_t vs2, size_t vl);
+long __riscv_vfirst(vbool8_t vm, vbool8_t vs2, size_t vl);
+long __riscv_vfirst(vbool16_t vm, vbool16_t vs2, size_t vl);
+long __riscv_vfirst(vbool32_t vm, vbool32_t vs2, size_t vl);
+long __riscv_vfirst(vbool64_t vm, vbool64_t vs2, size_t vl);
 ----
 
 [[overloaded-vmsbfm-set-before-first-mask-bit]]

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mask_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mask_template.py
@@ -72,7 +72,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
         G.func(
             inst_info_m,
             name="{OP}_m_b{MLEN}".format_map(args) + decorator.func_suffix,
-            return_type=type_helper.uint,
+            return_type=type_helper.ulong,
             **decorator.mask_args(type_helper.m),
             vs2=type_helper.m,
             vl=type_helper.size_t)
@@ -80,7 +80,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
         G.func(
             inst_info_m,
             name="{OP}_m_b{MLEN}".format_map(args) + decorator.func_suffix,
-            return_type=type_helper.int,
+            return_type=type_helper.long,
             **decorator.mask_args(type_helper.m),
             vs2=type_helper.m,
             vl=type_helper.size_t)


### PR DESCRIPTION
Neither gcc or LLVM implemented the original change from what I can tell.

Fixes #342 