### PR TITLE
Fix matmul example in the docs.

### DIFF
--- a/doc/rvv-intrinsic-examples.adoc
+++ b/doc/rvv-intrinsic-examples.adoc
@@ -103,7 +103,7 @@ void matmul_rvv(double *a, double *b, double *c, int n, int m, int p) {
       // Set accumulator to  zero.
       vfloat64m1_t vec_s = __riscv_vfmv_v_f_f64m1(0.0, vlmax);
       vfloat64m1_t vec_zero = __riscv_vfmv_v_f_f64m1(0.0, vlmax);
-      for (size_t vl; k > 0; k -= vl) {
+      for (size_t vl; k > 0; k -= vl, ptr_a += vl, ptr_b += vl * m) {
         vl = __riscv_vsetvl_e64m1(k);
 
         // Load row a[i][k..k+vl)


### PR DESCRIPTION
Fix matmul example in docs. The pointer ptr_a and ptr_b are not updated in the loop. 

See https://github.com/riscv-non-isa/rvv-intrinsic-doc/issues/359 for details.