### PR TITLE
Address latest comment from ARC review

### DIFF
--- a/auto-generated/intrinsic_funcs.adoc
+++ b/auto-generated/intrinsic_funcs.adoc
@@ -35506,6 +35506,7 @@ vuint64m8_t __riscv_vmv_v_x_u64m8(uint64_t rs1, size_t vl);
 
 [[vector-single-width-saturating-add-and-subtract]]
 ==== Vector Single-Width Saturating Add and Subtract Intrinsics
+After executing an intrinsic in this section, the `vxsat` CSR assumes an UNSPECIFIED value.
 
 [,c]
 ----
@@ -36904,6 +36905,7 @@ vuint64m8_t __riscv_vasubu_vx_u64m8_m(vbool8_t vm, vuint64m8_t vs2,
 
 [[vector-single-width-fractional-multiply-with-rounding-and-saturation]]
 ==== Vector Single-Width Fractional Multiply with Rounding and SaturationIntrinsics
+After executing an intrinsic in this section, the `vxsat` CSR assumes an UNSPECIFIED value.
 
 [,c]
 ----
@@ -37502,6 +37504,7 @@ vuint64m8_t __riscv_vssrl_vx_u64m8_m(vbool8_t vm, vuint64m8_t vs2, size_t rs1,
 
 [[vector-narrowing-fixed-point-clip]]
 ==== Vector Narrowing Fixed-Point Clip Intrinsics
+After executing an intrinsic in this section, the `vxsat` CSR assumes an UNSPECIFIED value.
 
 [,c]
 ----

--- a/auto-generated/intrinsic_funcs/03_vector_fixed-point_arithmetic_intrinsics.adoc
+++ b/auto-generated/intrinsic_funcs/03_vector_fixed-point_arithmetic_intrinsics.adoc
@@ -3,6 +3,7 @@
 
 [[vector-single-width-saturating-add-and-subtract]]
 ==== Vector Single-Width Saturating Add and Subtract Intrinsics
+After executing an intrinsic in this section, the `vxsat` CSR assumes an UNSPECIFIED value.
 
 [,c]
 ----
@@ -1401,6 +1402,7 @@ vuint64m8_t __riscv_vasubu_vx_u64m8_m(vbool8_t vm, vuint64m8_t vs2,
 
 [[vector-single-width-fractional-multiply-with-rounding-and-saturation]]
 ==== Vector Single-Width Fractional Multiply with Rounding and SaturationIntrinsics
+After executing an intrinsic in this section, the `vxsat` CSR assumes an UNSPECIFIED value.
 
 [,c]
 ----
@@ -1999,6 +2001,7 @@ vuint64m8_t __riscv_vssrl_vx_u64m8_m(vbool8_t vm, vuint64m8_t vs2, size_t rs1,
 
 [[vector-narrowing-fixed-point-clip]]
 ==== Vector Narrowing Fixed-Point Clip Intrinsics
+After executing an intrinsic in this section, the `vxsat` CSR assumes an UNSPECIFIED value.
 
 [,c]
 ----

--- a/auto-generated/overloaded_intrinsic_funcs.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs.adoc
@@ -28761,6 +28761,7 @@ vuint64m8_t __riscv_vmv_v(vuint64m8_t vs1, size_t vl);
 
 [[overloaded-vector-single-width-saturating-add-and-subtract]]
 ==== Vector Single-Width Saturating Add and Subtract Intrinsics
+After executing an intrinsic in this section, the `vxsat` CSR assumes an UNSPECIFIED value.
 
 [,c]
 ----
@@ -29955,6 +29956,7 @@ vuint64m8_t __riscv_vasubu(vbool8_t vm, vuint64m8_t vs2, uint64_t rs1,
 
 [[overloaded-vector-single-width-fractional-multiply-with-rounding-and-saturation]]
 ==== Vector Single-Width Fractional Multiply with Rounding and SaturationIntrinsics
+After executing an intrinsic in this section, the `vxsat` CSR assumes an UNSPECIFIED value.
 
 [,c]
 ----
@@ -30499,6 +30501,7 @@ vuint64m8_t __riscv_vssrl(vbool8_t vm, vuint64m8_t vs2, size_t rs1,
 
 [[overloaded-vector-narrowing-fixed-point-clip]]
 ==== Vector Narrowing Fixed-Point Clip Intrinsics
+After executing an intrinsic in this section, the `vxsat` CSR assumes an UNSPECIFIED value.
 
 [,c]
 ----

--- a/auto-generated/overloaded_intrinsic_funcs/03_vector_fixed-point_arithmetic_intrinsics.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs/03_vector_fixed-point_arithmetic_intrinsics.adoc
@@ -3,6 +3,7 @@
 
 [[overloaded-vector-single-width-saturating-add-and-subtract]]
 ==== Vector Single-Width Saturating Add and Subtract Intrinsics
+After executing an intrinsic in this section, the `vxsat` CSR assumes an UNSPECIFIED value.
 
 [,c]
 ----
@@ -1197,6 +1198,7 @@ vuint64m8_t __riscv_vasubu(vbool8_t vm, vuint64m8_t vs2, uint64_t rs1,
 
 [[overloaded-vector-single-width-fractional-multiply-with-rounding-and-saturation]]
 ==== Vector Single-Width Fractional Multiply with Rounding and SaturationIntrinsics
+After executing an intrinsic in this section, the `vxsat` CSR assumes an UNSPECIFIED value.
 
 [,c]
 ----
@@ -1741,6 +1743,7 @@ vuint64m8_t __riscv_vssrl(vbool8_t vm, vuint64m8_t vs2, size_t rs1,
 
 [[overloaded-vector-narrowing-fixed-point-clip]]
 ==== Vector Narrowing Fixed-Point Clip Intrinsics
+After executing an intrinsic in this section, the `vxsat` CSR assumes an UNSPECIFIED value.
 
 [,c]
 ----

--- a/auto-generated/policy_funcs/intrinsic_funcs/03_vector_fixed-point_arithmetic_intrinsics.adoc
+++ b/auto-generated/policy_funcs/intrinsic_funcs/03_vector_fixed-point_arithmetic_intrinsics.adoc
@@ -3,6 +3,7 @@
 
 [[policy-variant-vector-single-width-saturating-add-and-subtract]]
 ==== Vector Single-Width Saturating Add and Subtract Intrinsics
+After executing an intrinsic in this section, the `vxsat` CSR assumes an UNSPECIFIED value.
 
 [,c]
 ----
@@ -3753,6 +3754,7 @@ vuint64m8_t __riscv_vasubu_vx_u64m8_mu(vbool8_t vm, vuint64m8_t vd,
 
 [[policy-variant-vector-single-width-fractional-multiply-with-rounding-and-saturation]]
 ==== Vector Single-Width Fractional Multiply with Rounding and SaturationIntrinsics
+After executing an intrinsic in this section, the `vxsat` CSR assumes an UNSPECIFIED value.
 
 [,c]
 ----
@@ -5244,6 +5246,7 @@ vuint64m8_t __riscv_vssrl_vx_u64m8_mu(vbool8_t vm, vuint64m8_t vd,
 
 [[policy-variant-vector-narrowing-fixed-point-clip]]
 ==== Vector Narrowing Fixed-Point Clip Intrinsics
+After executing an intrinsic in this section, the `vxsat` CSR assumes an UNSPECIFIED value.
 
 [,c]
 ----

--- a/auto-generated/policy_funcs/overloaded_intrinsic_funcs/03_vector_fixed-point_arithmetic_intrinsics.adoc
+++ b/auto-generated/policy_funcs/overloaded_intrinsic_funcs/03_vector_fixed-point_arithmetic_intrinsics.adoc
@@ -3,6 +3,7 @@
 
 [[policy-variant-overloadedvector-single-width-saturating-add-and-subtract]]
 ==== Vector Single-Width Saturating Add and Subtract Intrinsics
+After executing an intrinsic in this section, the `vxsat` CSR assumes an UNSPECIFIED value.
 
 [,c]
 ----
@@ -2843,6 +2844,7 @@ vuint64m8_t __riscv_vasubu_mu(vbool8_t vm, vuint64m8_t vd, vuint64m8_t vs2,
 
 [[policy-variant-overloadedvector-single-width-fractional-multiply-with-rounding-and-saturation]]
 ==== Vector Single-Width Fractional Multiply with Rounding and SaturationIntrinsics
+After executing an intrinsic in this section, the `vxsat` CSR assumes an UNSPECIFIED value.
 
 [,c]
 ----
@@ -3919,6 +3921,7 @@ vuint64m8_t __riscv_vssrl_mu(vbool8_t vm, vuint64m8_t vd, vuint64m8_t vs2,
 
 [[policy-variant-overloadedvector-narrowing-fixed-point-clip]]
 ==== Vector Narrowing Fixed-Point Clip Intrinsics
+After executing an intrinsic in this section, the `vxsat` CSR assumes an UNSPECIFIED value.
 
 [,c]
 ----

--- a/doc/rvv-intrinsic-spec.adoc
+++ b/doc/rvv-intrinsic-spec.adoc
@@ -109,9 +109,9 @@ NOTE: The RISC-V psABI cite:[riscv-cc-vector] states that `vxrm` is not preserve
 
 [NOTE]
 ====
-This version of the specification of does not cover the control of the vector fixed-point saturation flag (`vxsat`). Support for this feature is planned for a later version of the specification in a way that is compatible with existing fixed-point intrinsics. No mechanism to set or retrieve the value of `vxsat` is specified either.
+This specification does not provide support for manipulating the `vxsat` CSR.  Since vxsat is not needed by a large majority of fixed-point code, we believe this specification is broadly useful as-is.  Nevertheless, we expect that a future extension will define an additional set of fixed-point intrinsics that update `vxsat` in a specified manner, along with intrinsics to explicitly read and write `vxsat`.  These new intrinsics would be interoperable with the intrinsics in this specification.
 
-The value of the `vxsat` after a fixed-point intrinsic is UNSPECIFIED. This includes the order in which the flag `vxsat` is updated in a program that executes a sequence of fixed-point intrinsics.
+The value of the `vxsat` after a fixed-point intrinsic is UNSPECIFIED.
 ====
 
 [[control-of-frm]]

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -55,8 +55,16 @@ class Generator(ABC):
   def func(self, inst_info, name, return_type, **kwargs):
     return NotImplemented
 
-  def function_group(self, template, title, link, op_list, type_list, sew_list,
-                     lmul_list, decorator_list, description=None):
+  def function_group(self,
+                     template,
+                     title,
+                     link,
+                     op_list,
+                     type_list,
+                     sew_list,
+                     lmul_list,
+                     decorator_list,
+                     description=None):
     # pylint: disable=unused-argument
     # NOTE: 'title' and 'link' are only used in DocGenerator and
     # OverloadedDocGenerator. Probably need some decoupling here.
@@ -342,8 +350,16 @@ class DocGenerator(Generator):
     self.write(s)
     return s
 
-  def function_group(self, template, title, link, op_list, type_list, sew_list,
-                     lmul_list, decorator_list, description=None):
+  def function_group(self,
+                     template,
+                     title,
+                     link,
+                     op_list,
+                     type_list,
+                     sew_list,
+                     lmul_list,
+                     decorator_list,
+                     description=None):
     self.write_title(title, link)
     if self.has_tail_policy and len(decorator_list) == 0:
       s = "Intrinsics here don't have a policy variant.\n"
@@ -353,8 +369,16 @@ class DocGenerator(Generator):
       self.write("Intrinsics here don't have an overloaded variant.\n")
       return
 
-    super().function_group(template, title, link, op_list, type_list, sew_list,
-                           lmul_list, decorator_list, description=description)
+    super().function_group(
+        template,
+        title,
+        link,
+        op_list,
+        type_list,
+        sew_list,
+        lmul_list,
+        decorator_list,
+        description=description)
 
   def func(self, inst_info, name, return_type, **kwargs):
     name = Generator.func_name(name)
@@ -389,7 +413,8 @@ class DocGenerator(Generator):
 
   def emit_function_group_description(self, description):
     if description:
-      self.write(f"{description}\n");
+      self.write(f"{description}\n")
+
 
 class OverloadedDocGenerator(DocGenerator):
   """
@@ -403,14 +428,30 @@ class OverloadedDocGenerator(DocGenerator):
     else:
       self.fd.write("\n[[overloaded-" + link + "]]\n==== " + text + "\n")
 
-  def function_group(self, template, title, link, op_list, type_list, sew_list,
-                     lmul_list, decorator_list, description=None):
+  def function_group(self,
+                     template,
+                     title,
+                     link,
+                     op_list,
+                     type_list,
+                     sew_list,
+                     lmul_list,
+                     decorator_list,
+                     description=None):
     self.do_not_have_overloaded_variant = True
     for op in op_list:
       if Generator.is_support_overloaded(op):
         self.do_not_have_overloaded_variant = False
-    super().function_group(template, title, link, op_list, type_list, sew_list,
-                           lmul_list, decorator_list, description=description)
+    super().function_group(
+        template,
+        title,
+        link,
+        op_list,
+        type_list,
+        sew_list,
+        lmul_list,
+        decorator_list,
+        description=description)
 
   def func(self, inst_info, name, return_type, **kwargs):
     func_name = Generator.func_name(name)
@@ -664,8 +705,16 @@ class APITestGenerator(Generator):
           self.fd.write(dg_pattern_str)
         self.fd.close()
 
-  def function_group(self, template, title, link, op_list, type_list, sew_list,
-                     lmul_list, decorator_list, description=None):
+  def function_group(self,
+                     template,
+                     title,
+                     link,
+                     op_list,
+                     type_list,
+                     sew_list,
+                     lmul_list,
+                     decorator_list,
+                     description=None):
     self.test_file_names = op_list
     template.render(
         G=self,
@@ -673,7 +722,8 @@ class APITestGenerator(Generator):
         type_list=type_list,
         sew_list=sew_list,
         lmul_list=lmul_list,
-        decorator_list=decorator_list, description=description)
+        decorator_list=decorator_list,
+        description=description)
 
 
 class Grouper(Generator):
@@ -719,8 +769,16 @@ class Grouper(Generator):
   def query_group_desc(self, func_name):
     return self.func_group[func_name]
 
-  def function_group(self, template, title, link, op_list, type_list, sew_list,
-                     lmul_list, decorator_list, description=None):
+  def function_group(self,
+                     template,
+                     title,
+                     link,
+                     op_list,
+                     type_list,
+                     sew_list,
+                     lmul_list,
+                     decorator_list,
+                     description=None):
     self.op_list = op_list
     self.groups[self.current_group].append(title)
     self.current_sub_group = title
@@ -869,12 +927,28 @@ _14, _15, _16, _17, _18, _19, _20, NAME, ...) NAME
   def inst_group_epilogue(self):
     return ""
 
-  def function_group(self, template, title, link, op_list, type_list, sew_list,
-                     lmul_list, decorator_list, description=None):
+  def function_group(self,
+                     template,
+                     title,
+                     link,
+                     op_list,
+                     type_list,
+                     sew_list,
+                     lmul_list,
+                     decorator_list,
+                     description=None):
     if self.has_tail_policy and len(decorator_list) == 0:
       return
-    super().function_group(template, title, link, op_list, type_list, sew_list,
-                           lmul_list, decorator_list, description=description)
+    super().function_group(
+        template,
+        title,
+        link,
+        op_list,
+        type_list,
+        sew_list,
+        lmul_list,
+        decorator_list,
+        description=description)
 
   @staticmethod
   def is_policy_func(inst_info):

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/inst.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/inst.py
@@ -236,12 +236,15 @@ def gen(g):
 
   ####################################################################
   g.start_group("Vector Fixed-Point Arithmetic Intrinsics")
+  vxsat_description = "After executing an intrinsic in this section, " + \
+                      "the `vxsat` CSR assumes an UNSPECIFIED value.";
 
   g.function_group(
       binary_op_template,
       "Vector Single-Width Saturating Add and Subtract Intrinsics",
       "vector-single-width-saturating-add-and-subtract", ["sadd", "ssub"],
-      ITYPES, SEWS, LMULS, decorators.has_masking_maskedoff_policy)
+      ITYPES, SEWS, LMULS, decorators.has_masking_maskedoff_policy,
+      description=vxsat_description)
 
   g.function_group(binary_op_template,
                    "Vector Single-Width Averaging Add and Subtract Intrinsics",
@@ -255,7 +258,8 @@ def gen(g):
       "Intrinsics",
       "vector-single-width-fractional-multiply-with-rounding-and-" +
       "saturation", ["smul"], ["int"], SEWS, LMULS,
-      decorators.has_masking_maskedoff_policy_vxrm)
+      decorators.has_masking_maskedoff_policy_vxrm,
+      description=vxsat_description)
 
   g.function_group(binary_op_template,
                    "Vector Single-Width Scaling Shift Intrinsics",
@@ -266,7 +270,8 @@ def gen(g):
   g.function_group(binary_nop_template,
                    "Vector Narrowing Fixed-Point Clip Intrinsics",
                    "vector-narrowing-fixed-point-clip", ["nclip"], ITYPES,
-                   WSEWS, WLMULS, decorators.has_masking_maskedoff_policy_vxrm)
+                   WSEWS, WLMULS, decorators.has_masking_maskedoff_policy_vxrm,
+                   description=vxsat_description)
 
   ####################################################################
   g.start_group("Vector Floating-Point Intrinsics")

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/inst.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/inst.py
@@ -237,13 +237,16 @@ def gen(g):
   ####################################################################
   g.start_group("Vector Fixed-Point Arithmetic Intrinsics")
   vxsat_description = "After executing an intrinsic in this section, " + \
-                      "the `vxsat` CSR assumes an UNSPECIFIED value.";
+                      "the `vxsat` CSR assumes an UNSPECIFIED value."
 
   g.function_group(
       binary_op_template,
       "Vector Single-Width Saturating Add and Subtract Intrinsics",
       "vector-single-width-saturating-add-and-subtract", ["sadd", "ssub"],
-      ITYPES, SEWS, LMULS, decorators.has_masking_maskedoff_policy,
+      ITYPES,
+      SEWS,
+      LMULS,
+      decorators.has_masking_maskedoff_policy,
       description=vxsat_description)
 
   g.function_group(binary_op_template,
@@ -257,7 +260,9 @@ def gen(g):
       "Vector Single-Width Fractional Multiply with Rounding and Saturation" +
       "Intrinsics",
       "vector-single-width-fractional-multiply-with-rounding-and-" +
-      "saturation", ["smul"], ["int"], SEWS, LMULS,
+      "saturation", ["smul"], ["int"],
+      SEWS,
+      LMULS,
       decorators.has_masking_maskedoff_policy_vxrm,
       description=vxsat_description)
 
@@ -267,11 +272,15 @@ def gen(g):
                    ITYPES, SEWS, LMULS,
                    decorators.has_masking_maskedoff_policy_vxrm)
 
-  g.function_group(binary_nop_template,
-                   "Vector Narrowing Fixed-Point Clip Intrinsics",
-                   "vector-narrowing-fixed-point-clip", ["nclip"], ITYPES,
-                   WSEWS, WLMULS, decorators.has_masking_maskedoff_policy_vxrm,
-                   description=vxsat_description)
+  g.function_group(
+      binary_nop_template,
+      "Vector Narrowing Fixed-Point Clip Intrinsics",
+      "vector-narrowing-fixed-point-clip", ["nclip"],
+      ITYPES,
+      WSEWS,
+      WLMULS,
+      decorators.has_masking_maskedoff_policy_vxrm,
+      description=vxsat_description)
 
   ####################################################################
   g.start_group("Vector Floating-Point Intrinsics")

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_intcarry_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_intcarry_template.py
@@ -26,7 +26,8 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_intcarry_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_intcarry_template.py
@@ -26,9 +26,10 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   for decorator in decorator_list:
     decorator.write_text_header(G)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_nop_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_nop_template.py
@@ -32,9 +32,10 @@ def must_int_type(**kargs):
 
 
 # narrowing op template
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   for decorator in decorator_list:
     decorator.write_text_header(G)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_nop_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_nop_template.py
@@ -32,7 +32,8 @@ def must_int_type(**kargs):
 
 
 # narrowing op template
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_op_template.py
@@ -28,9 +28,10 @@ from enums import InstType
 from enums import ExtraAttr
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   for decorator in decorator_list:
     decorator.write_text_header(G)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_op_template.py
@@ -28,7 +28,8 @@ from enums import InstType
 from enums import ExtraAttr
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_wop_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_wop_template.py
@@ -26,7 +26,8 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_wop_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_wop_template.py
@@ -26,9 +26,10 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   for decorator in decorator_list:
     decorator.write_text_header(G)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/cmp_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/cmp_template.py
@@ -26,7 +26,8 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/cmp_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/cmp_template.py
@@ -26,9 +26,10 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   for decorator in decorator_list:
     decorator.write_text_header(G)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/cvt_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/cvt_op_template.py
@@ -28,7 +28,8 @@ from enums import ExtraAttr
 from constants import ITYPES
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name, unused-argument
   # FIXME: Renaming 'G' to 'g' all in once later.
   # FIXME: Argument 'type_list' is unused but required for interface

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/cvt_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/cvt_op_template.py
@@ -28,11 +28,12 @@ from enums import ExtraAttr
 from constants import ITYPES
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name, unused-argument
   # FIXME: Renaming 'G' to 'g' all in once later.
   # FIXME: Argument 'type_list' is unused but required for interface
   # consistency. We can prune it in the future.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   for decorator in decorator_list:
     decorator.write_text_header(G)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/get_set_diff_lmul_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/get_set_diff_lmul_op_template.py
@@ -50,7 +50,8 @@ def vset_constraint(**kargs):
          and int(kargs["LMUL"]) > int(kargs["SRC_LMUL"])
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/get_set_diff_lmul_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/get_set_diff_lmul_op_template.py
@@ -50,9 +50,10 @@ def vset_constraint(**kargs):
          and int(kargs["LMUL"]) > int(kargs["SRC_LMUL"])
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   for decorator in decorator_list:
     decorator.write_text_header(G)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/load_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/load_template.py
@@ -29,7 +29,8 @@ from enums import MemType
 from enums import ExtraAttr
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/load_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/load_template.py
@@ -29,9 +29,10 @@ from enums import MemType
 from enums import ExtraAttr
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   for decorator in decorator_list:
     decorator.write_text_header(G)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mac_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mac_template.py
@@ -27,7 +27,8 @@ from enums import InstType
 from enums import ExtraAttr
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mac_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mac_template.py
@@ -27,9 +27,10 @@ from enums import InstType
 from enums import ExtraAttr
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   for decorator in decorator_list:
     decorator.write_text_header(G)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mask_load_store_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mask_load_store_template.py
@@ -26,11 +26,12 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name, unused-argument
   # FIXME: Renaming 'G' to 'g' all in once later.
   # FIXME: Argument 'lmul_list' is unused but required for interface
   # consistency. We can prune it in the future.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   for decorator in decorator_list:
     decorator.write_text_header(G)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mask_load_store_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mask_load_store_template.py
@@ -26,7 +26,8 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name, unused-argument
   # FIXME: Renaming 'G' to 'g' all in once later.
   # FIXME: Argument 'lmul_list' is unused but required for interface

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mask_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mask_template.py
@@ -25,9 +25,10 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   for decorator in decorator_list:
     decorator.write_text_header(G)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mask_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mask_template.py
@@ -25,7 +25,8 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/misc_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/misc_op_template.py
@@ -30,7 +30,8 @@ from enums import InstType
 from generator import CompatibleHeaderGenerator
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/misc_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/misc_op_template.py
@@ -30,9 +30,10 @@ from enums import InstType
 from generator import CompatibleHeaderGenerator
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   # vundefine for non-tuple
   for decorator in decorator_list:

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/permute_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/permute_template.py
@@ -26,7 +26,8 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/permute_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/permute_template.py
@@ -26,9 +26,10 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   for decorator in decorator_list:
     decorator.write_text_header(G)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/reduction_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/reduction_template.py
@@ -27,7 +27,8 @@ from enums import InstType
 from enums import ExtraAttr
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/reduction_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/reduction_template.py
@@ -27,9 +27,10 @@ from enums import InstType
 from enums import ExtraAttr
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   for decorator in decorator_list:
     decorator.write_text_header(G)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/reint_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/reint_op_template.py
@@ -27,9 +27,10 @@ from enums import InstType
 from generator import CompatibleHeaderGenerator
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name, unused-argument
   # FIXME: Renaming 'G' to 'g' all in once later.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   for decorator in decorator_list:
     decorator.write_text_header(G)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/reint_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/reint_op_template.py
@@ -27,7 +27,8 @@ from enums import InstType
 from generator import CompatibleHeaderGenerator
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name, unused-argument
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_load_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_load_template.py
@@ -32,9 +32,10 @@ from enums import MemType
 from generator import CompatibleHeaderGenerator
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   nf_list = range(2, 9)
   for decorator in decorator_list:

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_load_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_load_template.py
@@ -32,7 +32,8 @@ from enums import MemType
 from generator import CompatibleHeaderGenerator
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_store_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_store_template.py
@@ -32,9 +32,10 @@ from enums import MemType
 from generator import CompatibleHeaderGenerator
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   nf_list = range(2, 9)
   for decorator in decorator_list:

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_store_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_store_template.py
@@ -32,7 +32,8 @@ from enums import MemType
 from generator import CompatibleHeaderGenerator
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/setvl_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/setvl_template.py
@@ -25,7 +25,8 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name, unused-argument
   # FIXME: Renaming 'G' to 'g' all in once later.
   # FIXME: Argument 'type_list', 'decorator_list' is unused but required for

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/setvl_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/setvl_template.py
@@ -25,11 +25,12 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name, unused-argument
   # FIXME: Renaming 'G' to 'g' all in once later.
   # FIXME: Argument 'type_list', 'decorator_list' is unused but required for
   # interface consistency. We can prune it in the future.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   for args in prod(OP=op_list, SEW=sew_list, LMUL=lmul_list):
     type_helper = TypeHelper(**args)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/store_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/store_template.py
@@ -28,9 +28,10 @@ from enums import InstType
 from enums import MemType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   for decorator in decorator_list:
     decorator.write_text_header(G)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/store_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/store_template.py
@@ -28,7 +28,8 @@ from enums import InstType
 from enums import MemType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/unary_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/unary_op_template.py
@@ -28,7 +28,8 @@ from enums import ExtraAttr
 import copy
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/unary_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/unary_op_template.py
@@ -28,9 +28,10 @@ from enums import ExtraAttr
 import copy
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
   for decorator in decorator_list:
     decorator.write_text_header(G)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/vector_crypto_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/vector_crypto_template.py
@@ -74,9 +74,10 @@ def has_rs1_input(name):
   return name in has_rs1_input_inst_set
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
+  G.emit_function_group_description(description)
   G.inst_group_prologue()
 
   for decorator in decorator_list:

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/vector_crypto_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/vector_crypto_template.py
@@ -74,7 +74,8 @@ def has_rs1_input(name):
   return name in has_rs1_input_inst_set
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list, description):
+def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
+           description):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)


### PR DESCRIPTION
Review comment:


```
- "The value of the vxsat after a fixed-point intrinsic is UNSPECIFIED": Agreed, but this statement needs to be normative, and we need to be clear about exactly which intrinsics this applies to.  It seems to me that the intrinsics in Section A.4.1, A.4.3, and A.4.5 is the relevant set.  So, we ask that you add the following normative sentence to the top of each of those three sections: "After executing an intrinsic in this section, the vxsat CSR assumes an UNSPECIFIED value."

- "This includes the order in which the flag vxsat is updated in a program that executes a sequence of fixed-point intrinsics": This sentence should be deleted.

- Please add a non-normative note about future plans for vxsat.  As a starting point, you could replace the existing non-normative text with the following non-normative text: "This specification does not provide support for manipulating the vxsat CSR.  Since vxsat is not needed by a large majority of fixed-point code, we believe this specification is broadly useful as-is.  Nevertheless, we expect that a future extension will define an additional set of fixed-point intrinsics that update vxsat in a specified manner, along with intrinsics to explicitly read and write vxsat.  These new intrinsics would be interoperable with the intrinsics in this specification."
```

---

NOTE: This will backport to v1.0.x once merged into main branch.