### PR TITLE
Add vfext to get_overloaded_op_name

### DIFF
--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -267,9 +267,9 @@ class Generator(ABC):
     elif any(op in name for op in ["vlmul_ext", "vlmul_trunc"]):
       overloaded_name = "_".join([sn[0], sn[1], sn[-1]])
     elif any(op in name for op in [
-        "vzext", "vsext", "vwadd", "vwsub", "vfwadd", "vfwsub", "vwadd",
-        "vwsub", "vfwadd", "vfwsub", "vmv", "vfmv", "vsm4r", "vaesef", "vaesem",
-        "vaesdf", "vaesdm"
+        "vzext", "vsext", "vfext", "vwadd", "vwsub", "vfwadd", "vfwsub",
+        "vwadd", "vwsub", "vfwadd", "vfwsub", "vmv", "vfmv", "vsm4r", "vaesef",
+        "vaesem", "vaesdf", "vaesdm"
     ]):
       # 2. compiler can not distinguish *.wx and *.vx, need encode them in
       #    suffix, for example:


### PR DESCRIPTION
vfext.vf2 is introduced here: https://github.com/aswaterman/riscv-misc/blob/main/isa/zvfofp4min.adoc it's possible that there are vfext.vf4, vfext.vf8 added so we need a distinct name for them.