### PR TITLE
Support vmv.v.v and vmerge.vvm for bf16 with `zvfbfmin`

### DIFF
--- a/auto-generated/bfloat16/api-testing/vfmv.c
+++ b/auto-generated/bfloat16/api-testing/vfmv.c
@@ -1,0 +1,26 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vbfloat16mf4_t test_vfmv_v_f_bf16mf4(__bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16mf4(rs1, vl);
+}
+
+vbfloat16mf2_t test_vfmv_v_f_bf16mf2(__bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16mf2(rs1, vl);
+}
+
+vbfloat16m1_t test_vfmv_v_f_bf16m1(__bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16m1(rs1, vl);
+}
+
+vbfloat16m2_t test_vfmv_v_f_bf16m2(__bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16m2(rs1, vl);
+}
+
+vbfloat16m4_t test_vfmv_v_f_bf16m4(__bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16m4(rs1, vl);
+}
+
+vbfloat16m8_t test_vfmv_v_f_bf16m8(__bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16m8(rs1, vl);
+}

--- a/auto-generated/bfloat16/api-testing/vmerge.c
+++ b/auto-generated/bfloat16/api-testing/vmerge.c
@@ -1,0 +1,32 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vbfloat16mf4_t test_vmerge_vvm_bf16mf4(vbfloat16mf4_t vs2, vbfloat16mf4_t vs1,
+                                       vbool64_t v0, size_t vl) {
+  return __riscv_vmerge_vvm_bf16mf4(vs2, vs1, v0, vl);
+}
+
+vbfloat16mf2_t test_vmerge_vvm_bf16mf2(vbfloat16mf2_t vs2, vbfloat16mf2_t vs1,
+                                       vbool32_t v0, size_t vl) {
+  return __riscv_vmerge_vvm_bf16mf2(vs2, vs1, v0, vl);
+}
+
+vbfloat16m1_t test_vmerge_vvm_bf16m1(vbfloat16m1_t vs2, vbfloat16m1_t vs1,
+                                     vbool16_t v0, size_t vl) {
+  return __riscv_vmerge_vvm_bf16m1(vs2, vs1, v0, vl);
+}
+
+vbfloat16m2_t test_vmerge_vvm_bf16m2(vbfloat16m2_t vs2, vbfloat16m2_t vs1,
+                                     vbool8_t v0, size_t vl) {
+  return __riscv_vmerge_vvm_bf16m2(vs2, vs1, v0, vl);
+}
+
+vbfloat16m4_t test_vmerge_vvm_bf16m4(vbfloat16m4_t vs2, vbfloat16m4_t vs1,
+                                     vbool4_t v0, size_t vl) {
+  return __riscv_vmerge_vvm_bf16m4(vs2, vs1, v0, vl);
+}
+
+vbfloat16m8_t test_vmerge_vvm_bf16m8(vbfloat16m8_t vs2, vbfloat16m8_t vs1,
+                                     vbool2_t v0, size_t vl) {
+  return __riscv_vmerge_vvm_bf16m8(vs2, vs1, v0, vl);
+}

--- a/auto-generated/bfloat16/api-testing/vmv.c
+++ b/auto-generated/bfloat16/api-testing/vmv.c
@@ -1,0 +1,26 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vbfloat16mf4_t test_vmv_v_v_bf16mf4(vbfloat16mf4_t vs1, size_t vl) {
+  return __riscv_vmv_v_v_bf16mf4(vs1, vl);
+}
+
+vbfloat16mf2_t test_vmv_v_v_bf16mf2(vbfloat16mf2_t vs1, size_t vl) {
+  return __riscv_vmv_v_v_bf16mf2(vs1, vl);
+}
+
+vbfloat16m1_t test_vmv_v_v_bf16m1(vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vmv_v_v_bf16m1(vs1, vl);
+}
+
+vbfloat16m2_t test_vmv_v_v_bf16m2(vbfloat16m2_t vs1, size_t vl) {
+  return __riscv_vmv_v_v_bf16m2(vs1, vl);
+}
+
+vbfloat16m4_t test_vmv_v_v_bf16m4(vbfloat16m4_t vs1, size_t vl) {
+  return __riscv_vmv_v_v_bf16m4(vs1, vl);
+}
+
+vbfloat16m8_t test_vmv_v_v_bf16m8(vbfloat16m8_t vs1, size_t vl) {
+  return __riscv_vmv_v_v_bf16m8(vs1, vl);
+}

--- a/auto-generated/bfloat16/intrinsic_funcs.adoc
+++ b/auto-generated/bfloat16/intrinsic_funcs.adoc
@@ -1543,6 +1543,46 @@ vfloat32m8_t __riscv_vfwmaccbf16_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
                                                unsigned int frm, size_t vl);
 ----
 
+[[vector-bf16-move]]
+==== Vector BFloat16 Move Intrinsics
+
+[,c]
+----
+vbfloat16mf4_t __riscv_vmv_v_v_bf16mf4(vbfloat16mf4_t vs1, size_t vl);
+vbfloat16mf4_t __riscv_vfmv_v_f_bf16mf4(__bf16 rs1, size_t vl);
+vbfloat16mf2_t __riscv_vmv_v_v_bf16mf2(vbfloat16mf2_t vs1, size_t vl);
+vbfloat16mf2_t __riscv_vfmv_v_f_bf16mf2(__bf16 rs1, size_t vl);
+vbfloat16m1_t __riscv_vmv_v_v_bf16m1(vbfloat16m1_t vs1, size_t vl);
+vbfloat16m1_t __riscv_vfmv_v_f_bf16m1(__bf16 rs1, size_t vl);
+vbfloat16m2_t __riscv_vmv_v_v_bf16m2(vbfloat16m2_t vs1, size_t vl);
+vbfloat16m2_t __riscv_vfmv_v_f_bf16m2(__bf16 rs1, size_t vl);
+vbfloat16m4_t __riscv_vmv_v_v_bf16m4(vbfloat16m4_t vs1, size_t vl);
+vbfloat16m4_t __riscv_vfmv_v_f_bf16m4(__bf16 rs1, size_t vl);
+vbfloat16m8_t __riscv_vmv_v_v_bf16m8(vbfloat16m8_t vs1, size_t vl);
+vbfloat16m8_t __riscv_vfmv_v_f_bf16m8(__bf16 rs1, size_t vl);
+----
+
+[[vector-bf16-merge]]
+==== Vector BFloat16 Merge Intrinsics
+
+[,c]
+----
+vbfloat16mf4_t __riscv_vmerge_vvm_bf16mf4(vbfloat16mf4_t vs2,
+                                          vbfloat16mf4_t vs1, vbool64_t v0,
+                                          size_t vl);
+vbfloat16mf2_t __riscv_vmerge_vvm_bf16mf2(vbfloat16mf2_t vs2,
+                                          vbfloat16mf2_t vs1, vbool32_t v0,
+                                          size_t vl);
+vbfloat16m1_t __riscv_vmerge_vvm_bf16m1(vbfloat16m1_t vs2, vbfloat16m1_t vs1,
+                                        vbool16_t v0, size_t vl);
+vbfloat16m2_t __riscv_vmerge_vvm_bf16m2(vbfloat16m2_t vs2, vbfloat16m2_t vs1,
+                                        vbool8_t v0, size_t vl);
+vbfloat16m4_t __riscv_vmerge_vvm_bf16m4(vbfloat16m4_t vs2, vbfloat16m4_t vs1,
+                                        vbool4_t v0, size_t vl);
+vbfloat16m8_t __riscv_vmerge_vvm_bf16m8(vbfloat16m8_t vs2, vbfloat16m8_t vs1,
+                                        vbool2_t v0, size_t vl);
+----
+
 === BFloat16 Miscellaneous Vector Utility Intrinsics
 
 [[reinterpret-cast-conversion]]

--- a/auto-generated/bfloat16/intrinsic_funcs/03_bfloat16_arithmetic_intrinsics.adoc
+++ b/auto-generated/bfloat16/intrinsic_funcs/03_bfloat16_arithmetic_intrinsics.adoc
@@ -127,3 +127,43 @@ vfloat32m8_t __riscv_vfwmaccbf16_vf_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
                                                __bf16 vs1, vbfloat16m4_t vs2,
                                                unsigned int frm, size_t vl);
 ----
+
+[[vector-bf16-move]]
+==== Vector BFloat16 Move Intrinsics
+
+[,c]
+----
+vbfloat16mf4_t __riscv_vmv_v_v_bf16mf4(vbfloat16mf4_t vs1, size_t vl);
+vbfloat16mf4_t __riscv_vfmv_v_f_bf16mf4(__bf16 rs1, size_t vl);
+vbfloat16mf2_t __riscv_vmv_v_v_bf16mf2(vbfloat16mf2_t vs1, size_t vl);
+vbfloat16mf2_t __riscv_vfmv_v_f_bf16mf2(__bf16 rs1, size_t vl);
+vbfloat16m1_t __riscv_vmv_v_v_bf16m1(vbfloat16m1_t vs1, size_t vl);
+vbfloat16m1_t __riscv_vfmv_v_f_bf16m1(__bf16 rs1, size_t vl);
+vbfloat16m2_t __riscv_vmv_v_v_bf16m2(vbfloat16m2_t vs1, size_t vl);
+vbfloat16m2_t __riscv_vfmv_v_f_bf16m2(__bf16 rs1, size_t vl);
+vbfloat16m4_t __riscv_vmv_v_v_bf16m4(vbfloat16m4_t vs1, size_t vl);
+vbfloat16m4_t __riscv_vfmv_v_f_bf16m4(__bf16 rs1, size_t vl);
+vbfloat16m8_t __riscv_vmv_v_v_bf16m8(vbfloat16m8_t vs1, size_t vl);
+vbfloat16m8_t __riscv_vfmv_v_f_bf16m8(__bf16 rs1, size_t vl);
+----
+
+[[vector-bf16-merge]]
+==== Vector BFloat16 Merge Intrinsics
+
+[,c]
+----
+vbfloat16mf4_t __riscv_vmerge_vvm_bf16mf4(vbfloat16mf4_t vs2,
+                                          vbfloat16mf4_t vs1, vbool64_t v0,
+                                          size_t vl);
+vbfloat16mf2_t __riscv_vmerge_vvm_bf16mf2(vbfloat16mf2_t vs2,
+                                          vbfloat16mf2_t vs1, vbool32_t v0,
+                                          size_t vl);
+vbfloat16m1_t __riscv_vmerge_vvm_bf16m1(vbfloat16m1_t vs2, vbfloat16m1_t vs1,
+                                        vbool16_t v0, size_t vl);
+vbfloat16m2_t __riscv_vmerge_vvm_bf16m2(vbfloat16m2_t vs2, vbfloat16m2_t vs1,
+                                        vbool8_t v0, size_t vl);
+vbfloat16m4_t __riscv_vmerge_vvm_bf16m4(vbfloat16m4_t vs2, vbfloat16m4_t vs1,
+                                        vbool4_t v0, size_t vl);
+vbfloat16m8_t __riscv_vmerge_vvm_bf16m8(vbfloat16m8_t vs2, vbfloat16m8_t vs1,
+                                        vbool2_t v0, size_t vl);
+----

--- a/auto-generated/bfloat16/llvm-api-tests/vfmv.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vfmv.c
@@ -1,0 +1,32 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN:   -target-feature +experimental-zvfbfmin \
+// RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vbfloat16mf4_t test_vfmv_v_f_bf16mf4(__bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16mf4(rs1, vl);
+}
+
+vbfloat16mf2_t test_vfmv_v_f_bf16mf2(__bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16mf2(rs1, vl);
+}
+
+vbfloat16m1_t test_vfmv_v_f_bf16m1(__bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16m1(rs1, vl);
+}
+
+vbfloat16m2_t test_vfmv_v_f_bf16m2(__bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16m2(rs1, vl);
+}
+
+vbfloat16m4_t test_vfmv_v_f_bf16m4(__bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16m4(rs1, vl);
+}
+
+vbfloat16m8_t test_vfmv_v_f_bf16m8(__bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16m8(rs1, vl);
+}

--- a/auto-generated/bfloat16/llvm-api-tests/vmerge.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vmerge.c
@@ -1,0 +1,38 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN:   -target-feature +experimental-zvfbfmin \
+// RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vbfloat16mf4_t test_vmerge_vvm_bf16mf4(vbfloat16mf4_t vs2, vbfloat16mf4_t vs1,
+                                       vbool64_t v0, size_t vl) {
+  return __riscv_vmerge_vvm_bf16mf4(vs2, vs1, v0, vl);
+}
+
+vbfloat16mf2_t test_vmerge_vvm_bf16mf2(vbfloat16mf2_t vs2, vbfloat16mf2_t vs1,
+                                       vbool32_t v0, size_t vl) {
+  return __riscv_vmerge_vvm_bf16mf2(vs2, vs1, v0, vl);
+}
+
+vbfloat16m1_t test_vmerge_vvm_bf16m1(vbfloat16m1_t vs2, vbfloat16m1_t vs1,
+                                     vbool16_t v0, size_t vl) {
+  return __riscv_vmerge_vvm_bf16m1(vs2, vs1, v0, vl);
+}
+
+vbfloat16m2_t test_vmerge_vvm_bf16m2(vbfloat16m2_t vs2, vbfloat16m2_t vs1,
+                                     vbool8_t v0, size_t vl) {
+  return __riscv_vmerge_vvm_bf16m2(vs2, vs1, v0, vl);
+}
+
+vbfloat16m4_t test_vmerge_vvm_bf16m4(vbfloat16m4_t vs2, vbfloat16m4_t vs1,
+                                     vbool4_t v0, size_t vl) {
+  return __riscv_vmerge_vvm_bf16m4(vs2, vs1, v0, vl);
+}
+
+vbfloat16m8_t test_vmerge_vvm_bf16m8(vbfloat16m8_t vs2, vbfloat16m8_t vs1,
+                                     vbool2_t v0, size_t vl) {
+  return __riscv_vmerge_vvm_bf16m8(vs2, vs1, v0, vl);
+}

--- a/auto-generated/bfloat16/llvm-api-tests/vmv.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vmv.c
@@ -1,0 +1,32 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN:   -target-feature +experimental-zvfbfmin \
+// RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vbfloat16mf4_t test_vmv_v_v_bf16mf4(vbfloat16mf4_t vs1, size_t vl) {
+  return __riscv_vmv_v_v_bf16mf4(vs1, vl);
+}
+
+vbfloat16mf2_t test_vmv_v_v_bf16mf2(vbfloat16mf2_t vs1, size_t vl) {
+  return __riscv_vmv_v_v_bf16mf2(vs1, vl);
+}
+
+vbfloat16m1_t test_vmv_v_v_bf16m1(vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vmv_v_v_bf16m1(vs1, vl);
+}
+
+vbfloat16m2_t test_vmv_v_v_bf16m2(vbfloat16m2_t vs1, size_t vl) {
+  return __riscv_vmv_v_v_bf16m2(vs1, vl);
+}
+
+vbfloat16m4_t test_vmv_v_v_bf16m4(vbfloat16m4_t vs1, size_t vl) {
+  return __riscv_vmv_v_v_bf16m4(vs1, vl);
+}
+
+vbfloat16m8_t test_vmv_v_v_bf16m8(vbfloat16m8_t vs1, size_t vl) {
+  return __riscv_vmv_v_v_bf16m8(vs1, vl);
+}

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vmerge.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vmerge.c
@@ -1,0 +1,38 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN:   -target-feature +experimental-zvfbfmin \
+// RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vbfloat16mf4_t test_vmerge_vvm_bf16mf4(vbfloat16mf4_t vs2, vbfloat16mf4_t vs1,
+                                       vbool64_t v0, size_t vl) {
+  return __riscv_vmerge(vs2, vs1, v0, vl);
+}
+
+vbfloat16mf2_t test_vmerge_vvm_bf16mf2(vbfloat16mf2_t vs2, vbfloat16mf2_t vs1,
+                                       vbool32_t v0, size_t vl) {
+  return __riscv_vmerge(vs2, vs1, v0, vl);
+}
+
+vbfloat16m1_t test_vmerge_vvm_bf16m1(vbfloat16m1_t vs2, vbfloat16m1_t vs1,
+                                     vbool16_t v0, size_t vl) {
+  return __riscv_vmerge(vs2, vs1, v0, vl);
+}
+
+vbfloat16m2_t test_vmerge_vvm_bf16m2(vbfloat16m2_t vs2, vbfloat16m2_t vs1,
+                                     vbool8_t v0, size_t vl) {
+  return __riscv_vmerge(vs2, vs1, v0, vl);
+}
+
+vbfloat16m4_t test_vmerge_vvm_bf16m4(vbfloat16m4_t vs2, vbfloat16m4_t vs1,
+                                     vbool4_t v0, size_t vl) {
+  return __riscv_vmerge(vs2, vs1, v0, vl);
+}
+
+vbfloat16m8_t test_vmerge_vvm_bf16m8(vbfloat16m8_t vs2, vbfloat16m8_t vs1,
+                                     vbool2_t v0, size_t vl) {
+  return __riscv_vmerge(vs2, vs1, v0, vl);
+}

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vmv.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vmv.c
@@ -1,0 +1,32 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN:   -target-feature +experimental-zvfbfmin \
+// RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vbfloat16mf4_t test_vmv_v_v_bf16mf4(vbfloat16mf4_t vs1, size_t vl) {
+  return __riscv_vmv_v(vs1, vl);
+}
+
+vbfloat16mf2_t test_vmv_v_v_bf16mf2(vbfloat16mf2_t vs1, size_t vl) {
+  return __riscv_vmv_v(vs1, vl);
+}
+
+vbfloat16m1_t test_vmv_v_v_bf16m1(vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vmv_v(vs1, vl);
+}
+
+vbfloat16m2_t test_vmv_v_v_bf16m2(vbfloat16m2_t vs1, size_t vl) {
+  return __riscv_vmv_v(vs1, vl);
+}
+
+vbfloat16m4_t test_vmv_v_v_bf16m4(vbfloat16m4_t vs1, size_t vl) {
+  return __riscv_vmv_v(vs1, vl);
+}
+
+vbfloat16m8_t test_vmv_v_v_bf16m8(vbfloat16m8_t vs1, size_t vl) {
+  return __riscv_vmv_v(vs1, vl);
+}

--- a/auto-generated/bfloat16/overloaded-api-testing/vmerge.c
+++ b/auto-generated/bfloat16/overloaded-api-testing/vmerge.c
@@ -1,0 +1,32 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vbfloat16mf4_t test_vmerge_vvm_bf16mf4(vbfloat16mf4_t vs2, vbfloat16mf4_t vs1,
+                                       vbool64_t v0, size_t vl) {
+  return __riscv_vmerge(vs2, vs1, v0, vl);
+}
+
+vbfloat16mf2_t test_vmerge_vvm_bf16mf2(vbfloat16mf2_t vs2, vbfloat16mf2_t vs1,
+                                       vbool32_t v0, size_t vl) {
+  return __riscv_vmerge(vs2, vs1, v0, vl);
+}
+
+vbfloat16m1_t test_vmerge_vvm_bf16m1(vbfloat16m1_t vs2, vbfloat16m1_t vs1,
+                                     vbool16_t v0, size_t vl) {
+  return __riscv_vmerge(vs2, vs1, v0, vl);
+}
+
+vbfloat16m2_t test_vmerge_vvm_bf16m2(vbfloat16m2_t vs2, vbfloat16m2_t vs1,
+                                     vbool8_t v0, size_t vl) {
+  return __riscv_vmerge(vs2, vs1, v0, vl);
+}
+
+vbfloat16m4_t test_vmerge_vvm_bf16m4(vbfloat16m4_t vs2, vbfloat16m4_t vs1,
+                                     vbool4_t v0, size_t vl) {
+  return __riscv_vmerge(vs2, vs1, v0, vl);
+}
+
+vbfloat16m8_t test_vmerge_vvm_bf16m8(vbfloat16m8_t vs2, vbfloat16m8_t vs1,
+                                     vbool2_t v0, size_t vl) {
+  return __riscv_vmerge(vs2, vs1, v0, vl);
+}

--- a/auto-generated/bfloat16/overloaded-api-testing/vmv.c
+++ b/auto-generated/bfloat16/overloaded-api-testing/vmv.c
@@ -1,0 +1,26 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vbfloat16mf4_t test_vmv_v_v_bf16mf4(vbfloat16mf4_t vs1, size_t vl) {
+  return __riscv_vmv_v(vs1, vl);
+}
+
+vbfloat16mf2_t test_vmv_v_v_bf16mf2(vbfloat16mf2_t vs1, size_t vl) {
+  return __riscv_vmv_v(vs1, vl);
+}
+
+vbfloat16m1_t test_vmv_v_v_bf16m1(vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vmv_v(vs1, vl);
+}
+
+vbfloat16m2_t test_vmv_v_v_bf16m2(vbfloat16m2_t vs1, size_t vl) {
+  return __riscv_vmv_v(vs1, vl);
+}
+
+vbfloat16m4_t test_vmv_v_v_bf16m4(vbfloat16m4_t vs1, size_t vl) {
+  return __riscv_vmv_v(vs1, vl);
+}
+
+vbfloat16m8_t test_vmv_v_v_bf16m8(vbfloat16m8_t vs1, size_t vl) {
+  return __riscv_vmv_v(vs1, vl);
+}

--- a/auto-generated/bfloat16/overloaded_intrinsic_funcs.adoc
+++ b/auto-generated/bfloat16/overloaded_intrinsic_funcs.adoc
@@ -1123,6 +1123,38 @@ vfloat32m8_t __riscv_vfwmaccbf16(vbool4_t vm, vfloat32m8_t vd, __bf16 vs1,
                                  size_t vl);
 ----
 
+[[overloaded-vector-bf16-move]]
+==== Vector BFloat16 Move Intrinsics
+
+[,c]
+----
+vbfloat16mf4_t __riscv_vmv_v(vbfloat16mf4_t vs1, size_t vl);
+vbfloat16mf2_t __riscv_vmv_v(vbfloat16mf2_t vs1, size_t vl);
+vbfloat16m1_t __riscv_vmv_v(vbfloat16m1_t vs1, size_t vl);
+vbfloat16m2_t __riscv_vmv_v(vbfloat16m2_t vs1, size_t vl);
+vbfloat16m4_t __riscv_vmv_v(vbfloat16m4_t vs1, size_t vl);
+vbfloat16m8_t __riscv_vmv_v(vbfloat16m8_t vs1, size_t vl);
+----
+
+[[overloaded-vector-bf16-merge]]
+==== Vector BFloat16 Merge Intrinsics
+
+[,c]
+----
+vbfloat16mf4_t __riscv_vmerge(vbfloat16mf4_t vs2, vbfloat16mf4_t vs1,
+                              vbool64_t v0, size_t vl);
+vbfloat16mf2_t __riscv_vmerge(vbfloat16mf2_t vs2, vbfloat16mf2_t vs1,
+                              vbool32_t v0, size_t vl);
+vbfloat16m1_t __riscv_vmerge(vbfloat16m1_t vs2, vbfloat16m1_t vs1, vbool16_t v0,
+                             size_t vl);
+vbfloat16m2_t __riscv_vmerge(vbfloat16m2_t vs2, vbfloat16m2_t vs1, vbool8_t v0,
+                             size_t vl);
+vbfloat16m4_t __riscv_vmerge(vbfloat16m4_t vs2, vbfloat16m4_t vs1, vbool4_t v0,
+                             size_t vl);
+vbfloat16m8_t __riscv_vmerge(vbfloat16m8_t vs2, vbfloat16m8_t vs1, vbool2_t v0,
+                             size_t vl);
+----
+
 === BFloat16 Miscellaneous Vector Utility Intrinsics
 
 [[overloaded-reinterpret-cast-conversion]]

--- a/auto-generated/bfloat16/overloaded_intrinsic_funcs/03_bfloat16_arithmetic_intrinsics.adoc
+++ b/auto-generated/bfloat16/overloaded_intrinsic_funcs/03_bfloat16_arithmetic_intrinsics.adoc
@@ -111,3 +111,35 @@ vfloat32m8_t __riscv_vfwmaccbf16(vbool4_t vm, vfloat32m8_t vd, __bf16 vs1,
                                  vbfloat16m4_t vs2, unsigned int frm,
                                  size_t vl);
 ----
+
+[[overloaded-vector-bf16-move]]
+==== Vector BFloat16 Move Intrinsics
+
+[,c]
+----
+vbfloat16mf4_t __riscv_vmv_v(vbfloat16mf4_t vs1, size_t vl);
+vbfloat16mf2_t __riscv_vmv_v(vbfloat16mf2_t vs1, size_t vl);
+vbfloat16m1_t __riscv_vmv_v(vbfloat16m1_t vs1, size_t vl);
+vbfloat16m2_t __riscv_vmv_v(vbfloat16m2_t vs1, size_t vl);
+vbfloat16m4_t __riscv_vmv_v(vbfloat16m4_t vs1, size_t vl);
+vbfloat16m8_t __riscv_vmv_v(vbfloat16m8_t vs1, size_t vl);
+----
+
+[[overloaded-vector-bf16-merge]]
+==== Vector BFloat16 Merge Intrinsics
+
+[,c]
+----
+vbfloat16mf4_t __riscv_vmerge(vbfloat16mf4_t vs2, vbfloat16mf4_t vs1,
+                              vbool64_t v0, size_t vl);
+vbfloat16mf2_t __riscv_vmerge(vbfloat16mf2_t vs2, vbfloat16mf2_t vs1,
+                              vbool32_t v0, size_t vl);
+vbfloat16m1_t __riscv_vmerge(vbfloat16m1_t vs2, vbfloat16m1_t vs1, vbool16_t v0,
+                             size_t vl);
+vbfloat16m2_t __riscv_vmerge(vbfloat16m2_t vs2, vbfloat16m2_t vs1, vbool8_t v0,
+                             size_t vl);
+vbfloat16m4_t __riscv_vmerge(vbfloat16m4_t vs2, vbfloat16m4_t vs1, vbool4_t v0,
+                             size_t vl);
+vbfloat16m8_t __riscv_vmerge(vbfloat16m8_t vs2, vbfloat16m8_t vs1, vbool2_t v0,
+                             size_t vl);
+----

--- a/auto-generated/bfloat16/policy_funcs/api-testing/vfmv.c
+++ b/auto-generated/bfloat16/policy_funcs/api-testing/vfmv.c
@@ -1,0 +1,28 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vbfloat16mf4_t test_vfmv_v_f_bf16mf4_tu(vbfloat16mf4_t vd, __bf16 rs1,
+                                        size_t vl) {
+  return __riscv_vfmv_v_f_bf16mf4_tu(vd, rs1, vl);
+}
+
+vbfloat16mf2_t test_vfmv_v_f_bf16mf2_tu(vbfloat16mf2_t vd, __bf16 rs1,
+                                        size_t vl) {
+  return __riscv_vfmv_v_f_bf16mf2_tu(vd, rs1, vl);
+}
+
+vbfloat16m1_t test_vfmv_v_f_bf16m1_tu(vbfloat16m1_t vd, __bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16m1_tu(vd, rs1, vl);
+}
+
+vbfloat16m2_t test_vfmv_v_f_bf16m2_tu(vbfloat16m2_t vd, __bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16m2_tu(vd, rs1, vl);
+}
+
+vbfloat16m4_t test_vfmv_v_f_bf16m4_tu(vbfloat16m4_t vd, __bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16m4_tu(vd, rs1, vl);
+}
+
+vbfloat16m8_t test_vfmv_v_f_bf16m8_tu(vbfloat16m8_t vd, __bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16m8_tu(vd, rs1, vl);
+}

--- a/auto-generated/bfloat16/policy_funcs/api-testing/vmerge.c
+++ b/auto-generated/bfloat16/policy_funcs/api-testing/vmerge.c
@@ -1,0 +1,38 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vbfloat16mf4_t test_vmerge_vvm_bf16mf4_tu(vbfloat16mf4_t vd, vbfloat16mf4_t vs2,
+                                          vbfloat16mf4_t vs1, vbool64_t v0,
+                                          size_t vl) {
+  return __riscv_vmerge_vvm_bf16mf4_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16mf2_t test_vmerge_vvm_bf16mf2_tu(vbfloat16mf2_t vd, vbfloat16mf2_t vs2,
+                                          vbfloat16mf2_t vs1, vbool32_t v0,
+                                          size_t vl) {
+  return __riscv_vmerge_vvm_bf16mf2_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16m1_t test_vmerge_vvm_bf16m1_tu(vbfloat16m1_t vd, vbfloat16m1_t vs2,
+                                        vbfloat16m1_t vs1, vbool16_t v0,
+                                        size_t vl) {
+  return __riscv_vmerge_vvm_bf16m1_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16m2_t test_vmerge_vvm_bf16m2_tu(vbfloat16m2_t vd, vbfloat16m2_t vs2,
+                                        vbfloat16m2_t vs1, vbool8_t v0,
+                                        size_t vl) {
+  return __riscv_vmerge_vvm_bf16m2_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16m4_t test_vmerge_vvm_bf16m4_tu(vbfloat16m4_t vd, vbfloat16m4_t vs2,
+                                        vbfloat16m4_t vs1, vbool4_t v0,
+                                        size_t vl) {
+  return __riscv_vmerge_vvm_bf16m4_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16m8_t test_vmerge_vvm_bf16m8_tu(vbfloat16m8_t vd, vbfloat16m8_t vs2,
+                                        vbfloat16m8_t vs1, vbool2_t v0,
+                                        size_t vl) {
+  return __riscv_vmerge_vvm_bf16m8_tu(vd, vs2, vs1, v0, vl);
+}

--- a/auto-generated/bfloat16/policy_funcs/api-testing/vmv.c
+++ b/auto-generated/bfloat16/policy_funcs/api-testing/vmv.c
@@ -1,0 +1,32 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vbfloat16mf4_t test_vmv_v_v_bf16mf4_tu(vbfloat16mf4_t vd, vbfloat16mf4_t vs1,
+                                       size_t vl) {
+  return __riscv_vmv_v_v_bf16mf4_tu(vd, vs1, vl);
+}
+
+vbfloat16mf2_t test_vmv_v_v_bf16mf2_tu(vbfloat16mf2_t vd, vbfloat16mf2_t vs1,
+                                       size_t vl) {
+  return __riscv_vmv_v_v_bf16mf2_tu(vd, vs1, vl);
+}
+
+vbfloat16m1_t test_vmv_v_v_bf16m1_tu(vbfloat16m1_t vd, vbfloat16m1_t vs1,
+                                     size_t vl) {
+  return __riscv_vmv_v_v_bf16m1_tu(vd, vs1, vl);
+}
+
+vbfloat16m2_t test_vmv_v_v_bf16m2_tu(vbfloat16m2_t vd, vbfloat16m2_t vs1,
+                                     size_t vl) {
+  return __riscv_vmv_v_v_bf16m2_tu(vd, vs1, vl);
+}
+
+vbfloat16m4_t test_vmv_v_v_bf16m4_tu(vbfloat16m4_t vd, vbfloat16m4_t vs1,
+                                     size_t vl) {
+  return __riscv_vmv_v_v_bf16m4_tu(vd, vs1, vl);
+}
+
+vbfloat16m8_t test_vmv_v_v_bf16m8_tu(vbfloat16m8_t vd, vbfloat16m8_t vs1,
+                                     size_t vl) {
+  return __riscv_vmv_v_v_bf16m8_tu(vd, vs1, vl);
+}

--- a/auto-generated/bfloat16/policy_funcs/intrinsic_funcs.adoc
+++ b/auto-generated/bfloat16/policy_funcs/intrinsic_funcs.adoc
@@ -2855,6 +2855,64 @@ vfloat32m8_t __riscv_vfwmaccbf16_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
                                                 unsigned int frm, size_t vl);
 ----
 
+[[policy-variant-vector-bf16-move]]
+==== Vector BFloat16 Move Intrinsics
+
+[,c]
+----
+vbfloat16mf4_t __riscv_vmv_v_v_bf16mf4_tu(vbfloat16mf4_t vd, vbfloat16mf4_t vs1,
+                                          size_t vl);
+vbfloat16mf4_t __riscv_vfmv_v_f_bf16mf4_tu(vbfloat16mf4_t vd, __bf16 rs1,
+                                           size_t vl);
+vbfloat16mf2_t __riscv_vmv_v_v_bf16mf2_tu(vbfloat16mf2_t vd, vbfloat16mf2_t vs1,
+                                          size_t vl);
+vbfloat16mf2_t __riscv_vfmv_v_f_bf16mf2_tu(vbfloat16mf2_t vd, __bf16 rs1,
+                                           size_t vl);
+vbfloat16m1_t __riscv_vmv_v_v_bf16m1_tu(vbfloat16m1_t vd, vbfloat16m1_t vs1,
+                                        size_t vl);
+vbfloat16m1_t __riscv_vfmv_v_f_bf16m1_tu(vbfloat16m1_t vd, __bf16 rs1,
+                                         size_t vl);
+vbfloat16m2_t __riscv_vmv_v_v_bf16m2_tu(vbfloat16m2_t vd, vbfloat16m2_t vs1,
+                                        size_t vl);
+vbfloat16m2_t __riscv_vfmv_v_f_bf16m2_tu(vbfloat16m2_t vd, __bf16 rs1,
+                                         size_t vl);
+vbfloat16m4_t __riscv_vmv_v_v_bf16m4_tu(vbfloat16m4_t vd, vbfloat16m4_t vs1,
+                                        size_t vl);
+vbfloat16m4_t __riscv_vfmv_v_f_bf16m4_tu(vbfloat16m4_t vd, __bf16 rs1,
+                                         size_t vl);
+vbfloat16m8_t __riscv_vmv_v_v_bf16m8_tu(vbfloat16m8_t vd, vbfloat16m8_t vs1,
+                                        size_t vl);
+vbfloat16m8_t __riscv_vfmv_v_f_bf16m8_tu(vbfloat16m8_t vd, __bf16 rs1,
+                                         size_t vl);
+----
+
+[[policy-variant-vector-bf16-merge]]
+==== Vector BFloat16 Merge Intrinsics
+
+[,c]
+----
+vbfloat16mf4_t __riscv_vmerge_vvm_bf16mf4_tu(vbfloat16mf4_t vd,
+                                             vbfloat16mf4_t vs2,
+                                             vbfloat16mf4_t vs1, vbool64_t v0,
+                                             size_t vl);
+vbfloat16mf2_t __riscv_vmerge_vvm_bf16mf2_tu(vbfloat16mf2_t vd,
+                                             vbfloat16mf2_t vs2,
+                                             vbfloat16mf2_t vs1, vbool32_t v0,
+                                             size_t vl);
+vbfloat16m1_t __riscv_vmerge_vvm_bf16m1_tu(vbfloat16m1_t vd, vbfloat16m1_t vs2,
+                                           vbfloat16m1_t vs1, vbool16_t v0,
+                                           size_t vl);
+vbfloat16m2_t __riscv_vmerge_vvm_bf16m2_tu(vbfloat16m2_t vd, vbfloat16m2_t vs2,
+                                           vbfloat16m2_t vs1, vbool8_t v0,
+                                           size_t vl);
+vbfloat16m4_t __riscv_vmerge_vvm_bf16m4_tu(vbfloat16m4_t vd, vbfloat16m4_t vs2,
+                                           vbfloat16m4_t vs1, vbool4_t v0,
+                                           size_t vl);
+vbfloat16m8_t __riscv_vmerge_vvm_bf16m8_tu(vbfloat16m8_t vd, vbfloat16m8_t vs2,
+                                           vbfloat16m8_t vs1, vbool2_t v0,
+                                           size_t vl);
+----
+
 === BFloat16 Miscellaneous Vector Utility Intrinsics
 
 [[policy-variant-reinterpret-cast-conversion]]

--- a/auto-generated/bfloat16/policy_funcs/intrinsic_funcs/03_bfloat16_arithmetic_intrinsics.adoc
+++ b/auto-generated/bfloat16/policy_funcs/intrinsic_funcs/03_bfloat16_arithmetic_intrinsics.adoc
@@ -271,3 +271,61 @@ vfloat32m8_t __riscv_vfwmaccbf16_vf_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
                                                 __bf16 vs1, vbfloat16m4_t vs2,
                                                 unsigned int frm, size_t vl);
 ----
+
+[[policy-variant-vector-bf16-move]]
+==== Vector BFloat16 Move Intrinsics
+
+[,c]
+----
+vbfloat16mf4_t __riscv_vmv_v_v_bf16mf4_tu(vbfloat16mf4_t vd, vbfloat16mf4_t vs1,
+                                          size_t vl);
+vbfloat16mf4_t __riscv_vfmv_v_f_bf16mf4_tu(vbfloat16mf4_t vd, __bf16 rs1,
+                                           size_t vl);
+vbfloat16mf2_t __riscv_vmv_v_v_bf16mf2_tu(vbfloat16mf2_t vd, vbfloat16mf2_t vs1,
+                                          size_t vl);
+vbfloat16mf2_t __riscv_vfmv_v_f_bf16mf2_tu(vbfloat16mf2_t vd, __bf16 rs1,
+                                           size_t vl);
+vbfloat16m1_t __riscv_vmv_v_v_bf16m1_tu(vbfloat16m1_t vd, vbfloat16m1_t vs1,
+                                        size_t vl);
+vbfloat16m1_t __riscv_vfmv_v_f_bf16m1_tu(vbfloat16m1_t vd, __bf16 rs1,
+                                         size_t vl);
+vbfloat16m2_t __riscv_vmv_v_v_bf16m2_tu(vbfloat16m2_t vd, vbfloat16m2_t vs1,
+                                        size_t vl);
+vbfloat16m2_t __riscv_vfmv_v_f_bf16m2_tu(vbfloat16m2_t vd, __bf16 rs1,
+                                         size_t vl);
+vbfloat16m4_t __riscv_vmv_v_v_bf16m4_tu(vbfloat16m4_t vd, vbfloat16m4_t vs1,
+                                        size_t vl);
+vbfloat16m4_t __riscv_vfmv_v_f_bf16m4_tu(vbfloat16m4_t vd, __bf16 rs1,
+                                         size_t vl);
+vbfloat16m8_t __riscv_vmv_v_v_bf16m8_tu(vbfloat16m8_t vd, vbfloat16m8_t vs1,
+                                        size_t vl);
+vbfloat16m8_t __riscv_vfmv_v_f_bf16m8_tu(vbfloat16m8_t vd, __bf16 rs1,
+                                         size_t vl);
+----
+
+[[policy-variant-vector-bf16-merge]]
+==== Vector BFloat16 Merge Intrinsics
+
+[,c]
+----
+vbfloat16mf4_t __riscv_vmerge_vvm_bf16mf4_tu(vbfloat16mf4_t vd,
+                                             vbfloat16mf4_t vs2,
+                                             vbfloat16mf4_t vs1, vbool64_t v0,
+                                             size_t vl);
+vbfloat16mf2_t __riscv_vmerge_vvm_bf16mf2_tu(vbfloat16mf2_t vd,
+                                             vbfloat16mf2_t vs2,
+                                             vbfloat16mf2_t vs1, vbool32_t v0,
+                                             size_t vl);
+vbfloat16m1_t __riscv_vmerge_vvm_bf16m1_tu(vbfloat16m1_t vd, vbfloat16m1_t vs2,
+                                           vbfloat16m1_t vs1, vbool16_t v0,
+                                           size_t vl);
+vbfloat16m2_t __riscv_vmerge_vvm_bf16m2_tu(vbfloat16m2_t vd, vbfloat16m2_t vs2,
+                                           vbfloat16m2_t vs1, vbool8_t v0,
+                                           size_t vl);
+vbfloat16m4_t __riscv_vmerge_vvm_bf16m4_tu(vbfloat16m4_t vd, vbfloat16m4_t vs2,
+                                           vbfloat16m4_t vs1, vbool4_t v0,
+                                           size_t vl);
+vbfloat16m8_t __riscv_vmerge_vvm_bf16m8_tu(vbfloat16m8_t vd, vbfloat16m8_t vs2,
+                                           vbfloat16m8_t vs1, vbool2_t v0,
+                                           size_t vl);
+----

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vfmv.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vfmv.c
@@ -1,0 +1,32 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN:   -target-feature +experimental-zvfbfmin \
+// RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vbfloat16mf4_t test_vfmv_v_f_bf16mf4_tu(vbfloat16mf4_t vd, __bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16mf4_tu(vd, rs1, vl);
+}
+
+vbfloat16mf2_t test_vfmv_v_f_bf16mf2_tu(vbfloat16mf2_t vd, __bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16mf2_tu(vd, rs1, vl);
+}
+
+vbfloat16m1_t test_vfmv_v_f_bf16m1_tu(vbfloat16m1_t vd, __bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16m1_tu(vd, rs1, vl);
+}
+
+vbfloat16m2_t test_vfmv_v_f_bf16m2_tu(vbfloat16m2_t vd, __bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16m2_tu(vd, rs1, vl);
+}
+
+vbfloat16m4_t test_vfmv_v_f_bf16m4_tu(vbfloat16m4_t vd, __bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16m4_tu(vd, rs1, vl);
+}
+
+vbfloat16m8_t test_vfmv_v_f_bf16m8_tu(vbfloat16m8_t vd, __bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_f_bf16m8_tu(vd, rs1, vl);
+}

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vmerge.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vmerge.c
@@ -1,0 +1,32 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN:   -target-feature +experimental-zvfbfmin \
+// RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vbfloat16mf4_t test_vmerge_vvm_bf16mf4_tu(vbfloat16mf4_t vd, vbfloat16mf4_t vs2, vbfloat16mf4_t vs1, vbool64_t v0, size_t vl) {
+  return __riscv_vmerge_vvm_bf16mf4_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16mf2_t test_vmerge_vvm_bf16mf2_tu(vbfloat16mf2_t vd, vbfloat16mf2_t vs2, vbfloat16mf2_t vs1, vbool32_t v0, size_t vl) {
+  return __riscv_vmerge_vvm_bf16mf2_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16m1_t test_vmerge_vvm_bf16m1_tu(vbfloat16m1_t vd, vbfloat16m1_t vs2, vbfloat16m1_t vs1, vbool16_t v0, size_t vl) {
+  return __riscv_vmerge_vvm_bf16m1_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16m2_t test_vmerge_vvm_bf16m2_tu(vbfloat16m2_t vd, vbfloat16m2_t vs2, vbfloat16m2_t vs1, vbool8_t v0, size_t vl) {
+  return __riscv_vmerge_vvm_bf16m2_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16m4_t test_vmerge_vvm_bf16m4_tu(vbfloat16m4_t vd, vbfloat16m4_t vs2, vbfloat16m4_t vs1, vbool4_t v0, size_t vl) {
+  return __riscv_vmerge_vvm_bf16m4_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16m8_t test_vmerge_vvm_bf16m8_tu(vbfloat16m8_t vd, vbfloat16m8_t vs2, vbfloat16m8_t vs1, vbool2_t v0, size_t vl) {
+  return __riscv_vmerge_vvm_bf16m8_tu(vd, vs2, vs1, v0, vl);
+}

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vmv.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vmv.c
@@ -1,0 +1,32 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN:   -target-feature +experimental-zvfbfmin \
+// RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vbfloat16mf4_t test_vmv_v_v_bf16mf4_tu(vbfloat16mf4_t vd, vbfloat16mf4_t vs1, size_t vl) {
+  return __riscv_vmv_v_v_bf16mf4_tu(vd, vs1, vl);
+}
+
+vbfloat16mf2_t test_vmv_v_v_bf16mf2_tu(vbfloat16mf2_t vd, vbfloat16mf2_t vs1, size_t vl) {
+  return __riscv_vmv_v_v_bf16mf2_tu(vd, vs1, vl);
+}
+
+vbfloat16m1_t test_vmv_v_v_bf16m1_tu(vbfloat16m1_t vd, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vmv_v_v_bf16m1_tu(vd, vs1, vl);
+}
+
+vbfloat16m2_t test_vmv_v_v_bf16m2_tu(vbfloat16m2_t vd, vbfloat16m2_t vs1, size_t vl) {
+  return __riscv_vmv_v_v_bf16m2_tu(vd, vs1, vl);
+}
+
+vbfloat16m4_t test_vmv_v_v_bf16m4_tu(vbfloat16m4_t vd, vbfloat16m4_t vs1, size_t vl) {
+  return __riscv_vmv_v_v_bf16m4_tu(vd, vs1, vl);
+}
+
+vbfloat16m8_t test_vmv_v_v_bf16m8_tu(vbfloat16m8_t vd, vbfloat16m8_t vs1, size_t vl) {
+  return __riscv_vmv_v_v_bf16m8_tu(vd, vs1, vl);
+}

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vfmv.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vfmv.c
@@ -1,0 +1,34 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN:   -target-feature +experimental-zvfbfmin \
+// RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vbfloat16mf4_t test_vfmv_v_f_bf16mf4_tu(vbfloat16mf4_t vd, __bf16 rs1,
+                                        size_t vl) {
+  return __riscv_vfmv_v_tu(vd, rs1, vl);
+}
+
+vbfloat16mf2_t test_vfmv_v_f_bf16mf2_tu(vbfloat16mf2_t vd, __bf16 rs1,
+                                        size_t vl) {
+  return __riscv_vfmv_v_tu(vd, rs1, vl);
+}
+
+vbfloat16m1_t test_vfmv_v_f_bf16m1_tu(vbfloat16m1_t vd, __bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_tu(vd, rs1, vl);
+}
+
+vbfloat16m2_t test_vfmv_v_f_bf16m2_tu(vbfloat16m2_t vd, __bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_tu(vd, rs1, vl);
+}
+
+vbfloat16m4_t test_vfmv_v_f_bf16m4_tu(vbfloat16m4_t vd, __bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_tu(vd, rs1, vl);
+}
+
+vbfloat16m8_t test_vfmv_v_f_bf16m8_tu(vbfloat16m8_t vd, __bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_tu(vd, rs1, vl);
+}

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vmerge.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vmerge.c
@@ -1,0 +1,44 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN:   -target-feature +experimental-zvfbfmin \
+// RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vbfloat16mf4_t test_vmerge_vvm_bf16mf4_tu(vbfloat16mf4_t vd, vbfloat16mf4_t vs2,
+                                          vbfloat16mf4_t vs1, vbool64_t v0,
+                                          size_t vl) {
+  return __riscv_vmerge_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16mf2_t test_vmerge_vvm_bf16mf2_tu(vbfloat16mf2_t vd, vbfloat16mf2_t vs2,
+                                          vbfloat16mf2_t vs1, vbool32_t v0,
+                                          size_t vl) {
+  return __riscv_vmerge_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16m1_t test_vmerge_vvm_bf16m1_tu(vbfloat16m1_t vd, vbfloat16m1_t vs2,
+                                        vbfloat16m1_t vs1, vbool16_t v0,
+                                        size_t vl) {
+  return __riscv_vmerge_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16m2_t test_vmerge_vvm_bf16m2_tu(vbfloat16m2_t vd, vbfloat16m2_t vs2,
+                                        vbfloat16m2_t vs1, vbool8_t v0,
+                                        size_t vl) {
+  return __riscv_vmerge_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16m4_t test_vmerge_vvm_bf16m4_tu(vbfloat16m4_t vd, vbfloat16m4_t vs2,
+                                        vbfloat16m4_t vs1, vbool4_t v0,
+                                        size_t vl) {
+  return __riscv_vmerge_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16m8_t test_vmerge_vvm_bf16m8_tu(vbfloat16m8_t vd, vbfloat16m8_t vs2,
+                                        vbfloat16m8_t vs1, vbool2_t v0,
+                                        size_t vl) {
+  return __riscv_vmerge_tu(vd, vs2, vs1, v0, vl);
+}

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vmv.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vmv.c
@@ -1,0 +1,38 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN:   -target-feature +experimental-zvfbfmin \
+// RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vbfloat16mf4_t test_vmv_v_v_bf16mf4_tu(vbfloat16mf4_t vd, vbfloat16mf4_t vs1,
+                                       size_t vl) {
+  return __riscv_vmv_v_tu(vd, vs1, vl);
+}
+
+vbfloat16mf2_t test_vmv_v_v_bf16mf2_tu(vbfloat16mf2_t vd, vbfloat16mf2_t vs1,
+                                       size_t vl) {
+  return __riscv_vmv_v_tu(vd, vs1, vl);
+}
+
+vbfloat16m1_t test_vmv_v_v_bf16m1_tu(vbfloat16m1_t vd, vbfloat16m1_t vs1,
+                                     size_t vl) {
+  return __riscv_vmv_v_tu(vd, vs1, vl);
+}
+
+vbfloat16m2_t test_vmv_v_v_bf16m2_tu(vbfloat16m2_t vd, vbfloat16m2_t vs1,
+                                     size_t vl) {
+  return __riscv_vmv_v_tu(vd, vs1, vl);
+}
+
+vbfloat16m4_t test_vmv_v_v_bf16m4_tu(vbfloat16m4_t vd, vbfloat16m4_t vs1,
+                                     size_t vl) {
+  return __riscv_vmv_v_tu(vd, vs1, vl);
+}
+
+vbfloat16m8_t test_vmv_v_v_bf16m8_tu(vbfloat16m8_t vd, vbfloat16m8_t vs1,
+                                     size_t vl) {
+  return __riscv_vmv_v_tu(vd, vs1, vl);
+}

--- a/auto-generated/bfloat16/policy_funcs/overloaded-api-testing/vfmv.c
+++ b/auto-generated/bfloat16/policy_funcs/overloaded-api-testing/vfmv.c
@@ -1,0 +1,28 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vbfloat16mf4_t test_vfmv_v_f_bf16mf4_tu(vbfloat16mf4_t vd, __bf16 rs1,
+                                        size_t vl) {
+  return __riscv_vfmv_v_tu(vd, rs1, vl);
+}
+
+vbfloat16mf2_t test_vfmv_v_f_bf16mf2_tu(vbfloat16mf2_t vd, __bf16 rs1,
+                                        size_t vl) {
+  return __riscv_vfmv_v_tu(vd, rs1, vl);
+}
+
+vbfloat16m1_t test_vfmv_v_f_bf16m1_tu(vbfloat16m1_t vd, __bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_tu(vd, rs1, vl);
+}
+
+vbfloat16m2_t test_vfmv_v_f_bf16m2_tu(vbfloat16m2_t vd, __bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_tu(vd, rs1, vl);
+}
+
+vbfloat16m4_t test_vfmv_v_f_bf16m4_tu(vbfloat16m4_t vd, __bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_tu(vd, rs1, vl);
+}
+
+vbfloat16m8_t test_vfmv_v_f_bf16m8_tu(vbfloat16m8_t vd, __bf16 rs1, size_t vl) {
+  return __riscv_vfmv_v_tu(vd, rs1, vl);
+}

--- a/auto-generated/bfloat16/policy_funcs/overloaded-api-testing/vmerge.c
+++ b/auto-generated/bfloat16/policy_funcs/overloaded-api-testing/vmerge.c
@@ -1,0 +1,38 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vbfloat16mf4_t test_vmerge_vvm_bf16mf4_tu(vbfloat16mf4_t vd, vbfloat16mf4_t vs2,
+                                          vbfloat16mf4_t vs1, vbool64_t v0,
+                                          size_t vl) {
+  return __riscv_vmerge_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16mf2_t test_vmerge_vvm_bf16mf2_tu(vbfloat16mf2_t vd, vbfloat16mf2_t vs2,
+                                          vbfloat16mf2_t vs1, vbool32_t v0,
+                                          size_t vl) {
+  return __riscv_vmerge_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16m1_t test_vmerge_vvm_bf16m1_tu(vbfloat16m1_t vd, vbfloat16m1_t vs2,
+                                        vbfloat16m1_t vs1, vbool16_t v0,
+                                        size_t vl) {
+  return __riscv_vmerge_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16m2_t test_vmerge_vvm_bf16m2_tu(vbfloat16m2_t vd, vbfloat16m2_t vs2,
+                                        vbfloat16m2_t vs1, vbool8_t v0,
+                                        size_t vl) {
+  return __riscv_vmerge_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16m4_t test_vmerge_vvm_bf16m4_tu(vbfloat16m4_t vd, vbfloat16m4_t vs2,
+                                        vbfloat16m4_t vs1, vbool4_t v0,
+                                        size_t vl) {
+  return __riscv_vmerge_tu(vd, vs2, vs1, v0, vl);
+}
+
+vbfloat16m8_t test_vmerge_vvm_bf16m8_tu(vbfloat16m8_t vd, vbfloat16m8_t vs2,
+                                        vbfloat16m8_t vs1, vbool2_t v0,
+                                        size_t vl) {
+  return __riscv_vmerge_tu(vd, vs2, vs1, v0, vl);
+}

--- a/auto-generated/bfloat16/policy_funcs/overloaded-api-testing/vmv.c
+++ b/auto-generated/bfloat16/policy_funcs/overloaded-api-testing/vmv.c
@@ -1,0 +1,32 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vbfloat16mf4_t test_vmv_v_v_bf16mf4_tu(vbfloat16mf4_t vd, vbfloat16mf4_t vs1,
+                                       size_t vl) {
+  return __riscv_vmv_v_tu(vd, vs1, vl);
+}
+
+vbfloat16mf2_t test_vmv_v_v_bf16mf2_tu(vbfloat16mf2_t vd, vbfloat16mf2_t vs1,
+                                       size_t vl) {
+  return __riscv_vmv_v_tu(vd, vs1, vl);
+}
+
+vbfloat16m1_t test_vmv_v_v_bf16m1_tu(vbfloat16m1_t vd, vbfloat16m1_t vs1,
+                                     size_t vl) {
+  return __riscv_vmv_v_tu(vd, vs1, vl);
+}
+
+vbfloat16m2_t test_vmv_v_v_bf16m2_tu(vbfloat16m2_t vd, vbfloat16m2_t vs1,
+                                     size_t vl) {
+  return __riscv_vmv_v_tu(vd, vs1, vl);
+}
+
+vbfloat16m4_t test_vmv_v_v_bf16m4_tu(vbfloat16m4_t vd, vbfloat16m4_t vs1,
+                                     size_t vl) {
+  return __riscv_vmv_v_tu(vd, vs1, vl);
+}
+
+vbfloat16m8_t test_vmv_v_v_bf16m8_tu(vbfloat16m8_t vd, vbfloat16m8_t vs1,
+                                     size_t vl) {
+  return __riscv_vmv_v_tu(vd, vs1, vl);
+}

--- a/auto-generated/bfloat16/policy_funcs/overloaded_intrinsic_funcs.adoc
+++ b/auto-generated/bfloat16/policy_funcs/overloaded_intrinsic_funcs.adoc
@@ -2069,6 +2069,46 @@ vfloat32m8_t __riscv_vfwmaccbf16_mu(vbool4_t vm, vfloat32m8_t vd, __bf16 vs1,
                                     size_t vl);
 ----
 
+[[policy-variant-overloadedvector-bf16-move]]
+==== Vector BFloat16 Move Intrinsics
+
+[,c]
+----
+vbfloat16mf4_t __riscv_vmv_v_tu(vbfloat16mf4_t vd, vbfloat16mf4_t vs1,
+                                size_t vl);
+vbfloat16mf4_t __riscv_vfmv_v_tu(vbfloat16mf4_t vd, __bf16 rs1, size_t vl);
+vbfloat16mf2_t __riscv_vmv_v_tu(vbfloat16mf2_t vd, vbfloat16mf2_t vs1,
+                                size_t vl);
+vbfloat16mf2_t __riscv_vfmv_v_tu(vbfloat16mf2_t vd, __bf16 rs1, size_t vl);
+vbfloat16m1_t __riscv_vmv_v_tu(vbfloat16m1_t vd, vbfloat16m1_t vs1, size_t vl);
+vbfloat16m1_t __riscv_vfmv_v_tu(vbfloat16m1_t vd, __bf16 rs1, size_t vl);
+vbfloat16m2_t __riscv_vmv_v_tu(vbfloat16m2_t vd, vbfloat16m2_t vs1, size_t vl);
+vbfloat16m2_t __riscv_vfmv_v_tu(vbfloat16m2_t vd, __bf16 rs1, size_t vl);
+vbfloat16m4_t __riscv_vmv_v_tu(vbfloat16m4_t vd, vbfloat16m4_t vs1, size_t vl);
+vbfloat16m4_t __riscv_vfmv_v_tu(vbfloat16m4_t vd, __bf16 rs1, size_t vl);
+vbfloat16m8_t __riscv_vmv_v_tu(vbfloat16m8_t vd, vbfloat16m8_t vs1, size_t vl);
+vbfloat16m8_t __riscv_vfmv_v_tu(vbfloat16m8_t vd, __bf16 rs1, size_t vl);
+----
+
+[[policy-variant-overloadedvector-bf16-merge]]
+==== Vector BFloat16 Merge Intrinsics
+
+[,c]
+----
+vbfloat16mf4_t __riscv_vmerge_tu(vbfloat16mf4_t vd, vbfloat16mf4_t vs2,
+                                 vbfloat16mf4_t vs1, vbool64_t v0, size_t vl);
+vbfloat16mf2_t __riscv_vmerge_tu(vbfloat16mf2_t vd, vbfloat16mf2_t vs2,
+                                 vbfloat16mf2_t vs1, vbool32_t v0, size_t vl);
+vbfloat16m1_t __riscv_vmerge_tu(vbfloat16m1_t vd, vbfloat16m1_t vs2,
+                                vbfloat16m1_t vs1, vbool16_t v0, size_t vl);
+vbfloat16m2_t __riscv_vmerge_tu(vbfloat16m2_t vd, vbfloat16m2_t vs2,
+                                vbfloat16m2_t vs1, vbool8_t v0, size_t vl);
+vbfloat16m4_t __riscv_vmerge_tu(vbfloat16m4_t vd, vbfloat16m4_t vs2,
+                                vbfloat16m4_t vs1, vbool4_t v0, size_t vl);
+vbfloat16m8_t __riscv_vmerge_tu(vbfloat16m8_t vd, vbfloat16m8_t vs2,
+                                vbfloat16m8_t vs1, vbool2_t v0, size_t vl);
+----
+
 === BFloat16 Miscellaneous Vector Utility Intrinsics
 
 [[policy-variant-overloadedreinterpret-cast-conversion]]

--- a/auto-generated/bfloat16/policy_funcs/overloaded_intrinsic_funcs/03_bfloat16_arithmetic_intrinsics.adoc
+++ b/auto-generated/bfloat16/policy_funcs/overloaded_intrinsic_funcs/03_bfloat16_arithmetic_intrinsics.adoc
@@ -230,3 +230,43 @@ vfloat32m8_t __riscv_vfwmaccbf16_mu(vbool4_t vm, vfloat32m8_t vd, __bf16 vs1,
                                     vbfloat16m4_t vs2, unsigned int frm,
                                     size_t vl);
 ----
+
+[[policy-variant-overloadedvector-bf16-move]]
+==== Vector BFloat16 Move Intrinsics
+
+[,c]
+----
+vbfloat16mf4_t __riscv_vmv_v_tu(vbfloat16mf4_t vd, vbfloat16mf4_t vs1,
+                                size_t vl);
+vbfloat16mf4_t __riscv_vfmv_v_tu(vbfloat16mf4_t vd, __bf16 rs1, size_t vl);
+vbfloat16mf2_t __riscv_vmv_v_tu(vbfloat16mf2_t vd, vbfloat16mf2_t vs1,
+                                size_t vl);
+vbfloat16mf2_t __riscv_vfmv_v_tu(vbfloat16mf2_t vd, __bf16 rs1, size_t vl);
+vbfloat16m1_t __riscv_vmv_v_tu(vbfloat16m1_t vd, vbfloat16m1_t vs1, size_t vl);
+vbfloat16m1_t __riscv_vfmv_v_tu(vbfloat16m1_t vd, __bf16 rs1, size_t vl);
+vbfloat16m2_t __riscv_vmv_v_tu(vbfloat16m2_t vd, vbfloat16m2_t vs1, size_t vl);
+vbfloat16m2_t __riscv_vfmv_v_tu(vbfloat16m2_t vd, __bf16 rs1, size_t vl);
+vbfloat16m4_t __riscv_vmv_v_tu(vbfloat16m4_t vd, vbfloat16m4_t vs1, size_t vl);
+vbfloat16m4_t __riscv_vfmv_v_tu(vbfloat16m4_t vd, __bf16 rs1, size_t vl);
+vbfloat16m8_t __riscv_vmv_v_tu(vbfloat16m8_t vd, vbfloat16m8_t vs1, size_t vl);
+vbfloat16m8_t __riscv_vfmv_v_tu(vbfloat16m8_t vd, __bf16 rs1, size_t vl);
+----
+
+[[policy-variant-overloadedvector-bf16-merge]]
+==== Vector BFloat16 Merge Intrinsics
+
+[,c]
+----
+vbfloat16mf4_t __riscv_vmerge_tu(vbfloat16mf4_t vd, vbfloat16mf4_t vs2,
+                                 vbfloat16mf4_t vs1, vbool64_t v0, size_t vl);
+vbfloat16mf2_t __riscv_vmerge_tu(vbfloat16mf2_t vd, vbfloat16mf2_t vs2,
+                                 vbfloat16mf2_t vs1, vbool32_t v0, size_t vl);
+vbfloat16m1_t __riscv_vmerge_tu(vbfloat16m1_t vd, vbfloat16m1_t vs2,
+                                vbfloat16m1_t vs1, vbool16_t v0, size_t vl);
+vbfloat16m2_t __riscv_vmerge_tu(vbfloat16m2_t vd, vbfloat16m2_t vs2,
+                                vbfloat16m2_t vs1, vbool8_t v0, size_t vl);
+vbfloat16m4_t __riscv_vmerge_tu(vbfloat16m4_t vd, vbfloat16m4_t vs2,
+                                vbfloat16m4_t vs1, vbool4_t v0, size_t vl);
+vbfloat16m8_t __riscv_vmerge_tu(vbfloat16m8_t vd, vbfloat16m8_t vs2,
+                                vbfloat16m8_t vs1, vbool2_t v0, size_t vl);
+----

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/bfloat16_inst.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/bfloat16_inst.py
@@ -29,6 +29,7 @@ from templates import seg_store_template
 from templates import reint_op_template
 from templates import get_set_diff_lmul_op_template
 from templates import misc_op_template
+from templates import unary_op_template
 from templates import cvt_op_template
 from templates import mac_template
 from constants import LMULS, WLMULS, NCVTLMULS
@@ -125,6 +126,13 @@ def gen(g):
                    "Vector Widening Multiply-Accumulate Intrinsics",
                    "bf16-widening-multiply-accumulate", ["wmaccbf16"], TYPES,
                    SEWS, WLMULS, decorators.has_masking_no_maskedoff_policy_frm)
+  g.function_group(unary_op_template, "Vector BFloat16 Move Intrinsics",
+                   "vector-bf16-move", ["mv"], TYPES, SEWS, LMULS,
+                   decorators.has_no_masking_policy)
+
+  g.function_group(unary_op_template, "Vector BFloat16 Merge Intrinsics",
+                   "vector-bf16-merge", ["merge"], TYPES, SEWS, LMULS,
+                   decorators.has_no_masking_policy)
 
   ####################################################################
   g.start_group("BFloat16 Miscellaneous Vector Utility Intrinsics")

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/unary_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/unary_op_template.py
@@ -41,7 +41,7 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
       if op in ["zext", "sext"]:
         break
 
-      if data_type == "float":
+      if data_type == "float" or data_type == "bfloat":
         args["S_TYPE"] = "f"
         args["OP"] = "f" + args["OP"]
         inst_type_vvsm = InstType.VVFM
@@ -71,7 +71,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
       # for float type, accrdoing current naming scheming it
       # should be vmv_v_v, same for vmerge.vvm.
       vv_args = args
-      if data_type == "float" and op in ["mv", "merge"]:
+      if (data_type == "float" or
+          data_type == "bfloat") and op in ["mv", "merge"]:
         vv_args = copy.deepcopy(args)
         vv_args["OP"] = "v" + op
 
@@ -87,6 +88,10 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list):
             vs1=type_helper.v,
             v0=type_helper.m,
             vl=type_helper.size_t)
+
+        if data_type == "bfloat":
+          continue
+
         G.func(
             inst_info_vvsm,
             name="{OP}_v{S_TYPE}m_{TYPE}{SEW}m{LMUL}".format_map(args) +


### PR DESCRIPTION
Resolve: https://github.com/riscv-non-isa/rvv-intrinsic-doc/issues/349