### PR TITLE
generator: add required extension info

### DIFF
--- a/auto-generated/vector-crypto/llvm-api-tests/vaesdf.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vaesdf.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vaesdm.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vaesdm.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vaesef.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vaesef.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vaesem.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vaesem.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vaeskf1.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vaeskf1.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vaeskf2.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vaeskf2.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vaesz.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vaesz.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vandn.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vandn.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vbrev.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vbrev.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vbrev8.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vbrev8.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vclmul.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vclmul.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vclmulh.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vclmulh.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vclz.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vclz.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vcpop.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vcpop.c
@@ -1,5 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvbb \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vctz.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vctz.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vghsh.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vghsh.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vgmul.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vgmul.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vrev8.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vrev8.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vrol.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vrol.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvkb \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vror.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vror.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvkb \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vsha2ch.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vsha2ch.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vsha2cl.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vsha2cl.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vsha2ms.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vsha2ms.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vsm3c.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vsm3c.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvksh \
+// RUN:   -target-feature +zvl512b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vsm3me.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vsm3me.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvksh \
+// RUN:   -target-feature +zvl512b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vsm4k.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vsm4k.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vsm4r.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vsm4r.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-api-tests/vwsll.c
+++ b/auto-generated/vector-crypto/llvm-api-tests/vwsll.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vaesdf.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vaesdf.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vaesdm.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vaesdm.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vaesef.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vaesef.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vaesem.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vaesem.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vaeskf1.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vaeskf1.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vaeskf2.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vaeskf2.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vaesz.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vaesz.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vandn.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vandn.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vbrev.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vbrev.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vbrev8.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vbrev8.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vclmul.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vclmul.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vclmulh.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vclmulh.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vclz.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vclz.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vcpop.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vcpop.c
@@ -1,5 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvbb \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vctz.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vctz.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vghsh.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vghsh.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vgmul.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vgmul.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vrev8.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vrev8.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vrol.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vrol.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvkb \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vror.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vror.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvkb \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vsha2ch.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vsha2ch.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vsha2cl.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vsha2cl.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vsha2ms.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vsha2ms.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vsm3c.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vsm3c.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvksh \
+// RUN:   -target-feature +zvl512b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vsm3me.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vsm3me.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvksh \
+// RUN:   -target-feature +zvl512b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vsm4k.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vsm4k.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vsm4r.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vsm4r.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/llvm-overloaded-tests/vwsll.c
+++ b/auto-generated/vector-crypto/llvm-overloaded-tests/vwsll.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vaesdf.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vaesdf.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vaesdm.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vaesdm.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vaesef.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vaesef.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vaesem.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vaesem.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vaeskf1.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vaeskf1.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vaeskf2.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vaeskf2.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vaesz.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vaesz.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vandn.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vandn.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vbrev.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vbrev.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vbrev8.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vbrev8.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vclmul.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vclmul.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vclmulh.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vclmulh.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vclz.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vclz.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vcpop.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vcpop.c
@@ -1,5 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvbb \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vctz.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vctz.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vghsh.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vghsh.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vgmul.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vgmul.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vrev8.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vrev8.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vrol.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vrol.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvkb \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vror.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vror.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvkb \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vsha2ch.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vsha2ch.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vsha2cl.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vsha2cl.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vsha2ms.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vsha2ms.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vsm3c.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vsm3c.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvksh \
+// RUN:   -target-feature +zvl512b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vsm3me.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vsm3me.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvksh \
+// RUN:   -target-feature +zvl512b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vsm4k.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vsm4k.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vsm4r.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vsm4r.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vwsll.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-api-tests/vwsll.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vaesdf.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vaesdf.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vaesdm.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vaesdm.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vaesef.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vaesef.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vaesem.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vaesem.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vaeskf1.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vaeskf1.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vaeskf2.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vaeskf2.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vaesz.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vaesz.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vandn.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vandn.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vbrev.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vbrev.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vbrev8.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vbrev8.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vclmul.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vclmul.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vclmulh.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vclmulh.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vclz.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vclz.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vcpop.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vcpop.c
@@ -1,5 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvbb \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vctz.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vctz.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vghsh.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vghsh.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vgmul.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vgmul.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vrev8.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vrev8.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vrol.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vrol.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvkb \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vror.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vror.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvkb \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vsha2ch.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vsha2ch.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vsha2cl.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vsha2cl.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vsha2ms.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vsha2ms.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vsm3c.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vsm3c.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvksh \
+// RUN:   -target-feature +zvl512b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vsm3me.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vsm3me.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvksh \
+// RUN:   -target-feature +zvl512b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vsm4k.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vsm4k.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vsm4r.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vsm4r.c
@@ -1,12 +1,9 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zvl256b \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vwsll.c
+++ b/auto-generated/vector-crypto/policy_funcs/llvm-overloaded-tests/vwsll.c
@@ -1,12 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
 // RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/enums.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/enums.py
@@ -145,7 +145,8 @@ class InstInfo:
                inst_type=InstType.UNKNOWN,
                mem_type=MemType.NO_MEM,
                extra_attr=ExtraAttr.NO_ATTR,
-               NF=1):
+               NF=1,
+               required_ext=None):
     #pylint: disable=invalid-name
     self.SEW = SEW
     self.LMUL = LMUL
@@ -154,6 +155,9 @@ class InstInfo:
     self.mem_type = mem_type
     self.extra_attr = extra_attr
     self.NF = NF
+    if required_ext is None:
+      required_ext = []
+    self.required_ext = sorted(required_ext)
 
   def load_p(self):
     return self.mem_type == MemType.LOAD
@@ -185,3 +189,14 @@ class InstInfo:
       # For mask operation
       return InstInfo(0, 0, args["OP"], inst_type, mem_type,
                       extra_attr | decorator.flags)
+
+  def get_required_exts(self) -> list:
+    return sorted(self.required_ext)
+
+  def add_required_ext(self, ext: str) -> None:
+    if ext not in self.required_ext:
+      self.required_ext.append(ext)
+
+  def remove_required_ext(self, ext: str) -> None:
+    if ext in self.required_ext:
+      self.required_ext.remove(ext)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/enums.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/enums.py
@@ -173,22 +173,48 @@ class InstInfo:
           decorator,
           inst_type,
           mem_type=MemType.NO_MEM,
-          extra_attr=ExtraAttr.NO_ATTR):
+          extra_attr=ExtraAttr.NO_ATTR,
+          required_ext=None):
     if decorator is None:
       # vsetvl and vsetvlmax
-      return InstInfo(args["SEW"], args["LMUL"], args["OP"], inst_type,
-                      mem_type, extra_attr)
+      return InstInfo(
+          args["SEW"],
+          args["LMUL"],
+          args["OP"],
+          inst_type,
+          mem_type,
+          extra_attr,
+          required_ext=required_ext)
     elif "SEW" in args:
       if "NF" in args:
-        return InstInfo(args["SEW"], args["LMUL"], args["OP"], inst_type,
-                        mem_type, extra_attr | decorator.flags, args["NF"])
+        return InstInfo(
+            args["SEW"],
+            args["LMUL"],
+            args["OP"],
+            inst_type,
+            mem_type,
+            extra_attr | decorator.flags,
+            args["NF"],
+            required_ext=required_ext)
       else:
-        return InstInfo(args["SEW"], args["LMUL"], args["OP"], inst_type,
-                        mem_type, extra_attr | decorator.flags)
+        return InstInfo(
+            args["SEW"],
+            args["LMUL"],
+            args["OP"],
+            inst_type,
+            mem_type,
+            extra_attr | decorator.flags,
+            required_ext=required_ext)
     else:
       # For mask operation
-      return InstInfo(0, 0, args["OP"], inst_type, mem_type,
-                      extra_attr | decorator.flags)
+      return InstInfo(
+          0,
+          0,
+          args["OP"],
+          inst_type,
+          mem_type,
+          extra_attr | decorator.flags,
+          required_ext=required_ext)
 
   def get_required_exts(self) -> list:
     return sorted(self.required_ext)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -554,6 +554,12 @@ class APITestGenerator(Generator):
     if requires_exts:
       dynamic_llvm_header = dynamic_llvm_header_prologue
       for ext in requires_exts:
+        # Due to requirements of SEW==32 intrinsics will be used
+        # in the LLVM test header, the extension "zvknha"
+        # should be replaced with "zvknhb" for the following
+        # SEW==64 intrinsics.
+        if ext == "zvknha":
+          ext = "zvknhb"
         dynamic_llvm_header += f"// RUN:   -target-feature +{ext} \\\n"
       dynamic_llvm_header += dynamic_llvm_header_epilogue
 

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -557,39 +557,11 @@ class APITestGenerator(Generator):
         dynamic_llvm_header += f"// RUN:   -target-feature +{ext} \\\n"
       dynamic_llvm_header += dynamic_llvm_header_epilogue
 
-    vector_crypto_llvm_header = r"""// REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v -target-feature +zvl512b \
-// RUN:   -target-feature +zvbb \
-// RUN:   -target-feature +zvbc \
-// RUN:   -target-feature +zvkg \
-// RUN:   -target-feature +zvkned \
-// RUN:   -target-feature +zvknhb \
-// RUN:   -target-feature +zvksed \
-// RUN:   -target-feature +zvksh -disable-O0-optnone \
-// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
-// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
-
-"""
-
-    def is_vector_crypto_inst(name):
-      vector_crypto_inst = [
-          "vandn", "vbrev", "vbrev8", "vrev8", "vclz", "vctz", "vrol", "vror",
-          "vwsll", "vclmul", "vclmulh", "vghsh", "vgmul", "vaesef", "vaesem",
-          "vaesdf", "vaesdm", "vaeskf1", "vaeskf2", "vaesz", "vsha2ms",
-          "vsha2ch", "vsha2cl", "vsm4k", "vsm4r", "vsm3me", "vsm3c"
-      ]
-      for inst in vector_crypto_inst:
-        if inst in name:
-          return True
-      return False
-
     if self.toolchain_type == ToolChainType.LLVM:
       if requires_exts:
         self.fd.write(dynamic_llvm_header)
       elif has_bfloat16_type:
         self.fd.write(bfloat16_llvm_header)
-      elif is_vector_crypto_inst(name):
-        self.fd.write(vector_crypto_llvm_header)
       elif has_float_type:
         self.fd.write(float_llvm_header)
       else:

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -64,7 +64,8 @@ class Generator(ABC):
                      sew_list,
                      lmul_list,
                      decorator_list,
-                     description=None):
+                     description=None,
+                     required_ext_list=None):
     # pylint: disable=unused-argument
     # NOTE: 'title' and 'link' are only used in DocGenerator and
     # OverloadedDocGenerator. Probably need some decoupling here.
@@ -75,7 +76,8 @@ class Generator(ABC):
         sew_list=sew_list,
         lmul_list=lmul_list,
         decorator_list=decorator_list,
-        description=description)
+        description=description,
+        required_ext_list=required_ext_list)
 
   def start_group(self, group_name):
     raise NotImplementedError
@@ -359,7 +361,8 @@ class DocGenerator(Generator):
                      sew_list,
                      lmul_list,
                      decorator_list,
-                     description=None):
+                     description=None,
+                     required_ext_list=None):
     self.write_title(title, link)
     if self.has_tail_policy and len(decorator_list) == 0:
       s = "Intrinsics here don't have a policy variant.\n"
@@ -378,7 +381,8 @@ class DocGenerator(Generator):
         sew_list,
         lmul_list,
         decorator_list,
-        description=description)
+        description=description,
+        required_ext_list=required_ext_list)
 
   def func(self, inst_info, name, return_type, **kwargs):
     name = Generator.func_name(name)
@@ -437,7 +441,8 @@ class OverloadedDocGenerator(DocGenerator):
                      sew_list,
                      lmul_list,
                      decorator_list,
-                     description=None):
+                     description=None,
+                     required_ext_list=None):
     self.do_not_have_overloaded_variant = True
     for op in op_list:
       if Generator.is_support_overloaded(op):
@@ -451,7 +456,8 @@ class OverloadedDocGenerator(DocGenerator):
         sew_list,
         lmul_list,
         decorator_list,
-        description=description)
+        description=description,
+        required_ext_list=required_ext_list)
 
   def func(self, inst_info, name, return_type, **kwargs):
     func_name = Generator.func_name(name)
@@ -714,7 +720,8 @@ class APITestGenerator(Generator):
                      sew_list,
                      lmul_list,
                      decorator_list,
-                     description=None):
+                     description=None,
+                     required_ext_list=None):
     self.test_file_names = op_list
     template.render(
         G=self,
@@ -723,7 +730,8 @@ class APITestGenerator(Generator):
         sew_list=sew_list,
         lmul_list=lmul_list,
         decorator_list=decorator_list,
-        description=description)
+        description=description,
+        required_ext_list=required_ext_list)
 
 
 class Grouper(Generator):
@@ -778,7 +786,8 @@ class Grouper(Generator):
                      sew_list,
                      lmul_list,
                      decorator_list,
-                     description=None):
+                     description=None,
+                     required_ext_list=None):
     self.op_list = op_list
     self.groups[self.current_group].append(title)
     self.current_sub_group = title
@@ -789,7 +798,8 @@ class Grouper(Generator):
         sew_list=sew_list,
         lmul_list=lmul_list,
         decorator_list=decorator_list,
-        description=description)
+        description=description,
+        required_ext_list=required_ext_list)
 
 
 class CompatibleHeaderGenerator(Generator):
@@ -936,7 +946,8 @@ _14, _15, _16, _17, _18, _19, _20, NAME, ...) NAME
                      sew_list,
                      lmul_list,
                      decorator_list,
-                     description=None):
+                     description=None,
+                     required_ext_list=None):
     if self.has_tail_policy and len(decorator_list) == 0:
       return
     super().function_group(
@@ -948,7 +959,8 @@ _14, _15, _16, _17, _18, _19, _20, NAME, ...) NAME
         sew_list,
         lmul_list,
         decorator_list,
-        description=description)
+        description=description,
+        required_ext_list=required_ext_list)
 
   @staticmethod
   def is_policy_func(inst_info):

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_intcarry_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_intcarry_template.py
@@ -26,8 +26,14 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)
@@ -43,8 +49,10 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
       assert args["OP"] is not None
       args["OP"] = "v" + args["OP"]
 
-      inst_info_vvm = InstInfo.get(args, decorator, InstType.VVVM)
-      inst_info_vxm = InstInfo.get(args, decorator, InstType.VVXM)
+      inst_info_vvm = InstInfo.get(
+          args, decorator, InstType.VVVM, required_ext=required_ext_list)
+      inst_info_vxm = InstInfo.get(
+          args, decorator, InstType.VVXM, required_ext=required_ext_list)
 
       if not "m" in args["OP"]:
         G.func(
@@ -77,11 +85,15 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
       assert args["OP"] is not None
       args["OP"] = "v" + args["OP"]
 
-      inst_info_vvm = InstInfo.get(args, None, InstType.VVVM)
-      inst_info_vxm = InstInfo.get(args, None, InstType.VVXM)
+      inst_info_vvm = InstInfo.get(
+          args, None, InstType.VVVM, required_ext=required_ext_list)
+      inst_info_vxm = InstInfo.get(
+          args, None, InstType.VVXM, required_ext=required_ext_list)
 
-      inst_info_vv = InstInfo.get(args, None, InstType.VVV)
-      inst_info_vx = InstInfo.get(args, None, InstType.VVX)
+      inst_info_vv = InstInfo.get(
+          args, None, InstType.VVV, required_ext=required_ext_list)
+      inst_info_vx = InstInfo.get(
+          args, None, InstType.VVX, required_ext=required_ext_list)
 
       # madc or msbc
       if "m" in args["OP"]:

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_nop_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_nop_template.py
@@ -32,8 +32,14 @@ def must_int_type(**kargs):
 
 
 # narrowing op template
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)
@@ -74,7 +80,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
         continue
       type_helper = TypeHelper(**args)
 
-      inst_info = InstInfo.get(args, decorator, inst_type)
+      inst_info = InstInfo.get(
+          args, decorator, inst_type, required_ext=required_ext_list)
 
       if op in ["nsrl", "nsra", "nclip"]:
         if op2 == "v":

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_op_template.py
@@ -28,8 +28,14 @@ from enums import InstType
 from enums import ExtraAttr
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)
@@ -95,10 +101,14 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
 
       args["OP"] = "v" + args["OP"]
 
-      inst_info_vv = InstInfo.get(args, decorator, InstType.VVV)
-      inst_info_vx = InstInfo.get(args, decorator, InstType.VVX)
-      inst_info_vf = InstInfo.get(args, decorator, InstType.VVF)
-      inst_info_v = InstInfo.get(args, decorator, InstType.VV)
+      inst_info_vv = InstInfo.get(
+          args, decorator, InstType.VVV, required_ext=required_ext_list)
+      inst_info_vx = InstInfo.get(
+          args, decorator, InstType.VVX, required_ext=required_ext_list)
+      inst_info_vf = InstInfo.get(
+          args, decorator, InstType.VVF, required_ext=required_ext_list)
+      inst_info_v = InstInfo.get(
+          args, decorator, InstType.VV, required_ext=required_ext_list)
       if args["OP2"] == "v":
         inst_info = inst_info_vv
       elif args["OP2"] == "x":
@@ -147,7 +157,9 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
       elif "rgather" == op:
         if op2 == "v":
           G.func(
-              InstInfo.get(args, decorator, InstType.VVV),
+              InstInfo.get(
+                  args, decorator, InstType.VVV,
+                  required_ext=required_ext_list),
               name="{OP}_v{OP2}_{TYPE}{SEW}m{LMUL}".format_map(args) +
               decorator.func_suffix,
               return_type=type_helper.v,
@@ -158,7 +170,9 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
               vl=type_helper.size_t)
         else:  # vx
           G.func(
-              InstInfo.get(args, decorator, InstType.VVV),
+              InstInfo.get(
+                  args, decorator, InstType.VVV,
+                  required_ext=required_ext_list),
               name="{OP}_v{OP2}_{TYPE}{SEW}m{LMUL}".format_map(args) +
               decorator.func_suffix,
               return_type=type_helper.v,

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_wop_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/binary_wop_template.py
@@ -26,8 +26,14 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)
@@ -49,12 +55,18 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
 
       args["OP"] = "v" + args["OP"]
 
-      inst_info_wvv = InstInfo.get(args, decorator, InstType.WVV)
-      inst_info_wvx = InstInfo.get(args, decorator, InstType.WVX)
-      inst_info_wvf = InstInfo.get(args, decorator, InstType.WVF)
-      inst_info_wwv = InstInfo.get(args, decorator, InstType.WWV)
-      inst_info_wwx = InstInfo.get(args, decorator, InstType.WWX)
-      inst_info_wwf = InstInfo.get(args, decorator, InstType.WWF)
+      inst_info_wvv = InstInfo.get(
+          args, decorator, InstType.WVV, required_ext=required_ext_list)
+      inst_info_wvx = InstInfo.get(
+          args, decorator, InstType.WVX, required_ext=required_ext_list)
+      inst_info_wvf = InstInfo.get(
+          args, decorator, InstType.WVF, required_ext=required_ext_list)
+      inst_info_wwv = InstInfo.get(
+          args, decorator, InstType.WWV, required_ext=required_ext_list)
+      inst_info_wwx = InstInfo.get(
+          args, decorator, InstType.WWX, required_ext=required_ext_list)
+      inst_info_wwf = InstInfo.get(
+          args, decorator, InstType.WWF, required_ext=required_ext_list)
 
       args["LMUL"] = args["WLMUL"]
       args["SEW"] = args["WSEW"]

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/cmp_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/cmp_template.py
@@ -26,8 +26,14 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)
@@ -67,7 +73,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
           op = op + "u"
 
       args["OP"] = "v" + op
-      inst_info = InstInfo.get(args, decorator, inst_type)
+      inst_info = InstInfo.get(
+          args, decorator, inst_type, required_ext=required_ext_list)
       if op2 == "v":
         G.func(
             inst_info,

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/cvt_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/cvt_op_template.py
@@ -28,8 +28,14 @@ from enums import ExtraAttr
 from constants import ITYPES
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name, unused-argument
   # FIXME: Renaming 'G' to 'g' all in once later.
   # FIXME: Argument 'type_list' is unused but required for interface
@@ -112,7 +118,11 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
 
       extra_attr = ExtraAttr.CONVERT
       inst_info = InstInfo.get(
-          args, decorator, InstType.VV, extra_attr=extra_attr)
+          args,
+          decorator,
+          InstType.VV,
+          extra_attr=extra_attr,
+          required_ext=required_ext_list)
 
       args["TYPE"] = args["TYPES2"]
       src_type_helper = TypeHelper(**args)
@@ -159,7 +169,11 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
       if args["TYPES1"] != args["TYPES3"] and args["TYPES3"] == "f":
         args["OP"] = args["OP"] + "_rtz"
         inst_info = InstInfo.get(
-            args, decorator, InstType.VV, extra_attr=extra_attr)
+            args,
+            decorator,
+            InstType.VV,
+            extra_attr=extra_attr,
+            required_ext=required_ext_list)
         func_name =\
           "{OP}_{TYPES1}_{TYPES3}_{MIDDLE}_{D_TYPE}{LSEW}m{LLMUL}".format_map\
           (args)
@@ -175,7 +189,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
       if op == "ncvt" and args["TYPES1"] == "f" and args["TYPES3"] == "f":
         args["OP"] = args["OP"] + "_rod"
         inst_info = \
-          InstInfo.get(args, decorator, InstType.VV, extra_attr=extra_attr)
+          InstInfo.get(args, decorator, InstType.VV, extra_attr=extra_attr,
+                       required_ext = required_ext_list)
         func_name = \
           "{OP}_{TYPES1}_{TYPES3}_{MIDDLE}_{D_TYPE}{LSEW}m{LLMUL}".format_map\
           (args)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/get_set_diff_lmul_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/get_set_diff_lmul_op_template.py
@@ -50,8 +50,14 @@ def vset_constraint(**kargs):
          and int(kargs["LMUL"]) > int(kargs["SRC_LMUL"])
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)
@@ -84,14 +90,16 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
           args)
       if vget:
         G.func(
-            InstInfo.get(args, decorator, InstType.VGET),
+            InstInfo.get(
+                args, decorator, InstType.VGET, required_ext=required_ext_list),
             name=func_name,
             return_type=type_helper.v,
             src=src_type,
             index=type_helper.size_t)
       else:
         G.func(
-            InstInfo.get(args, decorator, InstType.VSET),
+            InstInfo.get(
+                args, decorator, InstType.VSET, required_ext=required_ext_list),
             name=func_name,
             return_type=type_helper.v,
             dest=type_helper.v,
@@ -115,7 +123,11 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
           func_name = "{OP}_v_{TYPE}{SEW}m{LMUL}x{NF}_{TYPE}{SEW}m{LMUL}".\
               format_map(args)
           G.func(
-              InstInfo.get(args, decorator, InstType.VGET),
+              InstInfo.get(
+                  args,
+                  decorator,
+                  InstType.VGET,
+                  required_ext=required_ext_list),
               name=func_name,
               return_type=vector_type,
               src=tuple_type,
@@ -124,7 +136,11 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
           func_name = "{OP}_v_{TYPE}{SEW}m{LMUL}_{TYPE}{SEW}m{LMUL}x{NF}".\
               format_map(args)
           G.func(
-              InstInfo.get(args, decorator, InstType.VSET),
+              InstInfo.get(
+                  args,
+                  decorator,
+                  InstType.VSET,
+                  required_ext=required_ext_list),
               name=func_name,
               return_type=tuple_type,
               dest=tuple_type,

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/load_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/load_template.py
@@ -29,8 +29,14 @@ from enums import MemType
 from enums import ExtraAttr
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)
@@ -70,7 +76,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
       if op not in ["vloxei", "vluxei"] and sew != eew:
         continue
       inst_info =\
-      InstInfo.get(args, decorator, inst_type, MemType.LOAD, extra_attr)
+      InstInfo.get(args, decorator, inst_type, MemType.LOAD, extra_attr,
+                   required_ext = required_ext_list)
       G.func(
           inst_info,
           name=\

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mac_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mac_template.py
@@ -27,8 +27,14 @@ from enums import InstType
 from enums import ExtraAttr
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)
@@ -58,11 +64,23 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
       args["OP"] = "v" + args["OP"]
 
       inst_info_vs = InstInfo.get(
-          args, decorator, inst_type, extra_attr=ExtraAttr.MAC)
+          args,
+          decorator,
+          inst_type,
+          extra_attr=ExtraAttr.MAC,
+          required_ext=required_ext_list)
       inst_info_vv = InstInfo.get(
-          args, decorator, InstType.VVV, extra_attr=ExtraAttr.MAC)
+          args,
+          decorator,
+          InstType.VVV,
+          extra_attr=ExtraAttr.MAC,
+          required_ext=required_ext_list)
       inst_info_vx = InstInfo.get(
-          args, decorator, InstType.VVX, extra_attr=ExtraAttr.MAC)
+          args,
+          decorator,
+          InstType.VVX,
+          extra_attr=ExtraAttr.MAC,
+          required_ext=required_ext_list)
 
       type_helper = TypeHelper(**args)
       if (("maccsu" in op) or ("maccus" in op)) and data_type == "uint":

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mask_load_store_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mask_load_store_template.py
@@ -26,8 +26,14 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name, unused-argument
   # FIXME: Renaming 'G' to 'g' all in once later.
   # FIXME: Argument 'lmul_list' is unused but required for interface
@@ -43,7 +49,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
 
       load_p = op == "vlm"
 
-      inst_info = InstInfo.get(args, decorator, InstType.V)
+      inst_info = InstInfo.get(
+          args, decorator, InstType.V, required_ext=required_ext_list)
 
       if load_p:
         base_type = "const uint8_t *"

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mask_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mask_template.py
@@ -25,8 +25,14 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)
@@ -46,8 +52,10 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
 
       args["OP"] = "v" + args["OP"]
 
-      inst_info_mm = InstInfo.get(args, decorator, InstType.MMM)
-      inst_info_m = InstInfo.get(args, decorator, InstType.MM)
+      inst_info_mm = InstInfo.get(
+          args, decorator, InstType.MMM, required_ext=required_ext_list)
+      inst_info_m = InstInfo.get(
+          args, decorator, InstType.MM, required_ext=required_ext_list)
 
       if op in ["mv", "not"]:  # unary operator
         G.func(
@@ -105,7 +113,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
 
       if op == "iota":
         G.func(
-            InstInfo.get(args, decorator, InstType.MM),
+            InstInfo.get(args, decorator, InstType.MM,
+                         required_ext = required_ext_list),
             name=\
             "viota_m_u{SEW}m{LMUL}".format_map(args) + decorator.func_suffix,
             return_type=type_helper.uiv,
@@ -115,7 +124,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
             vl=type_helper.size_t)
       if op == "id":
         G.func(
-            InstInfo.get(args, decorator, InstType.VM),
+            InstInfo.get(
+                args, decorator, InstType.VM, required_ext=required_ext_list),
             name="vid_v_u{SEW}m{LMUL}".format_map(args) + decorator.func_suffix,
             return_type=type_helper.uiv,
             **decorator.mask_args(type_helper.m, type_helper.uiv),

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/misc_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/misc_op_template.py
@@ -30,8 +30,14 @@ from enums import InstType
 from generator import CompatibleHeaderGenerator
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)
@@ -53,7 +59,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
       if args["OP"] == "vundefined":
         inst_type = InstType.VUNDEF
       G.func(
-          InstInfo.get(args, decorator, inst_type),
+          InstInfo.get(
+              args, decorator, inst_type, required_ext=required_ext_list),
           name="{OP}_{TYPE}{SEW}m{LMUL}".format_map(args) +
           decorator.func_suffix,
           return_type=type_helper.v)
@@ -84,7 +91,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
       if args["OP"] == "vundefined":
         inst_type = InstType.VUNDEF
       G.func(
-          InstInfo.get(args, decorator, inst_type),
+          InstInfo.get(
+              args, decorator, inst_type, required_ext=required_ext_list),
           name="{OP}_{TYPE}{SEW}m{LMUL}x{NF}".format_map(args) +
           decorator.func_suffix,
           return_type=type_helper.tuple_v)
@@ -111,7 +119,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
         if get_float_lmul(src_lmul) >= get_float_lmul(dst_lmul):
           continue
       type_helper = TypeHelper(**args)
-      inst_info = InstInfo.get(args, decorator, inst_type)
+      inst_info = InstInfo.get(
+          args, decorator, inst_type, required_ext=required_ext_list)
       if args["TYPE"] == "bfloat":
         args["TYPE1"] = args["TYPE"][0:2]
       else:
@@ -143,7 +152,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
         DST_LMUL=lmul_list):
 
       type_helper = TypeHelper(**args)
-      inst_info = InstInfo.get(args, decorator, InstType.VCREATE)
+      inst_info = InstInfo.get(
+          args, decorator, InstType.VCREATE, required_ext=required_ext_list)
       func_name = "{OP}_v_{TYPE}{SEW}m{LMUL}_{TYPE}{SEW}m{DST_LMUL}".format_map(
           args)
 
@@ -192,7 +202,9 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
         args_for_vcreate[arg_name] = type_helper.v
 
       G.func(
-          InstInfo.get(args, decorator, InstType.VCREATE),
+          InstInfo.get(
+              args, decorator, InstType.VCREATE,
+              required_ext=required_ext_list),
           name="{OP}_v_{TYPE}{SEW}m{LMUL}x{NF}".format_map(args),
           return_type=type_helper.tuple_v,
           **args_for_vcreate)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/permute_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/permute_template.py
@@ -26,8 +26,14 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)
@@ -59,13 +65,16 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
       if op == "mv":
         if decorator.func_suffix == "":
           G.func(
-              InstInfo.get(args, decorator, sv_inst_type),
+              InstInfo.get(
+                  args, decorator, sv_inst_type,
+                  required_ext=required_ext_list),
               name="{OP}_{S_TYPE}_s_{TYPE}{SEW}m{LMUL}_{TYPE}{SEW}".format_map(
                   args),
               return_type=type_helper.s,
               vs1=type_helper.v)
         G.func(
-            InstInfo.get(args, decorator, vs_inst_type),
+            InstInfo.get(
+                args, decorator, vs_inst_type, required_ext=required_ext_list),
             name="{OP}_s_{S_TYPE}_{TYPE}{SEW}m{LMUL}".format_map(args) +
             decorator.func_suffix,
             return_type=type_helper.v,
@@ -74,7 +83,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
             vl=type_helper.size_t)
       elif op in ["slide1up", "slide1down"]:
         G.func(
-            InstInfo.get(args, decorator, vvs_inst_type),
+            InstInfo.get(
+                args, decorator, vvs_inst_type, required_ext=required_ext_list),
             name="{OP}_v{S_TYPE}_{TYPE}{SEW}m{LMUL}".format_map(args) +
             decorator.func_suffix,
             return_type=type_helper.v,
@@ -85,7 +95,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
             vl=type_helper.size_t)
       elif op == "slideup":
         G.func(
-            InstInfo.get(args, decorator, InstType.VVX),
+            InstInfo.get(
+                args, decorator, InstType.VVX, required_ext=required_ext_list),
             name="{OP}_v{S_TYPE}_{TYPE}{SEW}m{LMUL}".format_map(args) +
             decorator.func_suffix,
             return_type=type_helper.v,
@@ -96,7 +107,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
             vl=type_helper.size_t)
       elif op == "slidedown":
         G.func(
-            InstInfo.get(args, decorator, InstType.VVX),
+            InstInfo.get(
+                args, decorator, InstType.VVX, required_ext=required_ext_list),
             name="{OP}_v{S_TYPE}_{TYPE}{SEW}m{LMUL}".format_map(args) +
             decorator.func_suffix,
             return_type=type_helper.v,
@@ -107,7 +119,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
             vl=type_helper.size_t)
       elif op == "compress":
         G.func(
-            InstInfo.get(args, decorator, InstType.VVV),
+            InstInfo.get(
+                args, decorator, InstType.VVV, required_ext=required_ext_list),
             name="{OP}_vm_{TYPE}{SEW}m{LMUL}".format_map(args) +
             decorator.func_suffix,
             return_type=type_helper.v,

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/reduction_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/reduction_template.py
@@ -27,8 +27,14 @@ from enums import InstType
 from enums import ExtraAttr
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)
@@ -66,7 +72,11 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
       args["OP"] = "v" + args["OP"]
 
       inst_info = InstInfo.get(
-          args, decorator, inst_type, extra_attr=ExtraAttr.REDUCE)
+          args,
+          decorator,
+          inst_type,
+          extra_attr=ExtraAttr.REDUCE,
+          required_ext=required_ext_list)
       if (data_type == "float" and
           op in ["redosum","redusum","redmax","redmin","wredosum","wredusum"])\
          or ("int" in data_type):

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/reint_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/reint_op_template.py
@@ -27,8 +27,14 @@ from enums import InstType
 from generator import CompatibleHeaderGenerator
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name, unused-argument
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)
@@ -74,7 +80,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
         "{OP}_v_{TYPES3}{SEW}m{LMUL}_{TYPES1}{SEW}m{LMUL}".format_map(args)
       src_type = "v{TYPES2}{SEW}m{LMUL}_t".format_map(args)
       G.func(
-          InstInfo.get(args, decorator, InstType.REINT),
+          InstInfo.get(
+              args, decorator, InstType.REINT, required_ext=required_ext_list),
           name=func_name + decorator.func_suffix,
           return_type=rt,
           **decorator.mask_args(type_helper.m, rt),
@@ -114,7 +121,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
         "{OP}_v_{TYPES3}{SEW}m{LMUL}_{TYPES1}{DST_SEW}m{LMUL}".format_map(args)
       src_type = "v{TYPES2}{SEW}m{LMUL}_t".format_map(args)
       G.func(
-          InstInfo.get(args, decorator, InstType.REINT),
+          InstInfo.get(
+              args, decorator, InstType.REINT, required_ext=required_ext_list),
           name=func_name + decorator.func_suffix,
           return_type=rt,
           **decorator.mask_args(type_helper.m, rt),
@@ -145,7 +153,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
       func_name =\
         "{OP}_v_{TYPES1}{SEW}m1_b{MLEN}".format_map(args)
       G.func(
-          InstInfo.get(args, decorator, InstType.REINT),
+          InstInfo.get(
+              args, decorator, InstType.REINT, required_ext=required_ext_list),
           name=func_name + decorator.func_suffix,
           return_type=mask_type,
           src=int_type)
@@ -153,7 +162,8 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
       func_name =\
         "{OP}_v_b{MLEN}_{TYPES1}{SEW}m1".format_map(args)
       G.func(
-          InstInfo.get(args, decorator, InstType.REINT),
+          InstInfo.get(
+              args, decorator, InstType.REINT, required_ext=required_ext_list),
           name=func_name + decorator.func_suffix,
           return_type=int_type,
           src=mask_type)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_load_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_load_template.py
@@ -32,8 +32,14 @@ from enums import MemType
 from generator import CompatibleHeaderGenerator
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)
@@ -80,7 +86,12 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
       else:
         args["OP"] = op + nf + "e" + str(eew)
 
-      inst_info = InstInfo.get(args, decorator, inst_type, MemType.LOAD)
+      inst_info = InstInfo.get(
+          args,
+          decorator,
+          inst_type,
+          MemType.LOAD,
+          required_ext=required_ext_list)
       # Legacy non-tuple-type variant for the compatible header
       if isinstance(G, CompatibleHeaderGenerator):
         G.func(

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_store_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_store_template.py
@@ -32,8 +32,14 @@ from enums import MemType
 from generator import CompatibleHeaderGenerator
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)
@@ -77,7 +83,12 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
       else:
         args["OP"] = op + nf + "e" + str(eew)
 
-      inst_info = InstInfo.get(args, decorator, inst_type, MemType.STORE)
+      inst_info = InstInfo.get(
+          args,
+          decorator,
+          inst_type,
+          MemType.STORE,
+          required_ext=required_ext_list)
       # Legacy non-tuple-type variant for the compatible header
       if isinstance(G, CompatibleHeaderGenerator):
         G.func(

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/setvl_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/setvl_template.py
@@ -25,8 +25,14 @@ from enums import InstInfo
 from enums import InstType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name, unused-argument
   # FIXME: Renaming 'G' to 'g' all in once later.
   # FIXME: Argument 'type_list', 'decorator_list' is unused but required for
@@ -38,12 +44,14 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
 
     if args["OP"] == "vsetvlmax":
       G.func(
-          InstInfo.get(args, None, InstType.SETVLMAX),
+          InstInfo.get(
+              args, None, InstType.SETVLMAX, required_ext=required_ext_list),
           name="{OP}_e{SEW}m{LMUL}".format_map(args),
           return_type=type_helper.size_t)
     else:  #vsetvl
       G.func(
-          InstInfo.get(args, None, InstType.SETVL),
+          InstInfo.get(
+              args, None, InstType.SETVL, required_ext=required_ext_list),
           name="{OP}_e{SEW}m{LMUL}".format_map(args),
           return_type=type_helper.size_t,
           avl=type_helper.size_t)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/store_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/store_template.py
@@ -28,8 +28,14 @@ from enums import InstType
 from enums import MemType
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)
@@ -62,7 +68,12 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
       if op not in ["vsoxei", "vsuxei"] and sew != eew:
         continue
 
-      inst_info = InstInfo.get(args, decorator, inst_type, MemType.STORE)
+      inst_info = InstInfo.get(
+          args,
+          decorator,
+          inst_type,
+          MemType.STORE,
+          required_ext=required_ext_list)
       G.func(
           inst_info,
           name="{OP}_v_{TYPE}{SEW}m{LMUL}".format_map(args) +

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/unary_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/unary_op_template.py
@@ -28,8 +28,14 @@ from enums import ExtraAttr
 import copy
 
 
-def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
-           description):
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
   #pylint: disable=invalid-name
   # FIXME: Renaming 'G' to 'g' all in once later.
   G.emit_function_group_description(description)
@@ -63,11 +69,23 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
         extra_attr = ExtraAttr.NO_ATTR
 
       inst_info_vv = InstInfo.get(
-          args, decorator, InstType.VV, extra_attr=extra_attr)
+          args,
+          decorator,
+          InstType.VV,
+          extra_attr=extra_attr,
+          required_ext=required_ext_list)
       inst_info_vs = InstInfo.get(
-          args, decorator, inst_type_vs, extra_attr=extra_attr)
+          args,
+          decorator,
+          inst_type_vs,
+          extra_attr=extra_attr,
+          required_ext=required_ext_list)
       inst_info_vvsm = InstInfo.get(
-          args, decorator, inst_type_vvsm, extra_attr=extra_attr)
+          args,
+          decorator,
+          inst_type_vvsm,
+          extra_attr=extra_attr,
+          required_ext=required_ext_list)
 
       # Special rule for vfmv_v_v, we don"t have vfmv.v.v but vmv.v.v can used
       # for float type, accrdoing current naming scheming it
@@ -80,7 +98,11 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
       if op == "merge":
         G.func(
             InstInfo.get(
-                vv_args, decorator, InstType.VVVM, extra_attr=extra_attr),
+                vv_args,
+                decorator,
+                InstType.VVVM,
+                extra_attr=extra_attr,
+                required_ext=required_ext_list),
             name="{OP}_vvm_{TYPE}{SEW}m{LMUL}".format_map(vv_args) +
             decorator.func_suffix,
             return_type=type_helper.v,
@@ -101,7 +123,9 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
             vl=type_helper.size_t)
       elif op == "mv":
         G.func(
-            InstInfo.get(vv_args, decorator, InstType.VV),
+            InstInfo.get(
+                vv_args, decorator, InstType.VV,
+                required_ext=required_ext_list),
             name="{OP}_v_v_{TYPE}{SEW}m{LMUL}".format_map(vv_args) +
             decorator.func_suffix,
             return_type=type_helper.v,
@@ -192,7 +216,11 @@ def render(G, op_list, type_list, sew_list, lmul_list, decorator_list,
         continue
 
       inst_info_v = InstInfo.get(
-          args, decorator, inst_type, extra_attr=ExtraAttr.INT_EXTENSION)
+          args,
+          decorator,
+          inst_type,
+          extra_attr=ExtraAttr.INT_EXTENSION,
+          required_ext=required_ext_list)
 
       G.func(
           inst_info_v,

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/vector_crypto_inst.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/vector_crypto_inst.py
@@ -20,7 +20,8 @@ def gen(g):
       UITYPE,
       SEWS,
       LMULS,
-      decorators.has_masking_maskedoff_policy)
+      decorators.has_masking_maskedoff_policy,
+      required_ext_list=["zvbb"])
 
   g.function_group(
       vector_crypto_template,
@@ -30,7 +31,8 @@ def gen(g):
       UITYPE,
       SEWS,
       LMULS,
-      decorators.has_masking_maskedoff_policy)
+      decorators.has_masking_maskedoff_policy,
+      required_ext_list=["zvbb"])
 
   g.function_group(
       vector_crypto_template,
@@ -40,7 +42,8 @@ def gen(g):
       UITYPE,
       SEWS,
       LMULS,
-      decorators.has_masking_maskedoff_policy)
+      decorators.has_masking_maskedoff_policy,
+      required_ext_list=["zvbb"])
 
   g.function_group(
       vector_crypto_template,
@@ -50,7 +53,8 @@ def gen(g):
       UITYPE,
       SEWS,
       LMULS,
-      decorators.has_masking_maskedoff_policy)
+      decorators.has_masking_maskedoff_policy,
+      required_ext_list=["zvbb"])
 
   g.function_group(
       vector_crypto_template,
@@ -60,7 +64,8 @@ def gen(g):
       UITYPE,
       SEWS,
       LMULS,
-      decorators.has_masking_maskedoff_policy)
+      decorators.has_masking_maskedoff_policy,
+      required_ext_list=["zvkb"])
 
   g.function_group(
       vector_crypto_template,
@@ -70,7 +75,8 @@ def gen(g):
       UITYPE,
       WSEWS,
       WLMULS,
-      decorators.has_masking_maskedoff_policy)
+      decorators.has_masking_maskedoff_policy,
+      required_ext_list=["zvbb"])
 
   ####################################################################
 
@@ -84,7 +90,8 @@ def gen(g):
       UITYPE,
       [64],
       LMULS,
-      decorators.has_masking_maskedoff_policy)
+      decorators.has_masking_maskedoff_policy,
+      required_ext_list=["zvbc"])
 
   ####################################################################
 
@@ -98,7 +105,8 @@ def gen(g):
       UITYPE,
       [32],
       LMULS,
-      decorators.has_no_masking_policy)
+      decorators.has_no_masking_policy,
+      required_ext_list=["zvkg"])
 
   ####################################################################
 
@@ -112,7 +120,8 @@ def gen(g):
       UITYPE,
       [32],
       LMULS,
-      decorators.has_no_masking_policy)
+      decorators.has_no_masking_policy,
+      required_ext_list=["zvkned"])
 
   g.function_group(
       vector_crypto_template,
@@ -122,7 +131,8 @@ def gen(g):
       UITYPE,
       [32],
       LMULS,
-      decorators.has_no_masking_policy)
+      decorators.has_no_masking_policy,
+      required_ext_list=["zvkned"])
 
   g.function_group(
       vector_crypto_template,
@@ -132,7 +142,8 @@ def gen(g):
       UITYPE,
       [32],
       LMULS,
-      decorators.has_no_masking_policy)
+      decorators.has_no_masking_policy,
+      required_ext_list=["zvkned"])
 
   g.function_group(
       vector_crypto_template,
@@ -142,12 +153,15 @@ def gen(g):
       UITYPE,
       [32],
       LMULS,
-      decorators.has_no_masking_policy)
+      decorators.has_no_masking_policy,
+      required_ext_list=["zvkned"])
 
   ####################################################################
 
   g.start_group("Zvknh - NIST Suite: Vector SHA-2 Secure Hash")
 
+  # We need extra condition to check if zvknhb is required
+  # If SEW=64, then zvknhb is required
   g.function_group(
       vector_crypto_template,
       "Vector SHA-2 message schedule",
@@ -156,7 +170,8 @@ def gen(g):
       UITYPE,
       [32, 64],
       LMULS,
-      decorators.has_no_masking_policy)
+      decorators.has_no_masking_policy,
+      required_ext_list=["zvknha"])
 
   g.function_group(
       vector_crypto_template,
@@ -166,7 +181,8 @@ def gen(g):
       UITYPE,
       [32, 64],
       LMULS,
-      decorators.has_no_masking_policy)
+      decorators.has_no_masking_policy,
+      required_ext_list=["zvknha"])
 
   ####################################################################
 
@@ -180,7 +196,8 @@ def gen(g):
       UITYPE,
       [32],
       LMULS,
-      decorators.has_no_masking_policy)
+      decorators.has_no_masking_policy,
+      required_ext_list=["zvksed"])
 
   g.function_group(
       vector_crypto_template,
@@ -190,7 +207,8 @@ def gen(g):
       UITYPE,
       [32],
       LMULS,
-      decorators.has_no_masking_policy)
+      decorators.has_no_masking_policy,
+      required_ext_list=["zvksed"])
 
   ####################################################################
 
@@ -204,7 +222,8 @@ def gen(g):
       UITYPE,
       [32],
       LMULS,
-      decorators.has_no_masking_policy)
+      decorators.has_no_masking_policy,
+      required_ext_list=["zvksh"])
 
   g.function_group(
       vector_crypto_template,
@@ -214,7 +233,8 @@ def gen(g):
       UITYPE,
       [32],
       LMULS,
-      decorators.has_no_masking_policy)
+      decorators.has_no_masking_policy,
+      required_ext_list=["zvksh"])
 
 
 ####################################################################


### PR DESCRIPTION
- Add a new field to store required extensions into a list
- Add required extension information for Zvk extensions
- Generate LLVM API test header dynamically based on required extensions
- Replace hardcoded LLVM header for Zvk and dynamically generate it
- Replaces #355 

Signed-off-by: Jerry Zhang Jian <jerry.zhangjian@sifive.com>