### PR TITLE
[1/n] add required extension support, BFloat16

### DIFF
--- a/auto-generated/bfloat16/llvm-api-tests/vcreate.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vcreate.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vfncvtbf16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vfncvtbf16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vfwcvtbf16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vfwcvtbf16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64f \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vfwmaccbf16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vfwmaccbf16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
-// RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvfbfwma \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vget.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vget.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vle16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vle16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vle16ff.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vle16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlmul_ext_v.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlmul_ext_v.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlmul_trunc_v.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlmul_trunc_v.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vloxei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vloxei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vloxseg2ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vloxseg2ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vloxseg3ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vloxseg3ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vloxseg4ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vloxseg4ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vloxseg5ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vloxseg5ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vloxseg6ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vloxseg6ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vloxseg7ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vloxseg7ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vloxseg8ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vloxseg8ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlse16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlse16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg2e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg2e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg2e16ff.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg2e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg3e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg3e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg3e16ff.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg3e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg4e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg4e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg4e16ff.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg4e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg5e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg5e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg5e16ff.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg5e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg6e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg6e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg6e16ff.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg6e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg7e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg7e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg7e16ff.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg7e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg8e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg8e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlseg8e16ff.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlseg8e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlsseg2e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlsseg2e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlsseg3e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlsseg3e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlsseg4e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlsseg4e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlsseg5e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlsseg5e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlsseg6e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlsseg6e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlsseg7e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlsseg7e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vlsseg8e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vlsseg8e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vluxei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vluxei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vluxseg2ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vluxseg2ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vluxseg3ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vluxseg3ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vluxseg4ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vluxseg4ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vluxseg5ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vluxseg5ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vluxseg6ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vluxseg6ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vluxseg7ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vluxseg7ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vluxseg8ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vluxseg8ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vreinterpret.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vreinterpret.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vse16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vse16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vset.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vset.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsoxei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsoxei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsoxseg2ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsoxseg2ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsoxseg3ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsoxseg3ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsoxseg4ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsoxseg4ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsoxseg5ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsoxseg5ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsoxseg6ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsoxseg6ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsoxseg7ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsoxseg7ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsoxseg8ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsoxseg8ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsse16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsse16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsseg2e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsseg2e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsseg3e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsseg3e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsseg4e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsseg4e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsseg5e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsseg5e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsseg6e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsseg6e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsseg7e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsseg7e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsseg8e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsseg8e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vssseg2e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vssseg2e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vssseg3e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vssseg3e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vssseg4e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vssseg4e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vssseg5e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vssseg5e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vssseg6e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vssseg6e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vssseg7e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vssseg7e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vssseg8e16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vssseg8e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsuxei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsuxei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsuxseg2ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsuxseg2ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsuxseg3ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsuxseg3ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsuxseg4ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsuxseg4ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsuxseg5ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsuxseg5ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsuxseg6ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsuxseg6ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsuxseg7ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsuxseg7ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vsuxseg8ei16.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vsuxseg8ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-api-tests/vundefined.c
+++ b/auto-generated/bfloat16/llvm-api-tests/vundefined.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vfncvtbf16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vfncvtbf16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vfwcvtbf16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vfwcvtbf16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64f \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vfwmaccbf16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vfwmaccbf16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
-// RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvfbfwma \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vget.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vget.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vle16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vle16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vle16ff.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vle16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlmul_ext_v.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlmul_ext_v.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlmul_trunc_v.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlmul_trunc_v.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vloxei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vloxei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg2ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg2ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg3ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg3ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg4ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg4ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg5ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg5ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg6ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg6ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg7ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg7ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg8ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vloxseg8ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlse16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlse16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg2e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg2e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg2e16ff.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg2e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg3e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg3e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg3e16ff.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg3e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg4e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg4e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg4e16ff.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg4e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg5e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg5e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg5e16ff.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg5e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg6e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg6e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg6e16ff.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg6e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg7e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg7e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg7e16ff.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg7e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg8e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg8e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlseg8e16ff.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlseg8e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg2e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg2e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg3e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg3e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg4e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg4e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg5e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg5e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg6e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg6e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg7e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg7e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg8e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vlsseg8e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vluxei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vluxei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg2ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg2ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg3ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg3ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg4ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg4ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg5ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg5ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg6ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg6ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg7ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg7ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg8ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vluxseg8ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vreinterpret.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vreinterpret.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vse16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vse16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vset.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vset.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsoxei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsoxei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg2ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg2ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg3ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg3ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg4ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg4ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg5ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg5ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg6ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg6ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg7ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg7ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg8ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsoxseg8ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsse16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsse16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsseg2e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsseg2e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsseg3e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsseg3e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsseg4e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsseg4e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsseg5e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsseg5e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsseg6e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsseg6e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsseg7e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsseg7e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsseg8e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsseg8e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vssseg2e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vssseg2e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vssseg3e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vssseg3e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vssseg4e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vssseg4e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vssseg5e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vssseg5e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vssseg6e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vssseg6e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vssseg7e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vssseg7e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vssseg8e16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vssseg8e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsuxei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsuxei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg2ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg2ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg3ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg3ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg4ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg4ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg5ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg5ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg6ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg6ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg7ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg7ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg8ei16.c
+++ b/auto-generated/bfloat16/llvm-overloaded-tests/vsuxseg8ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vfncvtbf16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vfncvtbf16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vfwcvtbf16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vfwcvtbf16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64f \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vfwmaccbf16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vfwmaccbf16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
-// RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvfbfwma \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vle16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vle16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vle16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vle16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg2ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg2ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg3ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg3ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg4ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg4ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg5ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg5ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg6ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg6ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg7ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg7ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg8ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vloxseg8ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlse16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlse16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg2e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg2e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg2e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg2e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg3e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg3e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg3e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg3e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg4e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg4e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg4e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg4e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg5e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg5e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg5e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg5e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg6e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg6e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg6e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg6e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg7e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg7e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg7e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg7e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg8e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg8e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg8e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlseg8e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg2e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg2e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg3e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg3e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg4e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg4e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg5e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg5e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg6e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg6e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg7e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg7e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg8e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vlsseg8e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg2ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg2ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg3ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg3ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg4ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg4ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg5ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg5ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg6ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg6ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg7ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg7ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg8ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-api-tests/vluxseg8ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vfncvtbf16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vfncvtbf16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vfwcvtbf16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vfwcvtbf16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64f \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vfwmaccbf16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vfwmaccbf16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
-// RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
+// RUN:   -target-feature +zvfbfwma \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vle16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vle16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vle16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vle16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg2ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg2ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg3ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg3ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg4ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg4ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg5ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg5ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg6ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg6ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg7ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg7ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg8ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vloxseg8ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlse16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlse16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg2e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg2e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg2e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg2e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg3e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg3e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg3e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg3e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg4e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg4e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg4e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg4e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg5e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg5e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg5e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg5e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg6e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg6e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg6e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg6e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg7e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg7e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg7e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg7e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg8e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg8e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg8e16ff.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlseg8e16ff.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg2e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg2e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg3e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg3e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg4e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg4e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg5e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg5e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg6e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg6e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg7e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg7e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg8e16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vlsseg8e16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg2ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg2ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg3ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg3ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg4ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg4ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg5ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg5ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg6ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg6ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg7ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg7ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg8ei16.c
+++ b/auto-generated/bfloat16/policy_funcs/llvm-overloaded-tests/vluxseg8ei16.c
@@ -1,7 +1,8 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 -target-feature +v \
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zve64x \
 // RUN:   -target-feature +zvfbfmin \
-// RUN:   -target-feature +zvfbfwma -disable-O0-optnone \
+// RUN:   -target-feature +experimental \
 // RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
 // RUN:   FileCheck --check-prefix=CHECK-RV64 %s
 

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/bfloat16_inst.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/bfloat16_inst.py
@@ -45,118 +45,247 @@ def gen(g):
   ####################################################################
   g.start_group("BFloat16 Vector Loads and Stores Intrinsics")
 
-  g.function_group(load_template, "Vector Unit-Stride Load Intrinsics",
-                   "bf16-vector-unit-stride-load", ["vle"], BFTYPES, SEWS,
-                   LMULS, decorators.has_masking_maskedoff_policy)
+  g.function_group(
+      load_template,
+      "Vector Unit-Stride Load Intrinsics",
+      "bf16-vector-unit-stride-load", ["vle"],
+      BFTYPES,
+      SEWS,
+      LMULS,
+      decorators.has_masking_maskedoff_policy,
+      required_ext_list=["zvfbfmin"])
 
-  g.function_group(store_template, "Vector Unit-Stride Store Intrinsics",
-                   "bf16-vector-unit-stride-store", ["vse"], BFTYPES, SEWS,
-                   LMULS, decorators.has_masking_no_maskedoff)
+  g.function_group(
+      store_template,
+      "Vector Unit-Stride Store Intrinsics",
+      "bf16-vector-unit-stride-store", ["vse"],
+      BFTYPES,
+      SEWS,
+      LMULS,
+      decorators.has_masking_no_maskedoff,
+      required_ext_list=["zvfbfmin"])
 
-  g.function_group(load_template, "Vector Strided Load Intrinsics",
-                   "vector-strided-load", ["vlse"], BFTYPES, SEWS, LMULS,
-                   decorators.has_masking_maskedoff_policy)
+  g.function_group(
+      load_template,
+      "Vector Strided Load Intrinsics",
+      "vector-strided-load", ["vlse"],
+      BFTYPES,
+      SEWS,
+      LMULS,
+      decorators.has_masking_maskedoff_policy,
+      required_ext_list=["zvfbfmin"])
 
-  g.function_group(store_template, "Vector Strided Store Intrinsics",
-                   "vector-strided-store", ["vsse"], BFTYPES, SEWS, LMULS,
-                   decorators.has_masking_no_maskedoff)
+  g.function_group(
+      store_template,
+      "Vector Strided Store Intrinsics",
+      "vector-strided-store", ["vsse"],
+      BFTYPES,
+      SEWS,
+      LMULS,
+      decorators.has_masking_no_maskedoff,
+      required_ext_list=["zvfbfmin"])
 
-  g.function_group(load_template, "Vector Indexed Load Intrinsics",
-                   "vector-indexed-load", ["vloxei", "vluxei"], BFTYPES, SEWS,
-                   LMULS, decorators.has_masking_maskedoff_policy)
+  g.function_group(
+      load_template,
+      "Vector Indexed Load Intrinsics",
+      "vector-indexed-load", ["vloxei", "vluxei"],
+      BFTYPES,
+      SEWS,
+      LMULS,
+      decorators.has_masking_maskedoff_policy,
+      required_ext_list=["zvfbfmin"])
 
-  g.function_group(store_template, "Vector Indexed Store Intrinsics",
-                   "vector-indexed-store", ["vsoxei", "vsuxei"], BFTYPES, SEWS,
-                   LMULS, decorators.has_masking_no_maskedoff)
+  g.function_group(
+      store_template,
+      "Vector Indexed Store Intrinsics",
+      "vector-indexed-store", ["vsoxei", "vsuxei"],
+      BFTYPES,
+      SEWS,
+      LMULS,
+      decorators.has_masking_no_maskedoff,
+      required_ext_list=["zvfbfmin"])
 
-  g.function_group(load_template,
-                   "Unit-stride Fault-Only-First Loads Intrinsics",
-                   "unit-stride-fault-only-first-loads", ["vleff"], BFTYPES,
-                   SEWS, LMULS, decorators.has_masking_maskedoff_policy)
+  g.function_group(
+      load_template,
+      "Unit-stride Fault-Only-First Loads Intrinsics",
+      "unit-stride-fault-only-first-loads", ["vleff"],
+      BFTYPES,
+      SEWS,
+      LMULS,
+      decorators.has_masking_maskedoff_policy,
+      required_ext_list=["zvfbfmin"])
 
   ####################################################################
   g.start_group("BFloat16 Vector Loads and Stores Segment Intrinsics")
 
-  g.function_group(seg_load_template,
-                   "Vector Unit-Stride Segment Load Intrinsics",
-                   "vector-unit-stride-segment-load", ["vlseg", "vlsegff"],
-                   BFTYPES, SEWS, LMULS,
-                   decorators.has_masking_maskedoff_policy)
+  g.function_group(
+      seg_load_template,
+      "Vector Unit-Stride Segment Load Intrinsics",
+      "vector-unit-stride-segment-load", ["vlseg", "vlsegff"],
+      BFTYPES,
+      SEWS,
+      LMULS,
+      decorators.has_masking_maskedoff_policy,
+      required_ext_list=["zvfbfmin"])
 
-  g.function_group(seg_store_template,
-                   "Vector Unit-Stride Segment Store Intrinsics",
-                   "vecrtor-unit-stride-segment-store", ["vsseg"], BFTYPES,
-                   SEWS, LMULS, decorators.has_masking_no_maskedoff)
+  g.function_group(
+      seg_store_template,
+      "Vector Unit-Stride Segment Store Intrinsics",
+      "vecrtor-unit-stride-segment-store", ["vsseg"],
+      BFTYPES,
+      SEWS,
+      LMULS,
+      decorators.has_masking_no_maskedoff,
+      required_ext_list=["zvfbfmin"])
 
-  g.function_group(seg_load_template, "Vector Strided Segment Load Intrinsics",
-                   "vector-strided-segment-load", ["vlsseg"], BFTYPES, SEWS,
-                   LMULS, decorators.has_masking_maskedoff_policy)
+  g.function_group(
+      seg_load_template,
+      "Vector Strided Segment Load Intrinsics",
+      "vector-strided-segment-load", ["vlsseg"],
+      BFTYPES,
+      SEWS,
+      LMULS,
+      decorators.has_masking_maskedoff_policy,
+      required_ext_list=["zvfbfmin"])
 
-  g.function_group(seg_store_template,
-                   "Vector Strided Segment Store Intrinsics",
-                   "vector-strided-segment-store", ["vssseg"], BFTYPES, SEWS,
-                   LMULS, decorators.has_masking_no_maskedoff)
+  g.function_group(
+      seg_store_template,
+      "Vector Strided Segment Store Intrinsics",
+      "vector-strided-segment-store", ["vssseg"],
+      BFTYPES,
+      SEWS,
+      LMULS,
+      decorators.has_masking_no_maskedoff,
+      required_ext_list=["zvfbfmin"])
 
-  g.function_group(seg_load_template, "Vector Indexed Segment Load Intrinsics",
-                   "vector-indexed-segment-load", ["vloxseg", "vluxseg"],
-                   BFTYPES, SEWS, LMULS,
-                   decorators.has_masking_maskedoff_policy)
+  g.function_group(
+      seg_load_template,
+      "Vector Indexed Segment Load Intrinsics",
+      "vector-indexed-segment-load", ["vloxseg", "vluxseg"],
+      BFTYPES,
+      SEWS,
+      LMULS,
+      decorators.has_masking_maskedoff_policy,
+      required_ext_list=["zvfbfmin"])
 
-  g.function_group(seg_store_template,
-                   "Vector Indexed Segment Store Intrinsics",
-                   "vector-indexed-segment-store", ["vsoxseg", "vsuxseg"],
-                   BFTYPES, SEWS, LMULS, decorators.has_masking_no_maskedoff)
+  g.function_group(
+      seg_store_template,
+      "Vector Indexed Segment Store Intrinsics",
+      "vector-indexed-segment-store", ["vsoxseg", "vsuxseg"],
+      BFTYPES,
+      SEWS,
+      LMULS,
+      decorators.has_masking_no_maskedoff,
+      required_ext_list=["zvfbfmin"])
 
   ####################################################################
   g.start_group("BFloat16 Convert Intrinsics")
 
-  g.function_group(cvt_op_template, "Vector Narrowing Convert Intrinsics",
-                   "bf16-vector-narrow-convert", ["ncvtbf16"], "bfloat16",
-                   NSEWS, NCVTLMULS,
-                   decorators.has_masking_maskedoff_policy_frm)
+  g.function_group(
+      cvt_op_template,
+      "Vector Narrowing Convert Intrinsics",
+      "bf16-vector-narrow-convert", ["ncvtbf16"],
+      "bfloat16",
+      NSEWS,
+      NCVTLMULS,
+      decorators.has_masking_maskedoff_policy_frm,
+      required_ext_list=["zvfbfmin"])
 
-  g.function_group(cvt_op_template, "Vector Widening Convert Intrinsics",
-                   "bf16-vector-widening-convert", ["wcvtbf16"], "bfloat16",
-                   SEWS, WLMULS, decorators.has_masking_maskedoff_policy)
+  g.function_group(
+      cvt_op_template,
+      "Vector Widening Convert Intrinsics",
+      "bf16-vector-widening-convert", ["wcvtbf16"],
+      "bfloat16",
+      SEWS,
+      WLMULS,
+      decorators.has_masking_maskedoff_policy,
+      required_ext_list=["zvfbfmin"])
 
   ####################################################################
   g.start_group("BFloat16 Arithmetic Intrinsics")
 
-  g.function_group(mac_template,
-                   "Vector Widening Multiply-Accumulate Intrinsics",
-                   "bf16-widening-multiply-accumulate", ["wmaccbf16"], BFTYPES,
-                   SEWS, WLMULS, decorators.has_masking_no_maskedoff_policy_frm)
+  g.function_group(
+      mac_template,
+      "Vector Widening Multiply-Accumulate Intrinsics",
+      "bf16-widening-multiply-accumulate", ["wmaccbf16"],
+      BFTYPES,
+      SEWS,
+      WLMULS,
+      decorators.has_masking_no_maskedoff_policy_frm,
+      required_ext_list=["zvfbfwma"])
 
   ####################################################################
   g.start_group("BFloat16 Miscellaneous Vector Utility Intrinsics")
 
-  g.function_group(reint_op_template, "Reinterpret Cast Conversion Intrinsics",
-                   "reinterpret-cast-conversion", ["vreinterpret"], "bfloat16",
-                   SEWS, LMULS, decorators.has_no_masking)
+  g.function_group(
+      reint_op_template,
+      "Reinterpret Cast Conversion Intrinsics",
+      "reinterpret-cast-conversion", ["vreinterpret"],
+      "bfloat16",
+      SEWS,
+      LMULS,
+      decorators.has_no_masking,
+      required_ext_list=["zvfbfmin"])
 
-  g.function_group(misc_op_template, "Vector LMUL Extension Intrinsics",
-                   "vector-lmul-extensionn", ["vlmul_ext_v"], BFTYPES, SEWS,
-                   LMULS, decorators.has_no_masking)
+  g.function_group(
+      misc_op_template,
+      "Vector LMUL Extension Intrinsics",
+      "vector-lmul-extensionn", ["vlmul_ext_v"],
+      BFTYPES,
+      SEWS,
+      LMULS,
+      decorators.has_no_masking,
+      required_ext_list=["zvfbfmin"])
 
-  g.function_group(misc_op_template, "Vector LMUL Truncation Intrinsics",
-                   "vector-lmul-truncation", ["vlmul_trunc_v"], BFTYPES, SEWS,
-                   LMULS, decorators.has_no_masking)
+  g.function_group(
+      misc_op_template,
+      "Vector LMUL Truncation Intrinsics",
+      "vector-lmul-truncation", ["vlmul_trunc_v"],
+      BFTYPES,
+      SEWS,
+      LMULS,
+      decorators.has_no_masking,
+      required_ext_list=["zvfbfmin"])
 
-  g.function_group(misc_op_template, "Vector Initialization Intrinsics",
-                   "vector-initialization", ["vundefined"], BFTYPES, SEWS,
-                   LMULS, decorators.has_no_masking)
+  g.function_group(
+      misc_op_template,
+      "Vector Initialization Intrinsics",
+      "vector-initialization", ["vundefined"],
+      BFTYPES,
+      SEWS,
+      LMULS,
+      decorators.has_no_masking,
+      required_ext_list=["zvfbfmin"])
 
-  g.function_group(get_set_diff_lmul_op_template, "Vector Insertion Intrinsics",
-                   "vector-insertion", ["vset"], BFTYPES, SEWS, LMULS,
-                   decorators.has_no_masking)
+  g.function_group(
+      get_set_diff_lmul_op_template,
+      "Vector Insertion Intrinsics",
+      "vector-insertion", ["vset"],
+      BFTYPES,
+      SEWS,
+      LMULS,
+      decorators.has_no_masking,
+      required_ext_list=["zvfbfmin"])
 
-  g.function_group(get_set_diff_lmul_op_template,
-                   "Vector Extraction Intrinsics", "vector-extraction",
-                   ["vget"], BFTYPES, SEWS, LMULS, decorators.has_no_masking)
+  g.function_group(
+      get_set_diff_lmul_op_template,
+      "Vector Extraction Intrinsics",
+      "vector-extraction", ["vget"],
+      BFTYPES,
+      SEWS,
+      LMULS,
+      decorators.has_no_masking,
+      required_ext_list=["zvfbfmin"])
 
-  g.function_group(misc_op_template, "Vector Creation Intrinsics",
-                   "vector-creation", ["vcreate"], BFTYPES, SEWS, LMULS,
-                   decorators.has_no_masking)
+  g.function_group(
+      misc_op_template,
+      "Vector Creation Intrinsics",
+      "vector-creation", ["vcreate"],
+      BFTYPES,
+      SEWS,
+      LMULS,
+      decorators.has_no_masking,
+      required_ext_list=["zvfbfmin"])
 
   ####################################################################
   g.gen_prologue()

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/enums.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/enums.py
@@ -222,6 +222,7 @@ class InstInfo:
   def add_required_ext(self, ext: str) -> None:
     if ext not in self.required_ext:
       self.required_ext.append(ext)
+      self.required_ext = sorted(self.required_ext)
 
   def remove_required_ext(self, ext: str) -> None:
     if ext in self.required_ext:

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/cvt_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/cvt_op_template.py
@@ -22,6 +22,7 @@ intrinsics.
 #pylint: disable=relative-beyond-top-level
 from utils import prod
 from utils import TypeHelper
+from utils import get_required_zve
 from enums import InstInfo
 from enums import InstType
 from enums import ExtraAttr
@@ -132,6 +133,10 @@ def render(G,
       dst_type_helper = TypeHelper(**args)
       src_type = src_type_helper.v
       dst_type = dst_type_helper.v
+
+      inst_info.add_required_ext(
+          get_required_zve(args["SEW"], args["LMUL"], args["TYPE"]))
+
       if not type_helper.valid_vtype(dst_type) or\
          not type_helper.valid_vtype(src_type):
         continue
@@ -174,6 +179,9 @@ def render(G,
             InstType.VV,
             extra_attr=extra_attr,
             required_ext=required_ext_list)
+
+        inst_info.add_required_ext(get_required_zve(args["SEW"], args["LMUL"], args["D_TYPE"]))
+
         func_name =\
           "{OP}_{TYPES1}_{TYPES3}_{MIDDLE}_{D_TYPE}{LSEW}m{LLMUL}".format_map\
           (args)
@@ -191,6 +199,9 @@ def render(G,
         inst_info = \
           InstInfo.get(args, decorator, InstType.VV, extra_attr=extra_attr,
                        required_ext = required_ext_list)
+
+        inst_info.add_required_ext(get_required_zve(args["SEW"], args["LMUL"], args["D_TYPE"]))
+
         func_name = \
           "{OP}_{TYPES1}_{TYPES3}_{MIDDLE}_{D_TYPE}{LSEW}m{LLMUL}".format_map\
           (args)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/get_set_diff_lmul_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/get_set_diff_lmul_op_template.py
@@ -24,6 +24,7 @@ from utils import prod
 from utils import TypeHelper
 from utils import basic_constraint
 from utils import seg_constraint
+from utils import get_required_zve
 from enums import InstInfo
 from enums import InstType
 from generator import CompatibleHeaderGenerator
@@ -89,17 +90,23 @@ def render(G,
       func_name = "{OP}_v_{TYPE}{SEW}m{SRC_LMUL}_{TYPE}{SEW}m{LMUL}".format_map(
           args)
       if vget:
+        inst_info = InstInfo.get(
+            args, decorator, InstType.VGET, required_ext=required_ext_list)
+        inst_info.add_required_ext(
+            get_required_zve(args["SEW"], args["LMUL"], args["TYPE"]))
         G.func(
-            InstInfo.get(
-                args, decorator, InstType.VGET, required_ext=required_ext_list),
+            inst_info,
             name=func_name,
             return_type=type_helper.v,
             src=src_type,
             index=type_helper.size_t)
       else:
+        inst_info = InstInfo.get(
+            args, decorator, InstType.VSET, required_ext=required_ext_list)
+        inst_info.add_required_ext(
+            get_required_zve(args["SEW"], args["LMUL"], args["TYPE"]))
         G.func(
-            InstInfo.get(
-                args, decorator, InstType.VSET, required_ext=required_ext_list),
+            inst_info,
             name=func_name,
             return_type=type_helper.v,
             dest=type_helper.v,
@@ -122,12 +129,12 @@ def render(G,
         if args["OP"] == "vget":
           func_name = "{OP}_v_{TYPE}{SEW}m{LMUL}x{NF}_{TYPE}{SEW}m{LMUL}".\
               format_map(args)
+          inst_info = InstInfo.get(
+              args, decorator, InstType.VGET, required_ext=required_ext_list)
+          inst_info.add_required_ext(
+              get_required_zve(args["SEW"], args["LMUL"], args["TYPE"]))
           G.func(
-              InstInfo.get(
-                  args,
-                  decorator,
-                  InstType.VGET,
-                  required_ext=required_ext_list),
+              inst_info,
               name=func_name,
               return_type=vector_type,
               src=tuple_type,
@@ -135,12 +142,12 @@ def render(G,
         elif args["OP"] == "vset":
           func_name = "{OP}_v_{TYPE}{SEW}m{LMUL}_{TYPE}{SEW}m{LMUL}x{NF}".\
               format_map(args)
+          inst_info = InstInfo.get(
+              args, decorator, InstType.VSET, required_ext=required_ext_list)
+          inst_info.add_required_ext(
+              get_required_zve(args["SEW"], args["LMUL"], args["TYPE"]))
           G.func(
-              InstInfo.get(
-                  args,
-                  decorator,
-                  InstType.VSET,
-                  required_ext=required_ext_list),
+              inst_info,
               name=func_name,
               return_type=tuple_type,
               dest=tuple_type,

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/load_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/load_template.py
@@ -21,6 +21,7 @@ Template for rendering load instructions to their corresponding intrinsics.
 #pylint: disable=relative-beyond-top-level
 from utils import prod
 from utils import TypeHelper
+from utils import get_required_zve
 from utils import get_string_lmul
 import collections
 from enums import InstInfo
@@ -78,6 +79,10 @@ def render(G,
       inst_info =\
       InstInfo.get(args, decorator, inst_type, MemType.LOAD, extra_attr,
                    required_ext = required_ext_list)
+
+      inst_info.add_required_ext(
+          get_required_zve(args["SEW"], args["LMUL"], args["TYPE"]))
+
       G.func(
           inst_info,
           name=\

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mac_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mac_template.py
@@ -22,6 +22,7 @@ intrinsics.
 #pylint: disable=relative-beyond-top-level
 from utils import prod
 from utils import TypeHelper
+from utils import get_required_zve
 from enums import InstInfo
 from enums import InstType
 from enums import ExtraAttr
@@ -81,6 +82,13 @@ def render(G,
           InstType.VVX,
           extra_attr=ExtraAttr.MAC,
           required_ext=required_ext_list)
+
+      inst_info_vs.add_required_ext(
+          get_required_zve(args["SEW"], args["LMUL"], args["TYPE"]))
+      inst_info_vv.add_required_ext(
+          get_required_zve(args["SEW"], args["LMUL"], args["TYPE"]))
+      inst_info_vx.add_required_ext(
+          get_required_zve(args["SEW"], args["LMUL"], args["TYPE"]))
 
       type_helper = TypeHelper(**args)
       if (("maccsu" in op) or ("maccus" in op)) and data_type == "uint":

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/reint_op_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/reint_op_template.py
@@ -22,6 +22,7 @@ corresponding intrinsics.
 #pylint: disable=relative-beyond-top-level
 from utils import prod
 from utils import TypeHelper
+from utils import get_required_zve
 from enums import InstInfo
 from enums import InstType
 from generator import CompatibleHeaderGenerator
@@ -79,9 +80,12 @@ def render(G,
       func_name =\
         "{OP}_v_{TYPES3}{SEW}m{LMUL}_{TYPES1}{SEW}m{LMUL}".format_map(args)
       src_type = "v{TYPES2}{SEW}m{LMUL}_t".format_map(args)
+      inst_info = InstInfo.get(
+          args, decorator, InstType.REINT, required_ext=required_ext_list)
+      inst_info.add_required_ext(
+          get_required_zve(args["SEW"], args["LMUL"], args["TYPES"]))
       G.func(
-          InstInfo.get(
-              args, decorator, InstType.REINT, required_ext=required_ext_list),
+          inst_info,
           name=func_name + decorator.func_suffix,
           return_type=rt,
           **decorator.mask_args(type_helper.m, rt),
@@ -120,9 +124,12 @@ def render(G,
       func_name =\
         "{OP}_v_{TYPES3}{SEW}m{LMUL}_{TYPES1}{DST_SEW}m{LMUL}".format_map(args)
       src_type = "v{TYPES2}{SEW}m{LMUL}_t".format_map(args)
+      inst_info = InstInfo.get(
+          args, decorator, InstType.REINT, required_ext=required_ext_list)
+      inst_info.add_required_ext(
+          get_required_zve(args["DST_SEW"], args["LMUL"], args["TYPES"]))
       G.func(
-          InstInfo.get(
-              args, decorator, InstType.REINT, required_ext=required_ext_list),
+          inst_info,
           name=func_name + decorator.func_suffix,
           return_type=rt,
           **decorator.mask_args(type_helper.m, rt),
@@ -150,11 +157,15 @@ def render(G,
       mask_type = "vbool{MLEN}_t".format_map(args)
       int_type = "v{TYPES0}{SEW}m1_t".format_map(args)
 
+      inst_info = InstInfo.get(
+          args, decorator, InstType.REINT, required_ext=required_ext_list)
+      inst_info.add_required_ext(
+          get_required_zve(args["SEW"], args["LMUL"], args["TYPES"]))
+
       func_name =\
         "{OP}_v_{TYPES1}{SEW}m1_b{MLEN}".format_map(args)
       G.func(
-          InstInfo.get(
-              args, decorator, InstType.REINT, required_ext=required_ext_list),
+          inst_info,
           name=func_name + decorator.func_suffix,
           return_type=mask_type,
           src=int_type)
@@ -162,8 +173,7 @@ def render(G,
       func_name =\
         "{OP}_v_b{MLEN}_{TYPES1}{SEW}m1".format_map(args)
       G.func(
-          InstInfo.get(
-              args, decorator, InstType.REINT, required_ext=required_ext_list),
+          inst_info,
           name=func_name + decorator.func_suffix,
           return_type=int_type,
           src=mask_type)

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_load_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_load_template.py
@@ -23,6 +23,7 @@ intrinsics.
 from utils import prod
 from utils import seg_constraint
 from utils import TypeHelper
+from utils import get_required_zve
 from utils import get_string_lmul
 from utils import seg_arg
 import collections
@@ -92,6 +93,10 @@ def render(G,
           inst_type,
           MemType.LOAD,
           required_ext=required_ext_list)
+
+      inst_info.add_required_ext(
+          get_required_zve(args["SEW"], args["LMUL"], args["TYPE"]))
+
       # Legacy non-tuple-type variant for the compatible header
       if isinstance(G, CompatibleHeaderGenerator):
         G.func(

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_store_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/seg_store_template.py
@@ -23,6 +23,7 @@ intrinsics.
 from utils import prod
 from utils import seg_constraint
 from utils import TypeHelper
+from utils import get_required_zve
 from utils import get_string_lmul
 from utils import seg_arg
 import collections
@@ -89,6 +90,10 @@ def render(G,
           inst_type,
           MemType.STORE,
           required_ext=required_ext_list)
+
+      inst_info.add_required_ext(
+          get_required_zve(args["SEW"], args["LMUL"], args["TYPE"]))
+
       # Legacy non-tuple-type variant for the compatible header
       if isinstance(G, CompatibleHeaderGenerator):
         G.func(

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/store_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/store_template.py
@@ -21,6 +21,7 @@ Template for rendering store instructions to their corresponding intrinsics.
 #pylint: disable=relative-beyond-top-level
 from utils import prod
 from utils import TypeHelper
+from utils import get_required_zve
 from utils import get_string_lmul
 import collections
 from enums import InstInfo
@@ -74,6 +75,10 @@ def render(G,
           inst_type,
           MemType.STORE,
           required_ext=required_ext_list)
+
+      inst_info.add_required_ext(
+          get_required_zve(args["SEW"], args["LMUL"], args["TYPE"]))
+
       G.func(
           inst_info,
           name="{OP}_v_{TYPE}{SEW}m{LMUL}".format_map(args) +

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/utils.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/utils.py
@@ -18,6 +18,7 @@ limitations under the License.
 Utility on handling RVV types
 """
 
+from constants import FTYPES
 import itertools
 import re
 
@@ -234,3 +235,21 @@ def prod(constraint=basic_constraint, **kargs):
     result = sorted(result, key=lambda d: d["TYPE"])
 
   return result
+
+
+def get_required_zve(sew, lmul, data_type) -> str:
+  lmul_num = get_float_lmul(lmul)
+  zve_str = "zve"
+  if int(sew / lmul_num) == 64:
+    zve_str += "64"
+  else:
+    zve_str += "32"
+  if data_type in FTYPES:
+    if sew < 64:
+      zve_str += "f"
+    else:
+      zve_str += "d"
+  else:
+    zve_str += "x"
+  return zve_str
+

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/utils.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/utils.py
@@ -253,3 +253,43 @@ def get_required_zve(sew, lmul, data_type) -> str:
     zve_str += "x"
   return zve_str
 
+
+def remove_from_list(required_ext: list, ext: str) -> list:
+  if ext in required_ext:
+    required_ext.remove(ext)
+  return required_ext
+
+
+def remove_implied_zve(required_ext: list) -> list:
+  # remove the implied zve* extensions
+  if "zve64d" in required_ext:
+    remove_list = ["zve64f", "zve64x", "zve32f", "zve32x"]
+    for ext in remove_list:
+      required_ext = remove_from_list(required_ext, ext)
+  if "zve64f" in required_ext:
+    remove_list = ["zve64x", "zve32f", "zve32x"]
+    for ext in remove_list:
+      required_ext = remove_from_list(required_ext, ext)
+  if "zve64x" in required_ext:
+    remove_list = ["zve32f", "zve32x"]
+    for ext in remove_list:
+      required_ext = remove_from_list(required_ext, ext)
+  if "zve32f" in required_ext and "zve32x" in required_ext:
+    required_ext.remove("zve32x")
+  return sorted(required_ext)
+
+
+def remove_implied_zvl(reqired_ext: list) -> list:
+  # remove the implied zvl* extensions
+  zvl_list = [ext for ext in reqired_ext if ext.startswith("zvl")]
+  if len(zvl_list) > 1:
+    zvl_list.sort(key=lambda x: int(x[3:-1]))
+    for ext in zvl_list[:-1]:
+      reqired_ext = remove_from_list(reqired_ext, ext)
+  return reqired_ext
+
+
+def remove_duplicated_zvknh(required_ext: list) -> list:
+  if "zvknhb" in required_ext:
+    required_ext = remove_from_list(required_ext, "zvknha")
+  return required_ext


### PR DESCRIPTION
- This is the first PR of adding required extension of each intrinsic function support
- There will be following PRs to add support for Float16 intrinsics and standard vector intrinsics

Signed-off-by: Jerry Zhang Jian <jerry.zhangjian@sifive.com>