### PR TITLE
Encourage versioned compatibility check via `__riscv_v_intrinsic >= 1000000`

### DIFF
--- a/doc/rvv-intrinsic-spec.adoc
+++ b/doc/rvv-intrinsic-spec.adoc
@@ -22,7 +22,7 @@ To leverage the intrinsics in the toolchain, the header `<riscv_vector.h>` needs
 
 [,c]
 ----
-#ifdef __riscv_v_intrinsic
+#if __riscv_v_intrinsic >= 1000000
 #include <riscv_vector.h>
 #endif /* __riscv_v_intrinsic */
 ----


### PR DESCRIPTION
The document currently suggests checking for RISC-V Vector intrinsics support via `#ifdef __riscv_v_intrinsic`.
This shouldn't be recommended, as earlier compiler versions of both gcc and clang that implement draft of the specs v0.11 and v0.12 also define `__riscv_v_intrinsics`, and don't implement all features of the 1.0 spec: https://godbolt.org/z/r6aW7hE3o

Instead, checking for v1.0 compliance should be encouraged, e.g. with `#if __riscv_v_intrinsic >= 1000000`, or if the code is otherwise compatible via explicitly checking support for the supported draft spec version or higher, e.g. `#if __riscv_v_intrinsic >= 12000`.

BTW: I noticed that I'm included in "doc/preface.adoc" as "Camel Coder", it would be cool if that can be adjusted to "Olaf Bernstein"