### PR TITLE
github: setup test matrix for LLVM API tests

### DIFF
--- a/.github/workflows/clang-compilation.yml
+++ b/.github/workflows/clang-compilation.yml
@@ -44,7 +44,7 @@ jobs:
             -DLLVM_DEFAULT_TARGET_TRIPLE="riscv64-unknown-linux-gnu" \
             -DLLVM_ENABLE_PROJECTS="clang;lld" \
             ../llvm
-          ninja -j 4
+          ninja -j `nproc`
           echo $(pwd)
           ls bin
       - name: Run compilation test, non-overloaded intrinsics (default (TAMA) policy)

--- a/.github/workflows/clang-compilation.yml
+++ b/.github/workflows/clang-compilation.yml
@@ -4,6 +4,9 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        llvm-version: ["main", "latest-rel"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -19,7 +22,14 @@ jobs:
         run: |
           cd ..
           rm -rf llvm-project
-          git clone https://github.com/llvm/llvm-project
+          git clone https://github.com/llvm/llvm-project -j `nproc`
+      - name: Checkout LLVM version
+        run: |
+          cd ../llvm-project
+          if [ "${{ matrix.llvm-version }}" = "latest-rel" ]; then
+            latestTag=$(git describe --tags `git rev-list --tags --max-count=1`)
+            git checkout $latestTag
+          fi
       - name: Build LLVM with Ninja
         run: |
           cd ../llvm-project


### PR DESCRIPTION
- Add test matrix to run LLVM API tests with the following two LLVM
versions
  - Latest release tag
  - Latest trunk commit

Signed-off-by: Jerry Zhang Jian <jerry.zhangjian@sifive.com>