### PR TITLE
Add custom llvm header support in generator

### DIFF
--- a/auto-generated/vector-crypto/llvm-api-tests/vcpop.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vcpop.c
@@ -1,5 +1,12 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN:   -target-feature +zvbb \
+// RUN:   -target-feature +zvbc \
+// RUN:   -target-feature +zvkg \
+// RUN:   -target-feature +zvkned \
+// RUN:   -target-feature +zvknhb \
+// RUN:   -target-feature +zvksed \
+// RUN:   -target-feature +zvksh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vcpop.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vcpop.c
@@ -1,5 +1,12 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN:   -target-feature +zvbb \
+// RUN:   -target-feature +zvbc \
+// RUN:   -target-feature +zvkg \
+// RUN:   -target-feature +zvkned \
+// RUN:   -target-feature +zvknhb \
+// RUN:   -target-feature +zvksed \
+// RUN:   -target-feature +zvksh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vcpop.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vcpop.c
@@ -1,5 +1,12 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN:   -target-feature +zvbb \
+// RUN:   -target-feature +zvbc \
+// RUN:   -target-feature +zvkg \
+// RUN:   -target-feature +zvkned \
+// RUN:   -target-feature +zvknhb \
+// RUN:   -target-feature +zvksed \
+// RUN:   -target-feature +zvksh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vcpop.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vcpop.c
@@ -1,5 +1,12 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN:   -target-feature +zvbb \
+// RUN:   -target-feature +zvbc \
+// RUN:   -target-feature +zvkg \
+// RUN:   -target-feature +zvkned \
+// RUN:   -target-feature +zvknhb \
+// RUN:   -target-feature +zvksed \
+// RUN:   -target-feature +zvksh -disable-O0-optnone \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/bfloat16_inst.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/bfloat16_inst.py
@@ -21,7 +21,7 @@ sequence and grouping.
 """
 
 from intrinsic_decorator import IntrinsicDecorators
-from generator import CompatibleHeaderGenerator
+from generator import CompatibleHeaderGenerator, APITestGenerator
 from templates import load_template
 from templates import seg_load_template
 from templates import store_template
@@ -37,10 +37,23 @@ SEWS = [16]
 NSEWS = [32]
 TYPES = ["bfloat"]
 
+llvm_header = r"""// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN:   -target-feature +experimental-zvfbfmin \
+// RUN:   -target-feature +experimental-zvfbfwma -disable-O0-optnone \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+"""
+
 
 def gen(g):
   if isinstance(g, CompatibleHeaderGenerator):
     assert False, "BFloat16 intrinsics is supported after v1.0"
+
+  if isinstance(g, APITestGenerator):
+    g.set_llvm_api_test_header(llvm_header)
+
   decorators = IntrinsicDecorators(g.has_tail_policy)
 
   ####################################################################

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -460,7 +460,7 @@ class APITestGenerator(Generator):
   def inst_group_epilogue(self):
     return ""
 
-  def write_file_header(self, has_float_type, name):
+  def write_file_header(self, has_float_type):
     #pylint: disable=line-too-long
     int_llvm_header = r"""// REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +v -disable-O0-optnone \
@@ -564,7 +564,7 @@ class APITestGenerator(Generator):
         has_float_type = True
 
     if header:
-      self.write_file_header(has_float_type, name)
+      self.write_file_header(has_float_type)
 
     def output_call_arg(arg_name, type_name):
       if ((name.startswith("vget") or name.startswith("vset")) \

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/vector_crypto_inst.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/vector_crypto_inst.py
@@ -3,11 +3,29 @@ Declares the vector crypto intrinsics through the vector crypto template.
 """
 
 from intrinsic_decorator import IntrinsicDecorators
+from generator import APITestGenerator
 from templates import vector_crypto_template
 from constants import LMULS, WLMULS, SEWS, WSEWS, UITYPE
 
+llvm_header = r"""// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN:   -target-feature +zvbb \
+// RUN:   -target-feature +zvbc \
+// RUN:   -target-feature +zvkg \
+// RUN:   -target-feature +zvkned \
+// RUN:   -target-feature +zvknhb \
+// RUN:   -target-feature +zvksed \
+// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+"""
+
 
 def gen(g):
+  if isinstance(g, APITestGenerator):
+    g.set_llvm_api_test_header(llvm_header)
+
   decorators = IntrinsicDecorators(g.has_tail_policy)
 
   g.start_group("Zvbb - Vector Bit-manipulation used in Cryptography")


### PR DESCRIPTION
It might be more extensions in the future, it's better to make each extension specify its own header file to prevent complex rule to check which header to use especially in llvm api tests.